### PR TITLE
docs: ADR-024 demo direction + design brief

### DIFF
--- a/docs/adr/ADR-024-Demo-Application-Direction.md
+++ b/docs/adr/ADR-024-Demo-Application-Direction.md
@@ -1,0 +1,52 @@
+# ADR-024: Demo Application Direction
+
+**Date**: 2026-06-11
+
+## Status
+
+Proposed
+
+## Context
+
+The starter needs a demo application that (a) markets the project in under 60 seconds, (b) demonstrates every HTMX/Alpine pattern it supports, and (c) proves the full stack works end-to-end — persisted Postgres data, Supabase auth, RLS ownership, and the performance budgets. The current demo uses an abstract "Items" resource backed by an in-memory `map` (`internal/handler/items_handlers.go`) — it persists nothing and exercises none of sqlc/repository/RLS/auth, so it under-sells exactly what the starter exists to provide.
+
+The prior plan ([`docs/updates/ux-overhaul-spec.md`](../updates/ux-overhaul-spec.md)) proposed a per-user **bookmarks** CRUD plus a `/patterns` showcase. The patterns showcase is strong and retained. Bookmarks is replaced: it is a generic domain unrelated to the product, and per-user scoping skips the multi-tenant story the repo already ships.
+
+A second constraint surfaced: to host this demo publicly, a forker should be able to *use* it (take the quiz, save flashcards, see progress) **without a signup wall** — but stripping auth would gut the starter's core proof.
+
+## Decision
+
+Build the demo as a **self-documenting architecture explainer** with three coherent surfaces, replacing the abstract Items domain:
+
+1. **Architecture explainer (narrative spine).** Interactive, server-rendered walkthrough of this system's own architecture — request lifecycle, middleware stack, templ rendering, sqlc/repository, RLS, and the performance budgets (rendered live from `internal/performance/` constants). The medium proves the message: a minimal-JS page teaching minimal-JS architecture.
+2. **`/patterns` showcase.** The interactive HTMX/Alpine pattern gallery from the prior spec (live demo + templ source + handler source per pattern). Stub data, no DB. Retained as-is.
+3. **Quiz + flashcards (the concrete, persisted, authenticated CRUD domain).** A quiz over the explainer content; wrong answers offer to save a **flashcard**; users review, mark-known, and delete flashcards, with progress persisted. This is the real full-stack demo: sqlc + repository + RLS + auth + forms.
+
+**Identity: anonymous-auth guest mode, issued server-side.** Visitors get a real but anonymous Supabase identity on arrival (no signup), so RLS and per-user CRUD are genuinely exercised — the anonymous user is just a `users` row whose `auth_id` is the anonymous `auth.uid()`, and the existing `auth_id = auth.uid()::text` self-access policy applies unchanged. Because the app is server-rendered (not a SPA), the Go backend performs the anonymous sign-in against GoTrue and manages an httpOnly session cookie. An **"upgrade to keep your progress"** flow links an email/password identity to the same account (data-preserving). This is one identity model — no parallel guest path.
+
+### Accompanying constraints (best practice for anonymous auth)
+
+- Gate expensive/destructive operations on the `is_anonymous` claim.
+- A TTL **reaper** background job deletes inactive anonymous users (demonstrates the background-jobs guide).
+- **Rate-limit** public write endpoints (demonstrates the existing rate-limiter middleware).
+
+## Consequences
+
+- One coherent story replaces three disconnected pieces (marketing + abstract CRUD + gallery); the demo exercises auth, RLS, CRUD, background jobs, and rate limiting with zero signup friction.
+- The abstract `items` handlers and in-memory `itemStore` are retired (some logic may be reused inside the `/patterns` showcase as stub demos).
+- New tables (`quiz_questions`, `quiz_attempts`, `flashcards`) with RLS mirroring the existing `users_self_access` pattern; new sqlc queries and repositories.
+- New surface area to secure: a public, anonymous-writable endpoint set — must ship with rate limiting and `is_anonymous` gating from day one.
+- Requires Supabase anonymous sign-in enabled; the Go/GoTrue server-side path must be verified (fallback: call the GoTrue anonymous sign-in REST endpoint directly — still a real anonymous user).
+- Explainer content is a writing cost, but it doubles as user-facing documentation.
+
+## Alternatives Considered
+
+- **Per-user or org-scoped bookmarks.** Rejected — generic, unmotivated domain; bookmarks doesn't tie to the learning experience the way quiz-driven flashcards do.
+- **No auth (cookie-only guest session, no Supabase user).** Rejected — builds a parallel non-auth code path that isn't what the starter is for, and skips the RLS/auth proof.
+- **Seeded read-only demo + login-to-write.** Rejected — reintroduces signup friction for the interactive part that matters.
+- **Client-only flashcards (Alpine + localStorage).** Rejected — demonstrates none of the backend.
+
+## References
+
+- Supersedes the bookmarks/landing scope of [`docs/updates/ux-overhaul-spec.md`](../updates/ux-overhaul-spec.md); design brief in [`docs/updates/demo-design-brief.md`](../updates/demo-design-brief.md).
+- Related: [ADR-004](ADR-004-Authorization-Strategy-RLS.md) (RLS), [ADR-007](ADR-007-Frontend-Stack-Selection.md) (frontend), [ADR-014](ADR-014-Security-Patterns-and-Threat-Model.md) (security), [ADR-017](ADR-017-Templ-Adoption.md) (templ).

