### PR TITLE
feat(view): complete templ migration (Phases 2-5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Complete templ migration** — all pages and partials converted from `html/template`
+  to [templ](https://templ.guide) type-safe templates (ADR-017)
+  - Pages: home, dashboard, terms, privacy, logout, auth (login/signup), profile, items
+  - Partials: profile_form, items_list, item (optimistic UI), first_run onboarding
+  - All template data is now typed props structs instead of `map[string]interface{}`
+  - HTMX partial responses render fragments directly (no layout wrapper)
+
+### Removed
+- `web/templates/` directory — all old `.html` template files
+- `webutil.RenderTemplate` and `RenderTemplateWithErrors` functions
+- `webutil.FormErrors` type and `view.TemplateFuncs()` — no longer needed with templ
+- Unused component templates (button, input, form, card, alert, accessibility) that
+  were defined but never invoked
+
 ## [0.1.0] - 2025-04-04
 
 ### Added

--- a/docs/adr/ADR-008-UI-Composition-and-Templates.md
+++ b/docs/adr/ADR-008-UI-Composition-and-Templates.md
@@ -1,7 +1,7 @@
 # ADR-008: UI Composition and Template Structure
 
 ## Status
-Accepted
+Superseded by ADR-017
 
 ## Context
 

--- a/docs/adr/ADR-017-Templ-Adoption.md
+++ b/docs/adr/ADR-017-Templ-Adoption.md
@@ -1,0 +1,68 @@
+# ADR-017: Templ Adoption for Type-Safe Templates
+
+## Status
+Accepted (supersedes ADR-008)
+
+## Context
+
+ADR-008 chose Go's `html/template` for UI rendering. While functional, this approach had
+significant drawbacks at scale:
+
+- **No compile-time safety.** Template errors (missing fields, wrong types) only surface at
+  runtime, often in production.
+- **Stringly-typed data passing.** Handlers pass `map[string]interface{}` — no IDE
+  autocompletion, no refactoring support, no type checking.
+- **No component model.** Partials are included via string names (`{{template "name" .}}`),
+  making dependency tracking and dead-code detection impossible.
+- **Fragment rendering bug.** The old `RenderTemplate` always executed the base layout, even
+  for HTMX partial responses, sending full-page HTML where only a fragment was needed.
+
+## Decision
+
+Replace `html/template` with [templ](https://templ.guide) for all server-rendered HTML.
+
+### Architecture
+
+```
+internal/view/
+├── layouts/base.templ       # Base layout (header, footer, dark mode, toasts)
+├── pages/*.templ             # Full-page components (wrap in @layouts.Base)
+├── partials/*.templ          # HTMX fragment components (no layout wrapper)
+├── render.go                 # view.Render(w, r, status, component)
+├── props.go                  # BaseProps + NewBaseProps helper
+├── helpers.go                # HTMX request/response utilities
+└── models.go                 # Shared view models (Item, UserProfile, etc.)
+```
+
+### Key patterns
+
+- **Typed props:** Every page defines a props struct embedding `view.BaseProps`. Handlers
+  construct props with concrete types — no `map[string]interface{}`.
+- **Layout composition:** Pages call `@layouts.Base(props.BaseProps) { children }`. Partials
+  render standalone (no layout wrapper) for correct HTMX fragment responses.
+- **Single render path:** `view.Render(w, r, status, component)` handles all responses.
+  Handlers choose between full-page and partial components based on
+  `view.IsHTMXRequest(r)`.
+- **Compile-time validation:** `templ generate` produces Go code. Type mismatches and
+  missing fields are caught by `go build`, not by users in production.
+
+### What was removed
+
+- `web/templates/` directory (all `.html` files)
+- `webutil.RenderTemplate` and `RenderTemplateWithErrors` functions
+- `webutil.FormErrors` type
+- `view.TemplateFuncs()` function map
+
+### What was kept
+
+- `webutil` HTMX helpers (`SetHXTrigger`, `SetHXRedirect`, etc.)
+- `webutil` context helpers (`GetUserFromContext`, `GetUserRepoFromContext`)
+- HTMX + Alpine.js frontend architecture (unchanged)
+
+## Consequences
+
+- All template errors are now compile-time errors.
+- IDE support (autocompletion, go-to-definition, rename) works across templates.
+- HTMX partial responses are correct — fragments render without the base layout.
+- `templ generate` adds a build step, integrated into CI and Taskfile.
+- Developers must learn templ syntax (minimal — it's Go with HTML).

--- a/internal/handler/auth_handlers.go
+++ b/internal/handler/auth_handlers.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"log"
+	"log/slog"
 	"net/http"
 
 	"github.com/supabase-community/gotrue-go/types"
@@ -13,8 +14,12 @@ import (
 
 // AuthPage renders the combined login/signup page.
 func AuthPage(w http.ResponseWriter, r *http.Request) {
-	props := pages.AuthPageProps{BaseProps: view.NewBaseProps("Login or Sign Up")}
-	view.Render(w, r, http.StatusOK, pages.AuthPage(props))
+	props := pages.AuthPageProps{
+		BaseProps: view.NewBaseProps("Login or Sign Up"),
+	}
+	if err := view.Render(w, r, http.StatusOK, pages.AuthPage(props)); err != nil {
+		slog.Error("Failed to render auth page", "error", err)
+	}
 }
 
 // AuthLoginPost handles the login form submission.

--- a/internal/handler/first_run_handlers.go
+++ b/internal/handler/first_run_handlers.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"log/slog"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
@@ -23,12 +24,10 @@ func ShowFirstRunWelcome(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/auth/page", http.StatusSeeOther)
 		return
 	}
-	// TODO: Re-enable after adding first_run_complete column to users table
-	// if user.FirstRunComplete {
-	// 	http.Redirect(w, r, "/dashboard", http.StatusSeeOther)
-	// 	return
-	// }
-	view.Render(w, r, http.StatusOK, partials.FirstRun(partials.FirstRunProps{Step: 1}))
+	props := partials.FirstRunProps{}
+	if err := view.Render(w, r, http.StatusOK, partials.FirstRunExperience(props)); err != nil {
+		slog.Error("Failed to render first-run welcome", "error", err)
+	}
 }
 
 // ShowFirstRunProfile serves the profile setup prompt (step 2).
@@ -38,16 +37,12 @@ func ShowFirstRunProfile(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/auth/page", http.StatusSeeOther)
 		return
 	}
-	// TODO: Re-enable after adding first_run_complete column to users table
-	// if user.FirstRunComplete {
-	// 	http.Redirect(w, r, "/dashboard", http.StatusSeeOther)
-	// 	return
-	// }
-	userName := ""
-	if user.Name.Valid {
-		userName = user.Name.String
+	props := partials.FirstRunProps{
+		ShowProfileSetup: true,
 	}
-	view.Render(w, r, http.StatusOK, partials.FirstRun(partials.FirstRunProps{Step: 2, UserName: userName}))
+	if err := view.Render(w, r, http.StatusOK, partials.FirstRunExperience(props)); err != nil {
+		slog.Error("Failed to render first-run profile", "error", err)
+	}
 }
 
 // ShowFirstRunCTAs serves the final CTAs (step 3).
@@ -57,22 +52,18 @@ func ShowFirstRunCTAs(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/auth/page", http.StatusSeeOther)
 		return
 	}
-	// TODO: Re-enable after adding first_run_complete column to users table
-	// if user.FirstRunComplete {
-	// 	http.Redirect(w, r, "/dashboard", http.StatusSeeOther)
-	// 	return
-	// }
 	// Mark onboarding as complete
 	repo := webutil.GetUserRepoFromContext(r.Context())
 	err := repo.UpdateFirstRunComplete(r.Context(), user.ID, true)
 	if err != nil {
-		view.Render(w, r, http.StatusInternalServerError, partials.FirstRun(partials.FirstRunProps{
-			Step:  3,
-			Error: "Could not complete onboarding. Please try again.",
-		}))
+		props := partials.FirstRunProps{
+			ShowCTAs: true,
+			Error:    "Could not complete onboarding. Please try again.",
+		}
+		if renderErr := view.Render(w, r, http.StatusInternalServerError, partials.FirstRunExperience(props)); renderErr != nil {
+			slog.Error("Failed to render first-run CTAs", "error", renderErr)
+		}
 		return
 	}
-	// Optionally update user in session/context
 	http.Redirect(w, r, "/dashboard", http.StatusSeeOther)
 }
-

--- a/internal/handler/items_handlers.go
+++ b/internal/handler/items_handlers.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
@@ -10,7 +11,6 @@ import (
 	"github.com/clownware/alpine-go-performance-starter/internal/view"
 	"github.com/clownware/alpine-go-performance-starter/internal/view/pages"
 	"github.com/clownware/alpine-go-performance-starter/internal/view/partials"
-	"github.com/clownware/alpine-go-performance-starter/internal/webutil"
 )
 
 const itemsPerPage = 5
@@ -37,7 +37,9 @@ func ItemsPage(w http.ResponseWriter, r *http.Request) {
 		Items:    items,
 		NextPage: page + 1,
 	}
-	view.Render(w, r, http.StatusOK, pages.ItemsPage(props))
+	if err := view.Render(w, r, http.StatusOK, pages.ItemsPage(props)); err != nil {
+		slog.Error("Failed to render items page", "error", err)
+	}
 }
 
 // ItemsList returns a fragment of items for HTMX requests
@@ -57,7 +59,9 @@ func ItemsList(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		listProps := partials.ItemsListProps{Items: results}
-		view.Render(w, r, http.StatusOK, partials.ItemsList(listProps))
+		if err := view.Render(w, r, http.StatusOK, partials.ItemsList(listProps)); err != nil {
+			slog.Error("Failed to render items list partial", "error", err)
+		}
 		return
 	}
 
@@ -79,24 +83,30 @@ func ItemsList(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	listProps := partials.ItemsListProps{Items: items, NextPage: page + 1}
+	listProps := partials.ItemsListProps{
+		Items:    items,
+		NextPage: page + 1,
+	}
 
 	// Render fragment or full page depending on HTMX
-	if webutil.IsHTMXRequest(r) {
-		view.Render(w, r, http.StatusOK, partials.ItemsList(listProps))
+	if view.IsHTMXRequest(r) {
+		if err := view.Render(w, r, http.StatusOK, partials.ItemsList(listProps)); err != nil {
+			slog.Error("Failed to render items list partial", "error", err)
+		}
 	} else {
-		pageProps := pages.ItemsPageProps{
+		props := pages.ItemsPageProps{
 			BaseProps: view.NewBaseProps("Items List"),
 			Items:    items,
 			NextPage: page + 1,
 		}
-		view.Render(w, r, http.StatusOK, pages.ItemsPage(pageProps))
+		if err := view.Render(w, r, http.StatusOK, pages.ItemsPage(props)); err != nil {
+			slog.Error("Failed to render items page", "error", err)
+		}
 	}
 }
 
 // ItemToggle handles toggling the favorite status of an item
 func ItemToggle(w http.ResponseWriter, r *http.Request) {
-	// Get item ID from path parameter
 	itemID := chi.URLParam(r, "id")
 	if itemID == "" {
 		http.Error(w, "Item ID is required", http.StatusBadRequest)
@@ -107,13 +117,13 @@ func ItemToggle(w http.ResponseWriter, r *http.Request) {
 	itemStore[itemID] = !itemStore[itemID]
 	isFavorite := itemStore[itemID]
 
-	itemName := fmt.Sprintf("Item %s", itemID)
-	itemProps := partials.ItemProps{
-		Item: view.Item{
-			ID:         itemID,
-			Name:       itemName,
-			IsFavorite: isFavorite,
-		},
+	item := view.Item{
+		ID:         itemID,
+		Name:       fmt.Sprintf("Item %s", itemID),
+		IsFavorite: isFavorite,
 	}
-	view.Render(w, r, http.StatusOK, partials.Item(itemProps))
+
+	if err := view.Render(w, r, http.StatusOK, partials.ItemCard(item)); err != nil {
+		slog.Error("Failed to render item partial", "error", err)
+	}
 }

--- a/internal/handler/profile_handlers.go
+++ b/internal/handler/profile_handlers.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -16,7 +17,9 @@ func ProfileView(w http.ResponseWriter, r *http.Request) {
 		BaseProps: view.NewBaseProps("Profile"),
 		Name:     "John Doe",
 	}
-	view.Render(w, r, http.StatusOK, pages.ProfilePage(props))
+	if err := view.Render(w, r, http.StatusOK, pages.ProfilePage(props)); err != nil {
+		slog.Error("Failed to render profile page", "error", err)
+	}
 }
 
 // ProfileUpdate processes the profile form submission with HTMX support.
@@ -26,32 +29,44 @@ func ProfileUpdate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	name := r.FormValue("name")
-	errors := map[string]string{}
+	errors := make(map[string]string)
 	if strings.TrimSpace(name) == "" {
 		errors["name"] = "Name cannot be empty"
 	}
 
 	// Validation errors
 	if len(errors) > 0 {
-		formProps := partials.ProfileFormProps{Name: name, Errors: errors}
-		if webutil.IsHTMXRequest(r) {
-			view.Render(w, r, http.StatusUnprocessableEntity, partials.ProfileForm(formProps))
+		formProps := partials.ProfileFormProps{
+			Name:   name,
+			Errors: errors,
+		}
+		if view.IsHTMXRequest(r) {
+			if err := view.Render(w, r, http.StatusUnprocessableEntity, partials.ProfileForm(formProps)); err != nil {
+				slog.Error("Failed to render profile form partial", "error", err)
+			}
 		} else {
 			pageProps := pages.ProfilePageProps{
 				BaseProps: view.NewBaseProps("Profile"),
 				Name:     name,
 				Errors:   errors,
 			}
-			view.Render(w, r, http.StatusUnprocessableEntity, pages.ProfilePage(pageProps))
+			if err := view.Render(w, r, http.StatusUnprocessableEntity, pages.ProfilePage(pageProps)); err != nil {
+				slog.Error("Failed to render profile page", "error", err)
+			}
 		}
 		return
 	}
 
 	// Stub update successful
-	if webutil.IsHTMXRequest(r) {
+	if view.IsHTMXRequest(r) {
 		webutil.SetHXTrigger(w, "Profile updated successfully!")
-		formProps := partials.ProfileFormProps{Name: name, Success: true}
-		view.Render(w, r, http.StatusOK, partials.ProfileForm(formProps))
+		formProps := partials.ProfileFormProps{
+			Name:    name,
+			Success: true,
+		}
+		if err := view.Render(w, r, http.StatusOK, partials.ProfileForm(formProps)); err != nil {
+			slog.Error("Failed to render profile form partial", "error", err)
+		}
 	} else {
 		http.Redirect(w, r, "/profile", http.StatusSeeOther)
 	}

--- a/internal/handler/static_handlers.go
+++ b/internal/handler/static_handlers.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"log/slog"
 	"net/http"
 
 	"github.com/clownware/alpine-go-performance-starter/internal/view"
@@ -9,27 +10,37 @@ import (
 
 // DashboardPage renders the dashboard page.
 func DashboardPage(w http.ResponseWriter, r *http.Request) {
-	props := pages.DashboardPageProps{BaseProps: view.NewBaseProps("Dashboard")}
-	view.Render(w, r, http.StatusOK, pages.DashboardPage(props))
+	props := pages.DashboardPageProps{
+		BaseProps: view.NewBaseProps("Dashboard"),
+	}
+	if err := view.Render(w, r, http.StatusOK, pages.DashboardPage(props)); err != nil {
+		slog.Error("Failed to render dashboard page", "error", err)
+	}
 }
 
 // TermsPage renders the terms of service page.
 func TermsPage(w http.ResponseWriter, r *http.Request) {
-	props := pages.TermsPageProps{BaseProps: view.NewBaseProps("Terms of Service")}
-	view.Render(w, r, http.StatusOK, pages.TermsPage(props))
+	props := view.NewBaseProps("Terms of Service")
+	if err := view.Render(w, r, http.StatusOK, pages.TermsPage(props)); err != nil {
+		slog.Error("Failed to render terms page", "error", err)
+	}
 }
 
 // PrivacyPage renders the privacy policy page.
 func PrivacyPage(w http.ResponseWriter, r *http.Request) {
-	props := pages.PrivacyPageProps{BaseProps: view.NewBaseProps("Privacy Policy")}
-	view.Render(w, r, http.StatusOK, pages.PrivacyPage(props))
+	props := view.NewBaseProps("Privacy Policy")
+	if err := view.Render(w, r, http.StatusOK, pages.PrivacyPage(props)); err != nil {
+		slog.Error("Failed to render privacy page", "error", err)
+	}
 }
 
-// LogoutPage handles GET /auth/logout by POSTing to logout and redirecting to home.
+// LogoutPage handles GET /auth/logout by rendering a confirmation form.
 func LogoutPage(w http.ResponseWriter, r *http.Request) {
 	if r.Method == http.MethodGet {
-		props := pages.LogoutPageProps{BaseProps: view.NewBaseProps("Sign Out")}
-		view.Render(w, r, http.StatusOK, pages.LogoutPage(props))
+		props := view.NewBaseProps("Sign Out")
+		if err := view.Render(w, r, http.StatusOK, pages.LogoutPage(props)); err != nil {
+			slog.Error("Failed to render logout page", "error", err)
+		}
 		return
 	}
 	// Fallback: redirect to home

--- a/internal/view/helpers.go
+++ b/internal/view/helpers.go
@@ -1,0 +1,65 @@
+package view
+
+import (
+	"net/http"
+)
+
+// HTMXRequest represents information from HTMX request headers
+type HTMXRequest struct {
+	IsHTMX             bool
+	Target             string
+	Trigger            string
+	TriggerName        string
+	TriggerID          string
+	CurrentURL         string
+	PromptResponse     string
+	Boosted            bool
+	HistoryRestoreType string
+}
+
+// GetHTMXRequest extracts HTMX information from the HTTP request headers
+func GetHTMXRequest(r *http.Request) HTMXRequest {
+	return HTMXRequest{
+		IsHTMX:             r.Header.Get("HX-Request") == "true",
+		Target:             r.Header.Get("HX-Target"),
+		Trigger:            r.Header.Get("HX-Trigger"),
+		TriggerName:        r.Header.Get("HX-Trigger-Name"),
+		TriggerID:          r.Header.Get("HX-Trigger-Id"),
+		CurrentURL:         r.Header.Get("HX-Current-URL"),
+		PromptResponse:     r.Header.Get("HX-Prompt"),
+		Boosted:            r.Header.Get("HX-Boosted") == "true",
+		HistoryRestoreType: r.Header.Get("HX-History-Restore-Request"),
+	}
+}
+
+// IsHTMXRequest checks if the request is from HTMX
+func IsHTMXRequest(r *http.Request) bool {
+	return r.Header.Get("HX-Request") == "true"
+}
+
+// AddHTMXResponseHeaders sets common HTMX response headers
+func AddHTMXResponseHeaders(w http.ResponseWriter, options map[string]string) {
+	// Common HTMX response headers
+	if options["location"] != "" {
+		w.Header().Set("HX-Location", options["location"])
+	}
+	if options["pushUrl"] != "" {
+		w.Header().Set("HX-Push-Url", options["pushUrl"])
+	}
+	if options["redirect"] != "" {
+		w.Header().Set("HX-Redirect", options["redirect"])
+	}
+	if options["refresh"] == "true" {
+		w.Header().Set("HX-Refresh", "true")
+	}
+	if options["trigger"] != "" {
+		w.Header().Set("HX-Trigger", options["trigger"])
+	}
+	if options["triggerAfterSwap"] != "" {
+		w.Header().Set("HX-Trigger-After-Swap", options["triggerAfterSwap"])
+	}
+	if options["triggerAfterSettle"] != "" {
+		w.Header().Set("HX-Trigger-After-Settle", options["triggerAfterSettle"])
+	}
+}
+

--- a/internal/view/pages/auth.templ
+++ b/internal/view/pages/auth.templ
@@ -5,8 +5,11 @@ import (
 	"github.com/clownware/alpine-go-performance-starter/internal/view/layouts"
 )
 
+// AuthPageProps holds data for the login/signup page.
 type AuthPageProps struct {
 	view.BaseProps
+	LoginFlash  string
+	SignupFlash string
 }
 
 templ AuthPage(props AuthPageProps) {
@@ -14,48 +17,105 @@ templ AuthPage(props AuthPageProps) {
 		<div class="min-h-screen flex flex-col justify-center items-center px-4 py-8 bg-background dark:bg-background-dark text-text dark:text-text-dark">
 			<h1 class="text-2xl font-bold mb-8 text-center">Welcome!</h1>
 			<div class="w-full max-w-md lg:max-w-4xl grid grid-cols-1 lg:grid-cols-2 gap-10">
-				<!-- Login Card -->
-				<div class="bg-surface text-text dark:bg-surface-dark dark:text-text-dark p-6 rounded shadow-md">
-					<h2 class="text-2xl font-semibold mb-6">Login</h2>
-					<form hx-post="/auth/login" hx-target="#auth-messages" hx-swap="innerHTML" autocomplete="on" class="space-y-6">
-						<div class="mb-4">
-							<label for="login-email" class="block text-text text-sm font-bold mb-2">Your Email Address</label>
-							<input type="email" id="login-email" name="email" required autocomplete="email" class="shadow appearance-none border rounded w-full py-2 px-3 text-text bg-background dark:bg-background-dark dark:text-text-dark leading-tight focus:outline-none focus:shadow-outline"/>
-						</div>
-						<div class="mb-2">
-							<label for="login-password" class="block text-text text-sm font-bold mb-2">Your Password</label>
-							<input type="password" id="login-password" name="password" required autocomplete="current-password" class="shadow appearance-none border rounded w-full py-2 px-3 text-text bg-background dark:bg-background-dark dark:text-text-dark mb-1 leading-tight focus:outline-none focus:shadow-outline"/>
-						</div>
-						<div class="mb-4 text-right">
-							<a href="#" class="text-sm text-primary hover:underline dark:text-primary-dark">Reset password</a>
-						</div>
-						<button type="submit" class="w-full bg-primary text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline hover:opacity-90 dark:bg-primary-dark dark:hover:opacity-90 mt-6">
-							Sign in to your account
-						</button>
-					</form>
-				</div>
-				<!-- Sign Up Card -->
-				<div class="bg-surface text-text dark:bg-surface-dark dark:text-text-dark p-6 rounded shadow-md mt-10 lg:mt-0">
-					<h2 class="text-2xl font-semibold mb-6">Sign Up</h2>
-					<form hx-post="/auth/signup" hx-target="#auth-messages" hx-swap="innerHTML" autocomplete="on" class="space-y-6">
-						<div class="mb-4">
-							<label for="signup-email" class="block text-text text-sm font-bold mb-2">Your Email Address</label>
-							<input type="email" id="signup-email" name="email" required autocomplete="email" class="shadow appearance-none border rounded w-full py-2 px-3 text-text bg-background dark:bg-background-dark dark:text-text-dark leading-tight focus:outline-none focus:shadow-outline"/>
-						</div>
-						<div class="mb-4">
-							<label for="signup-password" class="block text-text text-sm font-bold mb-2">Create a Password</label>
-							<input type="password" id="signup-password" name="password" required autocomplete="new-password" class="shadow appearance-none border rounded w-full py-2 px-3 text-text bg-background dark:bg-background-dark dark:text-text-dark leading-tight focus:outline-none focus:shadow-outline"/>
-						</div>
-						<div class="mb-6">
-							<label for="signup-password-confirm" class="block text-text text-sm font-bold mb-2">Confirm Password</label>
-							<input type="password" id="signup-password-confirm" name="password_confirm" required autocomplete="new-password" class="shadow appearance-none border rounded w-full py-2 px-3 text-text bg-background dark:bg-background-dark dark:text-text-dark leading-tight focus:outline-none focus:shadow-outline"/>
-						</div>
-						<button type="submit" class="w-full bg-primary text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline hover:opacity-90 dark:bg-primary-dark dark:hover:opacity-90 mt-6">
-							Create your account
-						</button>
-					</form>
-				</div>
+				@loginCard(props.LoginFlash)
+				@signupCard(props.SignupFlash)
 			</div>
 		</div>
 	}
+}
+
+templ loginCard(flash string) {
+	<div class="bg-surface text-text dark:bg-surface-dark dark:text-text-dark p-6 rounded shadow-md">
+		<h2 class="text-2xl font-semibold mb-6">Login</h2>
+		if flash != "" {
+			<div class="mb-4 p-3 rounded bg-red-100 text-red-700" role="alert">
+				{ flash }
+			</div>
+		}
+		<form hx-post="/auth/login" hx-target="#auth-messages" hx-swap="innerHTML" autocomplete="on" class="space-y-6">
+			<div class="mb-4">
+				<label for="login-email" class="block text-text text-sm font-bold mb-2">Your Email Address</label>
+				<input
+					type="email"
+					id="login-email"
+					name="email"
+					required
+					autocomplete="email"
+					class="shadow appearance-none border rounded w-full py-2 px-3 text-text bg-background dark:bg-background-dark dark:text-text-dark leading-tight focus:outline-none focus:shadow-outline"
+				/>
+			</div>
+			<div class="mb-2">
+				<label for="login-password" class="block text-text text-sm font-bold mb-2">Your Password</label>
+				<input
+					type="password"
+					id="login-password"
+					name="password"
+					required
+					autocomplete="current-password"
+					class="shadow appearance-none border rounded w-full py-2 px-3 text-text bg-background dark:bg-background-dark dark:text-text-dark mb-1 leading-tight focus:outline-none focus:shadow-outline"
+				/>
+			</div>
+			<div class="mb-4 text-right">
+				<a href="#" class="text-sm text-primary hover:underline dark:text-primary-dark">Reset password</a>
+			</div>
+			<button
+				type="submit"
+				class="w-full bg-primary text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline hover:opacity-90 dark:bg-primary-dark dark:hover:opacity-90 mt-6"
+			>
+				Sign in to your account
+			</button>
+		</form>
+	</div>
+}
+
+templ signupCard(flash string) {
+	<div class="bg-surface text-text dark:bg-surface-dark dark:text-text-dark p-6 rounded shadow-md mt-10 lg:mt-0">
+		<h2 class="text-2xl font-semibold mb-6">Sign Up</h2>
+		if flash != "" {
+			<div class="mb-4 p-3 rounded bg-red-100 text-red-700" role="alert">
+				{ flash }
+			</div>
+		}
+		<form hx-post="/auth/signup" hx-target="#auth-messages" hx-swap="innerHTML" autocomplete="on" class="space-y-6">
+			<div class="mb-4">
+				<label for="signup-email" class="block text-text text-sm font-bold mb-2">Your Email Address</label>
+				<input
+					type="email"
+					id="signup-email"
+					name="email"
+					required
+					autocomplete="email"
+					class="shadow appearance-none border rounded w-full py-2 px-3 text-text bg-background dark:bg-background-dark dark:text-text-dark leading-tight focus:outline-none focus:shadow-outline"
+				/>
+			</div>
+			<div class="mb-4">
+				<label for="signup-password" class="block text-text text-sm font-bold mb-2">Create a Password</label>
+				<input
+					type="password"
+					id="signup-password"
+					name="password"
+					required
+					autocomplete="new-password"
+					class="shadow appearance-none border rounded w-full py-2 px-3 text-text bg-background dark:bg-background-dark dark:text-text-dark leading-tight focus:outline-none focus:shadow-outline"
+				/>
+			</div>
+			<div class="mb-6">
+				<label for="signup-password-confirm" class="block text-text text-sm font-bold mb-2">Confirm Password</label>
+				<input
+					type="password"
+					id="signup-password-confirm"
+					name="password_confirm"
+					required
+					autocomplete="new-password"
+					class="shadow appearance-none border rounded w-full py-2 px-3 text-text bg-background dark:bg-background-dark dark:text-text-dark leading-tight focus:outline-none focus:shadow-outline"
+				/>
+			</div>
+			<button
+				type="submit"
+				class="w-full bg-primary text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline hover:opacity-90 dark:bg-primary-dark dark:hover:opacity-90 mt-6"
+			>
+				Create your account
+			</button>
+		</form>
+	</div>
 }

--- a/internal/view/pages/auth_templ.go
+++ b/internal/view/pages/auth_templ.go
@@ -13,8 +13,11 @@ import (
 	"github.com/clownware/alpine-go-performance-starter/internal/view/layouts"
 )
 
+// AuthPageProps holds data for the login/signup page.
 type AuthPageProps struct {
 	view.BaseProps
+	LoginFlash  string
+	SignupFlash string
 }
 
 func AuthPage(props AuthPageProps) templ.Component {
@@ -50,13 +53,129 @@ func AuthPage(props AuthPageProps) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"min-h-screen flex flex-col justify-center items-center px-4 py-8 bg-background dark:bg-background-dark text-text dark:text-text-dark\"><h1 class=\"text-2xl font-bold mb-8 text-center\">Welcome!</h1><div class=\"w-full max-w-md lg:max-w-4xl grid grid-cols-1 lg:grid-cols-2 gap-10\"><!-- Login Card --><div class=\"bg-surface text-text dark:bg-surface-dark dark:text-text-dark p-6 rounded shadow-md\"><h2 class=\"text-2xl font-semibold mb-6\">Login</h2><form hx-post=\"/auth/login\" hx-target=\"#auth-messages\" hx-swap=\"innerHTML\" autocomplete=\"on\" class=\"space-y-6\"><div class=\"mb-4\"><label for=\"login-email\" class=\"block text-text text-sm font-bold mb-2\">Your Email Address</label> <input type=\"email\" id=\"login-email\" name=\"email\" required autocomplete=\"email\" class=\"shadow appearance-none border rounded w-full py-2 px-3 text-text bg-background dark:bg-background-dark dark:text-text-dark leading-tight focus:outline-none focus:shadow-outline\"></div><div class=\"mb-2\"><label for=\"login-password\" class=\"block text-text text-sm font-bold mb-2\">Your Password</label> <input type=\"password\" id=\"login-password\" name=\"password\" required autocomplete=\"current-password\" class=\"shadow appearance-none border rounded w-full py-2 px-3 text-text bg-background dark:bg-background-dark dark:text-text-dark mb-1 leading-tight focus:outline-none focus:shadow-outline\"></div><div class=\"mb-4 text-right\"><a href=\"#\" class=\"text-sm text-primary hover:underline dark:text-primary-dark\">Reset password</a></div><button type=\"submit\" class=\"w-full bg-primary text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline hover:opacity-90 dark:bg-primary-dark dark:hover:opacity-90 mt-6\">Sign in to your account</button></form></div><!-- Sign Up Card --><div class=\"bg-surface text-text dark:bg-surface-dark dark:text-text-dark p-6 rounded shadow-md mt-10 lg:mt-0\"><h2 class=\"text-2xl font-semibold mb-6\">Sign Up</h2><form hx-post=\"/auth/signup\" hx-target=\"#auth-messages\" hx-swap=\"innerHTML\" autocomplete=\"on\" class=\"space-y-6\"><div class=\"mb-4\"><label for=\"signup-email\" class=\"block text-text text-sm font-bold mb-2\">Your Email Address</label> <input type=\"email\" id=\"signup-email\" name=\"email\" required autocomplete=\"email\" class=\"shadow appearance-none border rounded w-full py-2 px-3 text-text bg-background dark:bg-background-dark dark:text-text-dark leading-tight focus:outline-none focus:shadow-outline\"></div><div class=\"mb-4\"><label for=\"signup-password\" class=\"block text-text text-sm font-bold mb-2\">Create a Password</label> <input type=\"password\" id=\"signup-password\" name=\"password\" required autocomplete=\"new-password\" class=\"shadow appearance-none border rounded w-full py-2 px-3 text-text bg-background dark:bg-background-dark dark:text-text-dark leading-tight focus:outline-none focus:shadow-outline\"></div><div class=\"mb-6\"><label for=\"signup-password-confirm\" class=\"block text-text text-sm font-bold mb-2\">Confirm Password</label> <input type=\"password\" id=\"signup-password-confirm\" name=\"password_confirm\" required autocomplete=\"new-password\" class=\"shadow appearance-none border rounded w-full py-2 px-3 text-text bg-background dark:bg-background-dark dark:text-text-dark leading-tight focus:outline-none focus:shadow-outline\"></div><button type=\"submit\" class=\"w-full bg-primary text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline hover:opacity-90 dark:bg-primary-dark dark:hover:opacity-90 mt-6\">Create your account</button></form></div></div></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"min-h-screen flex flex-col justify-center items-center px-4 py-8 bg-background dark:bg-background-dark text-text dark:text-text-dark\"><h1 class=\"text-2xl font-bold mb-8 text-center\">Welcome!</h1><div class=\"w-full max-w-md lg:max-w-4xl grid grid-cols-1 lg:grid-cols-2 gap-10\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = loginCard(props.LoginFlash).Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = signupCard(props.SignupFlash).Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			return nil
 		})
 		templ_7745c5c3_Err = layouts.Base(props.BaseProps).Render(templ.WithChildren(ctx, templ_7745c5c3_Var2), templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+func loginCard(flash string) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var3 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var3 == nil {
+			templ_7745c5c3_Var3 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div class=\"bg-surface text-text dark:bg-surface-dark dark:text-text-dark p-6 rounded shadow-md\"><h2 class=\"text-2xl font-semibold mb-6\">Login</h2>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if flash != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "<div class=\"mb-4 p-3 rounded bg-red-100 text-red-700\" role=\"alert\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var4 string
+			templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(flash)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/auth.templ`, Line: 32, Col: 11}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<form hx-post=\"/auth/login\" hx-target=\"#auth-messages\" hx-swap=\"innerHTML\" autocomplete=\"on\" class=\"space-y-6\"><div class=\"mb-4\"><label for=\"login-email\" class=\"block text-text text-sm font-bold mb-2\">Your Email Address</label> <input type=\"email\" id=\"login-email\" name=\"email\" required autocomplete=\"email\" class=\"shadow appearance-none border rounded w-full py-2 px-3 text-text bg-background dark:bg-background-dark dark:text-text-dark leading-tight focus:outline-none focus:shadow-outline\"></div><div class=\"mb-2\"><label for=\"login-password\" class=\"block text-text text-sm font-bold mb-2\">Your Password</label> <input type=\"password\" id=\"login-password\" name=\"password\" required autocomplete=\"current-password\" class=\"shadow appearance-none border rounded w-full py-2 px-3 text-text bg-background dark:bg-background-dark dark:text-text-dark mb-1 leading-tight focus:outline-none focus:shadow-outline\"></div><div class=\"mb-4 text-right\"><a href=\"#\" class=\"text-sm text-primary hover:underline dark:text-primary-dark\">Reset password</a></div><button type=\"submit\" class=\"w-full bg-primary text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline hover:opacity-90 dark:bg-primary-dark dark:hover:opacity-90 mt-6\">Sign in to your account</button></form></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+func signupCard(flash string) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var5 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var5 == nil {
+			templ_7745c5c3_Var5 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div class=\"bg-surface text-text dark:bg-surface-dark dark:text-text-dark p-6 rounded shadow-md mt-10 lg:mt-0\"><h2 class=\"text-2xl font-semibold mb-6\">Sign Up</h2>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if flash != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<div class=\"mb-4 p-3 rounded bg-red-100 text-red-700\" role=\"alert\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var6 string
+			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(flash)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/auth.templ`, Line: 76, Col: 11}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<form hx-post=\"/auth/signup\" hx-target=\"#auth-messages\" hx-swap=\"innerHTML\" autocomplete=\"on\" class=\"space-y-6\"><div class=\"mb-4\"><label for=\"signup-email\" class=\"block text-text text-sm font-bold mb-2\">Your Email Address</label> <input type=\"email\" id=\"signup-email\" name=\"email\" required autocomplete=\"email\" class=\"shadow appearance-none border rounded w-full py-2 px-3 text-text bg-background dark:bg-background-dark dark:text-text-dark leading-tight focus:outline-none focus:shadow-outline\"></div><div class=\"mb-4\"><label for=\"signup-password\" class=\"block text-text text-sm font-bold mb-2\">Create a Password</label> <input type=\"password\" id=\"signup-password\" name=\"password\" required autocomplete=\"new-password\" class=\"shadow appearance-none border rounded w-full py-2 px-3 text-text bg-background dark:bg-background-dark dark:text-text-dark leading-tight focus:outline-none focus:shadow-outline\"></div><div class=\"mb-6\"><label for=\"signup-password-confirm\" class=\"block text-text text-sm font-bold mb-2\">Confirm Password</label> <input type=\"password\" id=\"signup-password-confirm\" name=\"password_confirm\" required autocomplete=\"new-password\" class=\"shadow appearance-none border rounded w-full py-2 px-3 text-text bg-background dark:bg-background-dark dark:text-text-dark leading-tight focus:outline-none focus:shadow-outline\"></div><button type=\"submit\" class=\"w-full bg-primary text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline hover:opacity-90 dark:bg-primary-dark dark:hover:opacity-90 mt-6\">Create your account</button></form></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/view/pages/dashboard.templ
+++ b/internal/view/pages/dashboard.templ
@@ -3,17 +3,12 @@ package pages
 import (
 	"github.com/clownware/alpine-go-performance-starter/internal/view"
 	"github.com/clownware/alpine-go-performance-starter/internal/view/layouts"
-	"github.com/clownware/alpine-go-performance-starter/internal/view/partials"
 )
 
+// DashboardPageProps holds data for the dashboard page.
 type DashboardPageProps struct {
 	view.BaseProps
 	HasProjects bool
-}
-
-// dashboardSkeletonData returns the Alpine.js x-data expression for the skeleton loader.
-func dashboardSkeletonData() string {
-	return "{ loading: true }"
 }
 
 templ DashboardPage(props DashboardPageProps) {
@@ -22,50 +17,70 @@ templ DashboardPage(props DashboardPageProps) {
 			<h1 class="text-3xl font-bold">Dashboard</h1>
 			<p>Welcome to your dashboard. This page is ready for your custom SaaS widgets and stats.</p>
 			if !props.HasProjects {
-				@partials.EmptyState(partials.EmptyStateProps{})
+				@emptyState()
 			}
 			if props.HasProjects {
-				<div
-					x-data={ dashboardSkeletonData() }
-					@htmx:beforeSwap.window="loading = false"
-					class="mt-10"
-				>
-					<!-- Skeleton Loader -->
-					<div
-						x-show="loading"
-						x-transition.opacity.duration.500ms
-						class="space-y-2"
-						aria-hidden="true"
-					>
-						<div class="animate-pulse flex space-x-4">
-							<div class="rounded bg-muted-dark h-6 w-1/4"></div>
-							<div class="rounded bg-muted-dark h-6 w-1/4"></div>
-							<div class="rounded bg-muted-dark h-6 w-1/4"></div>
-						</div>
-						<div class="animate-pulse flex space-x-4">
-							<div class="rounded bg-muted-dark h-6 w-1/4"></div>
-							<div class="rounded bg-muted-dark h-6 w-1/4"></div>
-							<div class="rounded bg-muted-dark h-6 w-1/4"></div>
-						</div>
-						<div class="animate-pulse flex space-x-4">
-							<div class="rounded bg-muted-dark h-6 w-1/4"></div>
-							<div class="rounded bg-muted-dark h-6 w-1/4"></div>
-							<div class="rounded bg-muted-dark h-6 w-1/4"></div>
-						</div>
-					</div>
-					<!-- Real Table Data (to be swapped in by HTMX) -->
-					<div
-						x-show="!loading"
-						x-transition.opacity.duration.500ms
-						id="dashboard-table"
-						hx-get="/dashboard/data"
-						hx-trigger="load"
-						hx-target="#dashboard-table"
-						hx-swap="outerHTML"
-					>
-					</div>
-				</div>
+				@skeletonTable()
 			}
 		</div>
 	}
+}
+
+templ emptyState() {
+	<section class="flex flex-col items-center justify-center py-20 text-center">
+		<div class="mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-blue-100 dark:bg-blue-900">
+			<svg class="h-8 w-8 text-blue-500 dark:text-blue-300" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+				<circle cx="12" cy="12" r="9" stroke="currentColor" stroke-width="2"></circle>
+				<path stroke-linecap="round" stroke-linejoin="round" d="M12 8v8m4-4H8"></path>
+			</svg>
+		</div>
+		<h2 class="mb-2 text-2xl font-semibold text-gray-900 dark:text-white">Welcome to Your Dashboard!</h2>
+		<p class="mb-6 max-w-md text-base text-gray-600 dark:text-gray-300">You haven't added any projects yet. Get started by creating your first project and unlock the full power of your SaaS workspace.</p>
+		<a href="/projects/new" class="inline-block rounded bg-blue-600 px-5 py-2 text-white font-medium shadow hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2 transition">
+			Create Project
+		</a>
+	</section>
+}
+
+templ skeletonTable() {
+	<div
+		x-data="{ loading: true }"
+		class="mt-10"
+	>
+		<!-- Skeleton Loader -->
+		<div
+			x-show="loading"
+			x-transition.opacity.duration.500ms
+			class="space-y-2"
+			aria-hidden="true"
+		>
+			<div class="animate-pulse flex space-x-4">
+				<div class="rounded bg-muted-dark h-6 w-1/4"></div>
+				<div class="rounded bg-muted-dark h-6 w-1/4"></div>
+				<div class="rounded bg-muted-dark h-6 w-1/4"></div>
+			</div>
+			<div class="animate-pulse flex space-x-4">
+				<div class="rounded bg-muted-dark h-6 w-1/4"></div>
+				<div class="rounded bg-muted-dark h-6 w-1/4"></div>
+				<div class="rounded bg-muted-dark h-6 w-1/4"></div>
+			</div>
+			<div class="animate-pulse flex space-x-4">
+				<div class="rounded bg-muted-dark h-6 w-1/4"></div>
+				<div class="rounded bg-muted-dark h-6 w-1/4"></div>
+				<div class="rounded bg-muted-dark h-6 w-1/4"></div>
+			</div>
+		</div>
+		<!-- Real Table Data (to be swapped in by HTMX) -->
+		<div
+			x-show="!loading"
+			x-transition.opacity.duration.500ms
+			id="dashboard-table"
+			hx-get="/dashboard/data"
+			hx-trigger="load"
+			hx-target="#dashboard-table"
+			hx-swap="outerHTML"
+		>
+			<!-- Table will be swapped in by HTMX -->
+		</div>
+	</div>
 }

--- a/internal/view/pages/dashboard_templ.go
+++ b/internal/view/pages/dashboard_templ.go
@@ -11,17 +11,12 @@ import templruntime "github.com/a-h/templ/runtime"
 import (
 	"github.com/clownware/alpine-go-performance-starter/internal/view"
 	"github.com/clownware/alpine-go-performance-starter/internal/view/layouts"
-	"github.com/clownware/alpine-go-performance-starter/internal/view/partials"
 )
 
+// DashboardPageProps holds data for the dashboard page.
 type DashboardPageProps struct {
 	view.BaseProps
 	HasProjects bool
-}
-
-// dashboardSkeletonData returns the Alpine.js x-data expression for the skeleton loader.
-func dashboardSkeletonData() string {
-	return "{ loading: true }"
 }
 
 func DashboardPage(props DashboardPageProps) templ.Component {
@@ -62,37 +57,82 @@ func DashboardPage(props DashboardPageProps) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			if !props.HasProjects {
-				templ_7745c5c3_Err = partials.EmptyState(partials.EmptyStateProps{}).Render(ctx, templ_7745c5c3_Buffer)
+				templ_7745c5c3_Err = emptyState().Render(ctx, templ_7745c5c3_Buffer)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
 			if props.HasProjects {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<div x-data=\"")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var3 string
-				templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(dashboardSkeletonData())
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/dashboard.templ`, Line: 29, Col: 37}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "\" @htmx:beforeSwap.window=\"loading = false\" class=\"mt-10\"><!-- Skeleton Loader --><div x-show=\"loading\" x-transition.opacity.duration.500ms class=\"space-y-2\" aria-hidden=\"true\"><div class=\"animate-pulse flex space-x-4\"><div class=\"rounded bg-muted-dark h-6 w-1/4\"></div><div class=\"rounded bg-muted-dark h-6 w-1/4\"></div><div class=\"rounded bg-muted-dark h-6 w-1/4\"></div></div><div class=\"animate-pulse flex space-x-4\"><div class=\"rounded bg-muted-dark h-6 w-1/4\"></div><div class=\"rounded bg-muted-dark h-6 w-1/4\"></div><div class=\"rounded bg-muted-dark h-6 w-1/4\"></div></div><div class=\"animate-pulse flex space-x-4\"><div class=\"rounded bg-muted-dark h-6 w-1/4\"></div><div class=\"rounded bg-muted-dark h-6 w-1/4\"></div><div class=\"rounded bg-muted-dark h-6 w-1/4\"></div></div></div><!-- Real Table Data (to be swapped in by HTMX) --><div x-show=\"!loading\" x-transition.opacity.duration.500ms id=\"dashboard-table\" hx-get=\"/dashboard/data\" hx-trigger=\"load\" hx-target=\"#dashboard-table\" hx-swap=\"outerHTML\"></div></div>")
+				templ_7745c5c3_Err = skeletonTable().Render(ctx, templ_7745c5c3_Buffer)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			return nil
 		})
 		templ_7745c5c3_Err = layouts.Base(props.BaseProps).Render(templ.WithChildren(ctx, templ_7745c5c3_Var2), templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+func emptyState() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var3 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var3 == nil {
+			templ_7745c5c3_Var3 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<section class=\"flex flex-col items-center justify-center py-20 text-center\"><div class=\"mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-blue-100 dark:bg-blue-900\"><svg class=\"h-8 w-8 text-blue-500 dark:text-blue-300\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" viewBox=\"0 0 24 24\" aria-hidden=\"true\"><circle cx=\"12\" cy=\"12\" r=\"9\" stroke=\"currentColor\" stroke-width=\"2\"></circle> <path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M12 8v8m4-4H8\"></path></svg></div><h2 class=\"mb-2 text-2xl font-semibold text-gray-900 dark:text-white\">Welcome to Your Dashboard!</h2><p class=\"mb-6 max-w-md text-base text-gray-600 dark:text-gray-300\">You haven't added any projects yet. Get started by creating your first project and unlock the full power of your SaaS workspace.</p><a href=\"/projects/new\" class=\"inline-block rounded bg-blue-600 px-5 py-2 text-white font-medium shadow hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2 transition\">Create Project</a></section>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+func skeletonTable() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var4 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var4 == nil {
+			templ_7745c5c3_Var4 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "<div x-data=\"{ loading: true }\" class=\"mt-10\"><!-- Skeleton Loader --><div x-show=\"loading\" x-transition.opacity.duration.500ms class=\"space-y-2\" aria-hidden=\"true\"><div class=\"animate-pulse flex space-x-4\"><div class=\"rounded bg-muted-dark h-6 w-1/4\"></div><div class=\"rounded bg-muted-dark h-6 w-1/4\"></div><div class=\"rounded bg-muted-dark h-6 w-1/4\"></div></div><div class=\"animate-pulse flex space-x-4\"><div class=\"rounded bg-muted-dark h-6 w-1/4\"></div><div class=\"rounded bg-muted-dark h-6 w-1/4\"></div><div class=\"rounded bg-muted-dark h-6 w-1/4\"></div></div><div class=\"animate-pulse flex space-x-4\"><div class=\"rounded bg-muted-dark h-6 w-1/4\"></div><div class=\"rounded bg-muted-dark h-6 w-1/4\"></div><div class=\"rounded bg-muted-dark h-6 w-1/4\"></div></div></div><!-- Real Table Data (to be swapped in by HTMX) --><div x-show=\"!loading\" x-transition.opacity.duration.500ms id=\"dashboard-table\" hx-get=\"/dashboard/data\" hx-trigger=\"load\" hx-target=\"#dashboard-table\" hx-swap=\"outerHTML\"><!-- Table will be swapped in by HTMX --></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/view/pages/items.templ
+++ b/internal/view/pages/items.templ
@@ -6,6 +6,7 @@ import (
 	"github.com/clownware/alpine-go-performance-starter/internal/view/partials"
 )
 
+// ItemsPageProps holds data for the items page.
 type ItemsPageProps struct {
 	view.BaseProps
 	Items    []view.Item

--- a/internal/view/pages/items_templ.go
+++ b/internal/view/pages/items_templ.go
@@ -14,6 +14,7 @@ import (
 	"github.com/clownware/alpine-go-performance-starter/internal/view/partials"
 )
 
+// ItemsPageProps holds data for the items page.
 type ItemsPageProps struct {
 	view.BaseProps
 	Items    []view.Item

--- a/internal/view/pages/logout.templ
+++ b/internal/view/pages/logout.templ
@@ -5,12 +5,8 @@ import (
 	"github.com/clownware/alpine-go-performance-starter/internal/view/layouts"
 )
 
-type LogoutPageProps struct {
-	view.BaseProps
-}
-
-templ LogoutPage(props LogoutPageProps) {
-	@layouts.Base(props.BaseProps) {
+templ LogoutPage(props view.BaseProps) {
+	@layouts.Base(props) {
 		<div class="max-w-md mx-auto bg-surface text-text dark:bg-surface-dark dark:text-text-dark rounded shadow p-6 mt-12 text-center">
 			<h1 class="text-2xl font-bold">Sign Out</h1>
 			<form hx-post="/auth/logout" hx-target="body" method="post">

--- a/internal/view/pages/logout_templ.go
+++ b/internal/view/pages/logout_templ.go
@@ -13,11 +13,7 @@ import (
 	"github.com/clownware/alpine-go-performance-starter/internal/view/layouts"
 )
 
-type LogoutPageProps struct {
-	view.BaseProps
-}
-
-func LogoutPage(props LogoutPageProps) templ.Component {
+func LogoutPage(props view.BaseProps) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -56,7 +52,7 @@ func LogoutPage(props LogoutPageProps) templ.Component {
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = layouts.Base(props.BaseProps).Render(templ.WithChildren(ctx, templ_7745c5c3_Var2), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = layouts.Base(props).Render(templ.WithChildren(ctx, templ_7745c5c3_Var2), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/view/pages/privacy.templ
+++ b/internal/view/pages/privacy.templ
@@ -5,12 +5,8 @@ import (
 	"github.com/clownware/alpine-go-performance-starter/internal/view/layouts"
 )
 
-type PrivacyPageProps struct {
-	view.BaseProps
-}
-
-templ PrivacyPage(props PrivacyPageProps) {
-	@layouts.Base(props.BaseProps) {
+templ PrivacyPage(props view.BaseProps) {
+	@layouts.Base(props) {
 		<div class="max-w-3xl mx-auto bg-surface text-text dark:bg-surface-dark dark:text-text-dark rounded shadow p-6 mt-12">
 			<h1 class="text-2xl font-bold">Privacy Policy</h1>
 			<p>This is a placeholder for your SaaS Privacy Policy. Please update this content.</p>

--- a/internal/view/pages/privacy_templ.go
+++ b/internal/view/pages/privacy_templ.go
@@ -13,11 +13,7 @@ import (
 	"github.com/clownware/alpine-go-performance-starter/internal/view/layouts"
 )
 
-type PrivacyPageProps struct {
-	view.BaseProps
-}
-
-func PrivacyPage(props PrivacyPageProps) templ.Component {
+func PrivacyPage(props view.BaseProps) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -56,7 +52,7 @@ func PrivacyPage(props PrivacyPageProps) templ.Component {
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = layouts.Base(props.BaseProps).Render(templ.WithChildren(ctx, templ_7745c5c3_Var2), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = layouts.Base(props).Render(templ.WithChildren(ctx, templ_7745c5c3_Var2), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/view/pages/profile.templ
+++ b/internal/view/pages/profile.templ
@@ -6,6 +6,7 @@ import (
 	"github.com/clownware/alpine-go-performance-starter/internal/view/partials"
 )
 
+// ProfilePageProps holds data for the profile page.
 type ProfilePageProps struct {
 	view.BaseProps
 	Name    string

--- a/internal/view/pages/profile_templ.go
+++ b/internal/view/pages/profile_templ.go
@@ -14,6 +14,7 @@ import (
 	"github.com/clownware/alpine-go-performance-starter/internal/view/partials"
 )
 
+// ProfilePageProps holds data for the profile page.
 type ProfilePageProps struct {
 	view.BaseProps
 	Name    string

--- a/internal/view/pages/terms.templ
+++ b/internal/view/pages/terms.templ
@@ -5,12 +5,8 @@ import (
 	"github.com/clownware/alpine-go-performance-starter/internal/view/layouts"
 )
 
-type TermsPageProps struct {
-	view.BaseProps
-}
-
-templ TermsPage(props TermsPageProps) {
-	@layouts.Base(props.BaseProps) {
+templ TermsPage(props view.BaseProps) {
+	@layouts.Base(props) {
 		<div class="max-w-3xl mx-auto bg-surface text-text dark:bg-surface-dark dark:text-text-dark rounded shadow p-6 mt-12">
 			<h1 class="text-2xl font-bold">Terms of Service</h1>
 			<p>This is a placeholder for your SaaS Terms of Service. Please update this content.</p>

--- a/internal/view/pages/terms_templ.go
+++ b/internal/view/pages/terms_templ.go
@@ -13,11 +13,7 @@ import (
 	"github.com/clownware/alpine-go-performance-starter/internal/view/layouts"
 )
 
-type TermsPageProps struct {
-	view.BaseProps
-}
-
-func TermsPage(props TermsPageProps) templ.Component {
+func TermsPage(props view.BaseProps) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -56,7 +52,7 @@ func TermsPage(props TermsPageProps) templ.Component {
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = layouts.Base(props.BaseProps).Render(templ.WithChildren(ctx, templ_7745c5c3_Var2), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = layouts.Base(props).Render(templ.WithChildren(ctx, templ_7745c5c3_Var2), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/view/partials/first_run.templ
+++ b/internal/view/partials/first_run.templ
@@ -1,23 +1,26 @@
 package partials
 
-// FirstRunProps holds data for the first-run onboarding wizard.
-// Step controls which phase is displayed: 1=welcome, 2=profile setup, 3=CTAs.
+// FirstRunProps holds data for the first-run onboarding experience.
 type FirstRunProps struct {
-	Step     int
-	UserName string // for pre-filling profile form in step 2
-	Error    string
+	ShowProfileSetup bool
+	ShowCTAs         bool
+	Name             string
+	Errors           map[string]string
+	Error            string
 }
 
-templ FirstRun(props FirstRunProps) {
+// FirstRunExperience renders the 3-step first-run onboarding flow.
+// Each step is an HTMX partial that swaps into #first-run-steps.
+templ FirstRunExperience(props FirstRunProps) {
 	<div id="first-run-steps" class="space-y-8">
-		if props.Step == 1 {
+		if !props.ShowProfileSetup && !props.ShowCTAs {
 			@firstRunWelcome()
 		}
-		if props.Step == 2 {
-			@firstRunProfileSetup(props.UserName)
+		if props.ShowProfileSetup {
+			@firstRunProfile(props)
 		}
-		if props.Step == 3 {
-			@firstRunCTAs()
+		if props.ShowCTAs {
+			@firstRunCTAs(props.Error)
 		}
 	</div>
 }
@@ -40,12 +43,15 @@ templ firstRunWelcome() {
 	</div>
 }
 
-templ firstRunProfileSetup(userName string) {
+templ firstRunProfile(props FirstRunProps) {
 	<!-- Step 2: Profile Setup Prompt -->
 	<div id="profile-setup" class="rounded bg-surface border border-gray-200 dark:bg-surface-dark dark:border-gray-800 p-6">
 		<h3 class="text-lg font-semibold mb-2">Set up your profile</h3>
 		<p class="mb-4 text-gray-700 dark:text-gray-300">For your security, please add a display name and confirm your email address. Never share your password with anyone.</p>
-		@ProfileForm(ProfileFormProps{Name: userName})
+		@ProfileForm(ProfileFormProps{
+			Name:   props.Name,
+			Errors: props.Errors,
+		})
 		<div class="flex justify-end mt-4">
 			<button
 				hx-get="/first-run/ctas"
@@ -59,11 +65,14 @@ templ firstRunProfileSetup(userName string) {
 	</div>
 }
 
-templ firstRunCTAs() {
+templ firstRunCTAs(errorMsg string) {
 	<!-- Step 3: CTAs -->
 	<div id="first-run-ctas" class="rounded bg-green-50 border border-green-200 p-6">
-		<h3 class="text-lg font-semibold mb-2 text-green-700">You&#39;re all set!</h3>
+		<h3 class="text-lg font-semibold mb-2 text-green-700">You're all set!</h3>
 		<p class="mb-4 text-green-900">Protect your account by enabling two-factor authentication and reviewing your security settings.</p>
+		if errorMsg != "" {
+			<p class="text-red-600 text-sm mb-4">{ errorMsg }</p>
+		}
 		<div class="flex flex-col sm:flex-row gap-3">
 			<a href="/settings/security" class="px-4 py-2 rounded bg-green-600 text-white font-medium shadow hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-600 text-center">Set Up 2FA</a>
 			<a href="/dashboard" class="px-4 py-2 rounded bg-surface text-green-700 border border-green-600 font-medium shadow hover:bg-green-50 focus:outline-none focus:ring-2 focus:ring-green-600 text-center">Go to Dashboard</a>

--- a/internal/view/partials/first_run_templ.go
+++ b/internal/view/partials/first_run_templ.go
@@ -8,15 +8,18 @@ package partials
 import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
-// FirstRunProps holds data for the first-run onboarding wizard.
-// Step controls which phase is displayed: 1=welcome, 2=profile setup, 3=CTAs.
+// FirstRunProps holds data for the first-run onboarding experience.
 type FirstRunProps struct {
-	Step     int
-	UserName string // for pre-filling profile form in step 2
-	Error    string
+	ShowProfileSetup bool
+	ShowCTAs         bool
+	Name             string
+	Errors           map[string]string
+	Error            string
 }
 
-func FirstRun(props FirstRunProps) templ.Component {
+// FirstRunExperience renders the 3-step first-run onboarding flow.
+// Each step is an HTMX partial that swaps into #first-run-steps.
+func FirstRunExperience(props FirstRunProps) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -41,20 +44,20 @@ func FirstRun(props FirstRunProps) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		if props.Step == 1 {
+		if !props.ShowProfileSetup && !props.ShowCTAs {
 			templ_7745c5c3_Err = firstRunWelcome().Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		if props.Step == 2 {
-			templ_7745c5c3_Err = firstRunProfileSetup(props.UserName).Render(ctx, templ_7745c5c3_Buffer)
+		if props.ShowProfileSetup {
+			templ_7745c5c3_Err = firstRunProfile(props).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		if props.Step == 3 {
-			templ_7745c5c3_Err = firstRunCTAs().Render(ctx, templ_7745c5c3_Buffer)
+		if props.ShowCTAs {
+			templ_7745c5c3_Err = firstRunCTAs(props.Error).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -96,7 +99,7 @@ func firstRunWelcome() templ.Component {
 	})
 }
 
-func firstRunProfileSetup(userName string) templ.Component {
+func firstRunProfile(props FirstRunProps) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -121,7 +124,10 @@ func firstRunProfileSetup(userName string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = ProfileForm(ProfileFormProps{Name: userName}).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = ProfileForm(ProfileFormProps{
+			Name:   props.Name,
+			Errors: props.Errors,
+		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -133,7 +139,7 @@ func firstRunProfileSetup(userName string) templ.Component {
 	})
 }
 
-func firstRunCTAs() templ.Component {
+func firstRunCTAs(errorMsg string) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -154,7 +160,30 @@ func firstRunCTAs() templ.Component {
 			templ_7745c5c3_Var4 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<!-- Step 3: CTAs --><div id=\"first-run-ctas\" class=\"rounded bg-green-50 border border-green-200 p-6\"><h3 class=\"text-lg font-semibold mb-2 text-green-700\">You&#39;re all set!</h3><p class=\"mb-4 text-green-900\">Protect your account by enabling two-factor authentication and reviewing your security settings.</p><div class=\"flex flex-col sm:flex-row gap-3\"><a href=\"/settings/security\" class=\"px-4 py-2 rounded bg-green-600 text-white font-medium shadow hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-600 text-center\">Set Up 2FA</a> <a href=\"/dashboard\" class=\"px-4 py-2 rounded bg-surface text-green-700 border border-green-600 font-medium shadow hover:bg-green-50 focus:outline-none focus:ring-2 focus:ring-green-600 text-center\">Go to Dashboard</a></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<!-- Step 3: CTAs --><div id=\"first-run-ctas\" class=\"rounded bg-green-50 border border-green-200 p-6\"><h3 class=\"text-lg font-semibold mb-2 text-green-700\">You're all set!</h3><p class=\"mb-4 text-green-900\">Protect your account by enabling two-factor authentication and reviewing your security settings.</p>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if errorMsg != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<p class=\"text-red-600 text-sm mb-4\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var5 string
+			templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(errorMsg)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/first_run.templ`, Line: 74, Col: 50}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</p>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<div class=\"flex flex-col sm:flex-row gap-3\"><a href=\"/settings/security\" class=\"px-4 py-2 rounded bg-green-600 text-white font-medium shadow hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-600 text-center\">Set Up 2FA</a> <a href=\"/dashboard\" class=\"px-4 py-2 rounded bg-surface text-green-700 border border-green-600 font-medium shadow hover:bg-green-50 focus:outline-none focus:ring-2 focus:ring-green-600 text-center\">Go to Dashboard</a></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/view/partials/item.templ
+++ b/internal/view/partials/item.templ
@@ -5,52 +5,49 @@ import (
 	"github.com/clownware/alpine-go-performance-starter/internal/view"
 )
 
-// ItemProps holds data for a single item row.
-type ItemProps struct {
-	Item view.Item
-}
-
-// itemFadeInData returns the Alpine.js x-data for the fade-in effect.
-func itemFadeInData() string {
-	return "{show:false}"
-}
-
-// itemToggleURL returns the HTMX toggle URL for an item.
-func itemToggleURL(id string) string {
-	return fmt.Sprintf("/items/%s/toggle", id)
-}
-
-// itemElementID returns the DOM id for an item element.
-func itemElementID(id string) string {
-	return fmt.Sprintf("item-%s", id)
-}
-
-templ Item(props ItemProps) {
+// ItemCard renders a single item row with favorite toggle (optimistic UI).
+// This is rendered as a standalone fragment for HTMX swaps on toggle.
+templ ItemCard(item view.Item) {
 	<li
-		x-data={ itemFadeInData() }
-		x-init="show=true"
+		x-data="{ show: false }"
+		x-init="show = true"
 		x-show="show"
 		x-cloak
 		x-transition
 		class="py-2 flex justify-between items-center"
-		id={ itemElementID(props.Item.ID) }
+		id={ fmt.Sprintf("item-%s", item.ID) }
 	>
-		<span>{ props.Item.Name }</span>
+		<span>{ item.Name }</span>
 		<button
-			hx-post={ itemToggleURL(props.Item.ID) }
+			hx-post={ fmt.Sprintf("/items/%s/toggle", item.ID) }
 			hx-target="this"
 			hx-swap="outerHTML"
-			class={ templ.KV("text-yellow-500", props.Item.IsFavorite), templ.KV("text-gray-400", !props.Item.IsFavorite), "hover:text-yellow-500" }
+			class={ favoriteButtonClass(item.IsFavorite) }
 		>
-			if props.Item.IsFavorite {
-				<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-					<path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"></path>
-				</svg>
+			if item.IsFavorite {
+				@filledStar()
 			} else {
-				<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.196-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118L2.04 10.099c-.783-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z"></path>
-				</svg>
+				@outlineStar()
 			}
 		</button>
 	</li>
+}
+
+func favoriteButtonClass(isFavorite bool) string {
+	if isFavorite {
+		return "text-yellow-500 hover:text-yellow-500"
+	}
+	return "text-gray-400 hover:text-yellow-500"
+}
+
+templ filledStar() {
+	<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+		<path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"></path>
+	</svg>
+}
+
+templ outlineStar() {
+	<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+		<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.196-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118L2.04 10.099c-.783-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z"></path>
+	</svg>
 }

--- a/internal/view/partials/item_templ.go
+++ b/internal/view/partials/item_templ.go
@@ -13,27 +13,9 @@ import (
 	"github.com/clownware/alpine-go-performance-starter/internal/view"
 )
 
-// ItemProps holds data for a single item row.
-type ItemProps struct {
-	Item view.Item
-}
-
-// itemFadeInData returns the Alpine.js x-data for the fade-in effect.
-func itemFadeInData() string {
-	return "{show:false}"
-}
-
-// itemToggleURL returns the HTMX toggle URL for an item.
-func itemToggleURL(id string) string {
-	return fmt.Sprintf("/items/%s/toggle", id)
-}
-
-// itemElementID returns the DOM id for an item element.
-func itemElementID(id string) string {
-	return fmt.Sprintf("item-%s", id)
-}
-
-func Item(props ItemProps) templ.Component {
+// ItemCard renders a single item row with favorite toggle (optimistic UI).
+// This is rendered as a standalone fragment for HTMX swaps on toggle.
+func ItemCard(item view.Item) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -54,96 +36,148 @@ func Item(props ItemProps) templ.Component {
 			templ_7745c5c3_Var1 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<li x-data=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<li x-data=\"{ show: false }\" x-init=\"show = true\" x-show=\"show\" x-cloak x-transition class=\"py-2 flex justify-between items-center\" id=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var2 string
-		templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(itemFadeInData())
+		templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("item-%s", item.ID))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/item.templ`, Line: 30, Col: 27}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/item.templ`, Line: 18, Col: 38}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "\" x-init=\"show=true\" x-show=\"show\" x-cloak x-transition class=\"py-2 flex justify-between items-center\" id=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "\"><span>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var3 string
-		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(itemElementID(props.Item.ID))
+		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(item.Name)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/item.templ`, Line: 36, Col: 35}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/item.templ`, Line: 20, Col: 19}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "\"><span>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</span> ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var4 string
-		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(props.Item.Name)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/item.templ`, Line: 38, Col: 25}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
+		var templ_7745c5c3_Var4 = []any{favoriteButtonClass(item.IsFavorite)}
+		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var4...)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</span> ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "<button hx-post=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var5 = []any{templ.KV("text-yellow-500", props.Item.IsFavorite), templ.KV("text-gray-400", !props.Item.IsFavorite), "hover:text-yellow-500"}
-		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var5...)
+		var templ_7745c5c3_Var5 string
+		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("/items/%s/toggle", item.ID))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/item.templ`, Line: 22, Col: 53}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<button hx-post=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "\" hx-target=\"this\" hx-swap=\"outerHTML\" class=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var6 string
-		templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(itemToggleURL(props.Item.ID))
+		templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var4).String())
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/item.templ`, Line: 40, Col: 41}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/item.templ`, Line: 1, Col: 0}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "\" hx-target=\"this\" hx-swap=\"outerHTML\" class=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var7 string
-		templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var5).String())
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/item.templ`, Line: 1, Col: 0}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "\">")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		if props.Item.IsFavorite {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<svg xmlns=\"http://www.w3.org/2000/svg\" class=\"h-5 w-5\" viewBox=\"0 0 20 20\" fill=\"currentColor\"><path d=\"M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z\"></path></svg>")
+		if item.IsFavorite {
+			templ_7745c5c3_Err = filledStar().Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<svg xmlns=\"http://www.w3.org/2000/svg\" class=\"h-5 w-5\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.196-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118L2.04 10.099c-.783-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z\"></path></svg>")
+			templ_7745c5c3_Err = outlineStar().Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</button></li>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</button></li>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+func favoriteButtonClass(isFavorite bool) string {
+	if isFavorite {
+		return "text-yellow-500 hover:text-yellow-500"
+	}
+	return "text-gray-400 hover:text-yellow-500"
+}
+
+func filledStar() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var7 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var7 == nil {
+			templ_7745c5c3_Var7 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<svg xmlns=\"http://www.w3.org/2000/svg\" class=\"h-5 w-5\" viewBox=\"0 0 20 20\" fill=\"currentColor\"><path d=\"M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z\"></path></svg>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+func outlineStar() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var8 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var8 == nil {
+			templ_7745c5c3_Var8 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<svg xmlns=\"http://www.w3.org/2000/svg\" class=\"h-5 w-5\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.196-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118L2.04 10.099c-.783-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z\"></path></svg>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/view/partials/items_list.templ
+++ b/internal/view/partials/items_list.templ
@@ -5,27 +5,24 @@ import (
 	"github.com/clownware/alpine-go-performance-starter/internal/view"
 )
 
-// ItemsListProps holds data for the items list fragment.
+// ItemsListProps holds data for the items list partial.
 type ItemsListProps struct {
 	Items    []view.Item
 	NextPage int
 }
 
-// itemsNextPageURL returns the HTMX URL for loading the next page.
-func itemsNextPageURL(page int) string {
-	return fmt.Sprintf("/items/list?page=%d", page)
-}
-
+// ItemsList renders the list of items with infinite scroll support.
+// Rendered as a standalone fragment for HTMX swaps.
 templ ItemsList(props ItemsListProps) {
 	<ul id="item-ul" class="divide-y divide-gray-200">
 		for _, item := range props.Items {
-			@Item(ItemProps{Item: item})
+			@ItemCard(item)
 		}
 	</ul>
 	if props.NextPage > 0 {
 		<!-- Infinite scroll sentinel: loads next page when revealed -->
 		<div
-			hx-get={ itemsNextPageURL(props.NextPage) }
+			hx-get={ fmt.Sprintf("/items/list?page=%d", props.NextPage) }
 			hx-trigger="revealed"
 			hx-target="#item-ul"
 			hx-swap="beforeend"
@@ -36,7 +33,7 @@ templ ItemsList(props ItemsListProps) {
 		<!-- Fallback Load More button -->
 		<div class="mt-4 text-center">
 			<button
-				hx-get={ itemsNextPageURL(props.NextPage) }
+				hx-get={ fmt.Sprintf("/items/list?page=%d", props.NextPage) }
 				hx-target="#item-ul"
 				hx-swap="beforeend"
 				class="px-4 py-2 bg-primary-600 text-white rounded"

--- a/internal/view/partials/items_list_templ.go
+++ b/internal/view/partials/items_list_templ.go
@@ -13,17 +13,14 @@ import (
 	"github.com/clownware/alpine-go-performance-starter/internal/view"
 )
 
-// ItemsListProps holds data for the items list fragment.
+// ItemsListProps holds data for the items list partial.
 type ItemsListProps struct {
 	Items    []view.Item
 	NextPage int
 }
 
-// itemsNextPageURL returns the HTMX URL for loading the next page.
-func itemsNextPageURL(page int) string {
-	return fmt.Sprintf("/items/list?page=%d", page)
-}
-
+// ItemsList renders the list of items with infinite scroll support.
+// Rendered as a standalone fragment for HTMX swaps.
 func ItemsList(props ItemsListProps) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
@@ -50,7 +47,7 @@ func ItemsList(props ItemsListProps) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		for _, item := range props.Items {
-			templ_7745c5c3_Err = Item(ItemProps{Item: item}).Render(ctx, templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = ItemCard(item).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -65,9 +62,9 @@ func ItemsList(props ItemsListProps) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var2 string
-			templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(itemsNextPageURL(props.NextPage))
+			templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("/items/list?page=%d", props.NextPage))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/items_list.templ`, Line: 28, Col: 44}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/items_list.templ`, Line: 25, Col: 62}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 			if templ_7745c5c3_Err != nil {
@@ -78,9 +75,9 @@ func ItemsList(props ItemsListProps) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var3 string
-			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(itemsNextPageURL(props.NextPage))
+			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("/items/list?page=%d", props.NextPage))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/items_list.templ`, Line: 39, Col: 45}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/items_list.templ`, Line: 36, Col: 63}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 			if templ_7745c5c3_Err != nil {

--- a/internal/view/partials/profile_form.templ
+++ b/internal/view/partials/profile_form.templ
@@ -1,34 +1,36 @@
 package partials
 
-// ProfileFormProps holds data for the profile form fragment.
+// ProfileFormProps holds data for the profile form partial.
 type ProfileFormProps struct {
 	Name    string
 	Errors  map[string]string
 	Success bool
 }
 
-// successAutoDismiss returns the Alpine.js x-data for the auto-dismissing success message.
-func successAutoDismiss() string {
-	return "{show: true}"
-}
-
-// successAutoDismissInit returns the Alpine.js x-init for the auto-dismissing success message.
-func successAutoDismissInit() string {
-	return "setTimeout(() => show = false, 3000)"
-}
-
+// ProfileForm renders the profile form as a standalone fragment (for HTMX swaps).
 templ ProfileForm(props ProfileFormProps) {
 	<div class="space-y-4">
-		if nameErr, ok := props.Errors["name"]; ok {
-			<p class="text-red-600 text-sm">{ nameErr }</p>
+		if errMsg, ok := props.Errors["name"]; ok {
+			<p class="text-red-600 text-sm">{ errMsg }</p>
 		}
 		if props.Success {
-			<div x-data={ successAutoDismiss() } x-show="show" x-init={ successAutoDismissInit() } class="bg-green-100 border border-green-400 text-green-700 px-4 py-2 rounded">
+			<div
+				x-data="{ show: true }"
+				x-show="show"
+				x-init="setTimeout(() => show = false, 3000)"
+				class="bg-green-100 border border-green-400 text-green-700 px-4 py-2 rounded"
+			>
 				Profile updated successfully!
 			</div>
 		}
 		<label for="name" class="block text-sm font-medium text-gray-700">Name</label>
-		<input type="text" name="name" id="name" value={ props.Name } class="mt-1 block w-full border-gray-300 rounded-md focus:ring-primary-500 focus:border-primary-500"/>
+		<input
+			type="text"
+			name="name"
+			id="name"
+			value={ props.Name }
+			class="mt-1 block w-full border-gray-300 rounded-md focus:ring-primary-500 focus:border-primary-500"
+		/>
 		<div class="mt-2">
 			<button type="submit" class="px-4 py-2 bg-primary-600 text-white rounded" hx-indicator=".indicator">Save</button>
 			<span class="indicator hidden text-gray-500 ml-2">Saving...</span>

--- a/internal/view/partials/profile_form_templ.go
+++ b/internal/view/partials/profile_form_templ.go
@@ -8,23 +8,14 @@ package partials
 import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
-// ProfileFormProps holds data for the profile form fragment.
+// ProfileFormProps holds data for the profile form partial.
 type ProfileFormProps struct {
 	Name    string
 	Errors  map[string]string
 	Success bool
 }
 
-// successAutoDismiss returns the Alpine.js x-data for the auto-dismissing success message.
-func successAutoDismiss() string {
-	return "{show: true}"
-}
-
-// successAutoDismissInit returns the Alpine.js x-init for the auto-dismissing success message.
-func successAutoDismissInit() string {
-	return "setTimeout(() => show = false, 3000)"
-}
-
+// ProfileForm renders the profile form as a standalone fragment (for HTMX swaps).
 func ProfileForm(props ProfileFormProps) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
@@ -50,15 +41,15 @@ func ProfileForm(props ProfileFormProps) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		if nameErr, ok := props.Errors["name"]; ok {
+		if errMsg, ok := props.Errors["name"]; ok {
 			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<p class=\"text-red-600 text-sm\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var2 string
-			templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(nameErr)
+			templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(errMsg)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/profile_form.templ`, Line: 23, Col: 44}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/profile_form.templ`, Line: 14, Col: 43}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 			if templ_7745c5c3_Err != nil {
@@ -70,51 +61,25 @@ func ProfileForm(props ProfileFormProps) templ.Component {
 			}
 		}
 		if props.Success {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "<div x-data=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var3 string
-			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(successAutoDismiss())
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/profile_form.templ`, Line: 26, Col: 37}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "\" x-show=\"show\" x-init=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var4 string
-			templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(successAutoDismissInit())
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/profile_form.templ`, Line: 26, Col: 87}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "\" class=\"bg-green-100 border border-green-400 text-green-700 px-4 py-2 rounded\">Profile updated successfully!</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "<div x-data=\"{ show: true }\" x-show=\"show\" x-init=\"setTimeout(() => show = false, 3000)\" class=\"bg-green-100 border border-green-400 text-green-700 px-4 py-2 rounded\">Profile updated successfully!</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<label for=\"name\" class=\"block text-sm font-medium text-gray-700\">Name</label> <input type=\"text\" name=\"name\" id=\"name\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<label for=\"name\" class=\"block text-sm font-medium text-gray-700\">Name</label> <input type=\"text\" name=\"name\" id=\"name\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var5 string
-		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(props.Name)
+		var templ_7745c5c3_Var3 string
+		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(props.Name)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/profile_form.templ`, Line: 31, Col: 61}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/profile_form.templ`, Line: 31, Col: 21}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "\" class=\"mt-1 block w-full border-gray-300 rounded-md focus:ring-primary-500 focus:border-primary-500\"><div class=\"mt-2\"><button type=\"submit\" class=\"px-4 py-2 bg-primary-600 text-white rounded\" hx-indicator=\".indicator\">Save</button> <span class=\"indicator hidden text-gray-500 ml-2\">Saving...</span></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "\" class=\"mt-1 block w-full border-gray-300 rounded-md focus:ring-primary-500 focus:border-primary-500\"><div class=\"mt-2\"><button type=\"submit\" class=\"px-4 py-2 bg-primary-600 text-white rounded\" hx-indicator=\".indicator\">Save</button> <span class=\"indicator hidden text-gray-500 ml-2\">Saving...</span></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
## Summary
- Convert all remaining `html/template` files to type-safe templ components (8 pages, 4 partials)
- Update all handlers to use `view.Render()` with typed props structs
- Delete `web/templates/` directory, old rendering pipeline, and dead component templates
- Add ADR-017 documenting the templ adoption decision

## Details

**Pages converted:** dashboard, terms, privacy, logout, auth (login/signup), profile, items
**Partials converted:** profile_form, items_list, item (optimistic UI), first_run (3-step onboarding)

**Key improvements:**
- All template data is typed props (no more `map[string]interface{}`)
- HTMX partial responses render fragments directly without base layout wrapper (fixes a bug in the old system)
- Compile-time validation of all template fields and types
- 6 unused component templates identified as dead code and removed (#8)

**Removed:** `webutil.RenderTemplate`, `RenderTemplateWithErrors`, `FormErrors`, `view.TemplateFuncs()`
**Kept:** `webutil` HTMX helpers and context helpers (still used by handlers)

## Test plan
- [x] `templ generate` — no errors
- [x] `go build ./...` — clean
- [x] `go test -race ./...` — all passing
- [ ] Manual browser test: all pages render, dark mode, HTMX interactions, form validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)