--- a/docs/updates/demo-design-brief.md
+++ b/docs/updates/demo-design-brief.md
@@ -1,0 +1,105 @@
+# Demo Design Brief
+
+> Input for the design/mockup phase (Claude Design). Defines the screens to mock and the constraints that make mockups buildable against the existing templ + Tailwind stack. Decision context: [ADR-024](../adr/ADR-024-Demo-Application-Direction.md).
+
+## Concept in one line
+
+A self-documenting, server-rendered tour of this starter's own architecture — explainer → interactive pattern showcase → quiz that spawns saveable flashcards — usable instantly as an anonymous guest, upgradeable to a real account.
+
+## Design principles
+
+1. **The medium is the message.** Minimal JS, fast, server-rendered. The page should *feel* like what it teaches. No heavy client framework, no spinner-heavy SPA feel.
+2. **Progressive disclosure.** Value prop in 10s, patterns in 5 min, a working forkable scaffold in 15.
+3. **Guest-first.** Nothing the visitor wants to try is behind a signup wall. "Upgrade to keep progress" is a reward, never a gate.
+4. **Accessibility is non-negotiable** (ADR-009): WCAG 2.1 AA, semantic HTML, visible focus, keyboard-operable, labelled controls, contrast-checked tokens.
+5. **Dark mode is first-class** — every screen must be mocked in both light and dark (the app already switches via the `.dark` class).
+
+## Design tokens (source of truth: `web/static/css/semantic-colors.css`)
+
+Mock against these *roles*, not raw hex — they flip in dark mode.
+
+| Role | Light | Dark | Tailwind/CSS var |
+|---|---|---|---|
+| Primary | `#468189` (teal) | teal | `--color-primary` |
+| Danger | `#bf4342` (bittersweet) | bittersweet | `--color-danger` |
+| Background | `#f0ffce` (nyanza) | `#0c0c0c` (night) | `--color-background` |
+| Surface | `#ffffff` | `#1a1a1a` | `--color-surface` |
+| Text | `#0c0c0c` (night) | `#f0ffce` (nyanza) | `--color-text` |
+| Accent / Muted | `#d2cca1` (sage) | sage / teal | `--color-accent`, `--color-muted` |
+
+Base palette: **teal `#468189`, bittersweet `#bf4342`, night `#0c0c0c`, nyanza `#f0ffce`, sage `#d2cca1`.** Type: Inter (body) + Oxanium (display/headings) — both already bundled. Styling is Tailwind v4 utilities; **no hardcoded colors, no manual `dark:` overrides** — use the role tokens so dark mode is automatic.
+
+> Gap to close in parallel: these roles should be promoted into a formal token doc + Tailwind `@theme` mapping (mirroring the astro starter's role-based token ADR). Flagged for an engineering follow-up; mockups can proceed against the table above now.
+
+## Components to reuse (don't redesign these)
+
+Existing templ components in `internal/view/components/`: **button, input, form, card, alert, accessibility** (skip-links/sr-only helpers). Layout shell: `internal/view/layouts/base.templ` (nav, footer, dark-mode toggle, toast region). Mock new screens by *composing* these; only design genuinely new elements (diagram nodes, quiz card, flashcard, request-tracer).
+
+## Screen inventory to mock
+
+**Mock in both light + dark. Priority 1 = highest design value.**
+
+| Priority | Screen | Route | Notes |
+|---|---|---|---|
+| **1** | Landing / explainer | `/` | Hero, stack overview, **live perf stats** (from budget constants below), architecture diagram entry, footer CTA. The marketing surface. |
+| **1** | Patterns showcase | `/patterns` | Vertical sections; each = demo panel + tabbed (templ \| handler) source. The centerpiece. |
+| **1** | Quiz flow | `/learn/quiz` | Question card, choices, submit → result + explanation swap, running score, "save as flashcard" on wrong answers. |
+| **1** | Flashcards | `/learn/flashcards` | Grid/list of saved cards; flip interaction; mark-known; delete; empty state. |
+| 2 | Guest banner + upgrade | (global) | Persistent "You're browsing as a guest — save your progress" affordance; upgrade modal (email/password) that links the account. |
+| 2 | Dashboard | `/dashboard` | Progress widgets (quiz score history, cards-to-review), skeleton loaders. |
+| 3 | Auth (sign in / create) | `/auth` | Tabbed card (Alpine `x-show`); only reached via upgrade or direct nav. |
+| 3 | Profile | `/profile` | Reuse existing; minor polish. |
+
+## Explainer content map (the teachable spine)
+
+Order the narrative as a request's journey through the stack, each a diagram node + short prose + a source peek:
+
+1. Request in → **Chi router + middleware stack** (security headers, request ID, rate limit, metrics, recover, timeout, auth).
+2. **Handler** resolves typed input.
+3. **Repository → sqlc → Postgres**, with **RLS** scoping rows to `auth.uid()`.
+4. **templ** renders typed components; **HTMX** swaps fragments; **Alpine** handles light interactivity.
+5. **Performance budgets** enforced in CI + observed via Prometheus.
+
+Each node links to its ADR. The quiz draws questions from these five topics.
+
+## Live performance stats (render from constants, never hardcode)
+
+Source: `internal/performance/budgets.go`. Display on the landing page via a Go handler that reads these — itself a demo of server-rendered dynamic content.
+
+- P50 < 50ms · P95 < 100ms · P99 < 200ms
+- Binary < 20MB · Memory < 128MB (peak 256MB) · Startup < 500ms
+- JS < 50KB · CSS < 30KB · Total page < 500KB
+
+## Data model (for the quiz/flashcard surfaces)
+
+New tables, RLS mirroring the existing `users_self_access` policy (`auth_id = auth.uid()::text`) so **anonymous guests are scoped identically**. UUID PKs, `updated_at` trigger, FORCE RLS + service-role bypass — same conventions as `migrations/000001`/`000002`.
+
+```
+quiz_questions     -- seeded reference content (permissive SELECT; not user-owned)
+  id uuid pk, slug text unique, topic text, prompt text,
+  choices jsonb, correct_index int, explanation text, created_at
+
+quiz_attempts      -- user-owned (RLS via users.auth_id)
+  id uuid pk, user_id uuid fk users, question_id uuid fk quiz_questions,
+  selected_index int, is_correct bool, created_at
+
+flashcards         -- user-owned (RLS via users.auth_id); created from wrong answers
+  id uuid pk, user_id uuid fk users, question_id uuid fk quiz_questions null,
+  front text, back text, is_known bool default false, created_at, updated_at
+```
+
+Progress (score, streak, cards-to-review) is computed from `quiz_attempts` + `flashcards` — no extra table needed for v1.
+
+## HTMX/Alpine patterns this demo must exercise
+
+Quiz answer submit (`hx-post` → result swap), save-flashcard (`hx-post`, optimistic), flashcard delete (`hx-delete`, `hx-swap="outerHTML swap:200ms"`), mark-known toggle, live perf stats, skeleton loaders on dashboard widgets, dark-mode toggle, toast on save/delete via `HX-Trigger`. (The full pattern catalogue lives in the retained `/patterns` section of [`ux-overhaul-spec.md`](ux-overhaul-spec.md).)
+
+## What NOT to mock
+
+CRUD edit forms beyond the flashcard/quiz cards, settings pages, and anything that's a conventional reuse of the existing component set — build those directly from components.
+
+## Deliverables expected back from the design phase
+
+1. Light + dark mockups for the Priority-1 screens.
+2. Any *new* component specs (diagram node, quiz card, flashcard, request-tracer) expressed as composable pieces with the role tokens above.
+3. Confirmation that contrast passes AA for the token pairings in both modes.

--- a/docs/updates/ux-overhaul-spec.md
+++ b/docs/updates/ux-overhaul-spec.md
@@ -1,6 +1,6 @@
 # UX Overhaul: Product Spec
 
-> **Status: Active / planned.** The Tailwind v4 and templ migrations this spec depended on are now complete. This is the next planned body of work for the demo application; it has not yet been built.
+> **Status: Partially superseded by [ADR-024](../adr/ADR-024-Demo-Application-Direction.md) (2026-06-11).** The demo direction changed: the per-user **bookmarks** domain and the landing-page scope are replaced by an architecture-explainer + quiz + saveable-flashcards concept with anonymous-guest auth. **The `/patterns` showcase section of this document is retained** as the pattern catalogue for that surface. See [`demo-design-brief.md`](demo-design-brief.md) for the current screen inventory and data model.
 
 Target state for the Alpine Go Performance Starter demo application. This spec defines the page inventory, routes, data models, and showcase content that will be built after the Tailwind v4 and templ migrations are complete.
 


### PR DESCRIPTION
## Why
Records the demo pivot decided in conversation, replacing the abstract in-memory Items domain (and the prior per-user bookmarks scope) with a coherent, full-stack demo.

## What
- **ADR-024 (Proposed)** — self-documenting architecture explainer + `/patterns` HTMX showcase + quiz that spawns saveable **flashcards**, with **anonymous guest auth** (server-issued Supabase anonymous identity, RLS-scoped via the existing `auth_id = auth.uid()` policy, plus a data-preserving upgrade flow). Alternatives (bookmarks, no-auth cookie session, read-only+login) recorded and rejected.
- **`docs/updates/demo-design-brief.md`** — the Claude Design input: screen inventory (light+dark), role-based token palette from `semantic-colors.css`, components to reuse, explainer content map, live-perf-stats source, and the `quiz_questions`/`quiz_attempts`/`flashcards` data model.
- Marked the bookmarks/landing scope of `ux-overhaul-spec.md` superseded; retained its `/patterns` pattern catalogue.

## Next
Design phase (full mockups) → then build under `task ci`: data layer + anonymous-auth session + quiz/flashcards handlers. Open question to verify at build time: `gotrue-go` anonymous sign-in support (fallback: direct GoTrue REST call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)