### PR TITLE
fix(lint): migrate golangci-lint to v2 + add vuln-scan job (closes #18)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,29 @@ jobs:
     - name: Check AGENTS.md is in sync with its sources (ADR-022)
       run: go run ./scripts/agentsmd check
 
+  security:
+    name: Vulnerability Scan
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.25'
+        cache: true
+
+    - name: Install templ
+      run: go install github.com/a-h/templ/cmd/templ@v0.3.1001
+
+    - name: Generate templ
+      run: templ generate
+
+    - name: govulncheck
+      run: |
+        go install golang.org/x/vuln/cmd/govulncheck@latest
+        govulncheck ./...
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,48 +1,46 @@
+version: "2"
 run:
-  timeout: 5m
-  go: '1.24'
+  go: "1.25"
   modules-download-mode: readonly
-
 linters:
-  disable-all: true
+  default: none
   enable:
-    # Basic linters
-    - errcheck      # Checks for unchecked errors
-    - gosimple      # Simplifies code
-    - govet         # Reports suspicious constructs
-    - ineffassign   # Detects unused assignments
-    - staticcheck   # Go static analysis tool
-    - typecheck     # Type checking
-    - unused        # Checks for unused constants, variables, functions, types
-    
-    # Style linters
-    - goimports     # Manages imports and formats code
-    - gofmt         # Formats code
-    - misspell      # Finds commonly misspelled words
-    - whitespace    # Checks for unnecessary whitespace
-    
-    # Additional linters (can be enabled as needed)
-    # - bodyclose     # Checks whether HTTP response bodies are closed
-    # - gosec         # Security checker
-    # - prealloc      # Finds slice declarations that could be preallocated
-
-linters-settings:
-  goimports:
-    local-prefixes: github.com/clownware/alpine-go-performance-starter
-
+    - errcheck
+    - govet
+    - ineffassign
+    - misspell
+    - staticcheck
+    - unused
+    - whitespace
+  exclusions:
+    generated: lax
+    rules:
+      - linters:
+          - errcheck
+          - gosec
+        path: _test\.go
+      - path: (.+)\.go$
+        text: should have a package comment
+      - path: (.+)\.go$
+        text: exported .* should have comment or be unexported
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 issues:
-  exclude-rules:
-    # Exclude some linters from tests
-    - path: _test\.go
-      linters:
-        - errcheck
-        - gosec
-      
   max-issues-per-linter: 0
   max-same-issues: 0
-  
-  # Don't show issues with auto-generated code  
-  exclude-use-default: false
-  exclude:
-    - should have a package comment
-    - exported .* should have comment or be unexported
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/clownware/alpine-go-performance-starter
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -43,9 +43,10 @@ tasks:
       - golangci-lint run ./...
 
   fmt:
-    desc: Format Go code
+    desc: Format Go code (gofmt + goimports via golangci-lint v2)
+    deps: [lint:install]
     cmds:
-      - go fmt ./...
+      - golangci-lint fmt ./...
 
   fmt:check:
     desc: Fail if any Go file is not gofmt-clean

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -10,12 +10,13 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/joho/godotenv"
+
 	"github.com/clownware/alpine-go-performance-starter/internal/config"
 	_ "github.com/clownware/alpine-go-performance-starter/internal/database" // Keep for sqlc generated types, alias not needed directly here
 	"github.com/clownware/alpine-go-performance-starter/internal/middleware"
 	"github.com/clownware/alpine-go-performance-starter/internal/server"
-	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/joho/godotenv"
 )
 
 // version is set at build time via -ldflags "-X main.version=..."

--- a/internal/auth/client.go
+++ b/internal/auth/client.go
@@ -14,7 +14,7 @@ type AuthClient struct {
 // NewAuthClient creates and initializes a new Supabase client.
 func NewAuthClient(supabaseURL, supabaseAnonKey string) (*AuthClient, error) {
 	if supabaseURL == "" || supabaseAnonKey == "" {
-		return nil, errors.New("Supabase URL and Anon Key are required")
+		return nil, errors.New("supabase URL and anon key are required")
 	}
 
 	// Initialize the Supabase client

--- a/internal/database/fixtures/fixtures.go
+++ b/internal/database/fixtures/fixtures.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/clownware/alpine-go-performance-starter/internal/database"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/clownware/alpine-go-performance-starter/internal/database"
 )
 
 // TestFixtures provides utilities for setting up test data.

--- a/internal/handler/api_handlers.go
+++ b/internal/handler/api_handlers.go
@@ -3,17 +3,21 @@ package handler
 import (
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http"
 
-	"github.com/clownware/alpine-go-performance-starter/internal/view"
 	"github.com/go-chi/chi/v5"
+
+	"github.com/clownware/alpine-go-performance-starter/internal/view"
 )
 
 // APIPlaceholder returns a simple JSON message
 func APIPlaceholder(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(map[string]string{"message": "API is running"})
+	if err := json.NewEncoder(w).Encode(map[string]string{"message": "API is running"}); err != nil {
+		slog.Error("failed to encode response", "handler", "APIPlaceholder", "error", err)
+	}
 }
 
 // GetUserProfile returns a stub user profile
@@ -31,7 +35,9 @@ func GetUserProfile(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(user)
+	if err := json.NewEncoder(w).Encode(user); err != nil {
+		slog.Error("failed to encode response", "handler", "GetUserProfile", "error", err)
+	}
 }
 
 // ListOrganizations returns a stub list of organizations
@@ -42,5 +48,7 @@ func ListOrganizations(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(orgs)
+	if err := json.NewEncoder(w).Encode(orgs); err != nil {
+		slog.Error("failed to encode response", "handler", "ListOrganizations", "error", err)
+	}
 }

--- a/internal/handler/auth_handlers.go
+++ b/internal/handler/auth_handlers.go
@@ -5,10 +5,11 @@ import (
 	"log/slog"
 	"net/http"
 
+	"github.com/supabase-community/gotrue-go/types"
+
 	"github.com/clownware/alpine-go-performance-starter/internal/auth"
 	"github.com/clownware/alpine-go-performance-starter/internal/view"
 	"github.com/clownware/alpine-go-performance-starter/internal/view/pages"
-	"github.com/supabase-community/gotrue-go/types"
 )
 
 // AuthPage renders the combined login/signup page.

--- a/internal/handler/error_handler.go
+++ b/internal/handler/error_handler.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"encoding/json"
+	"log/slog"
 	"net/http"
 )
 
@@ -14,5 +15,7 @@ type APIError struct {
 func JSONError(w http.ResponseWriter, status int, err error) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	json.NewEncoder(w).Encode(APIError{Error: err.Error()})
+	if encodeErr := json.NewEncoder(w).Encode(APIError{Error: err.Error()}); encodeErr != nil {
+		slog.Error("failed to encode error response", "error", encodeErr)
+	}
 }

--- a/internal/handler/first_run_handlers.go
+++ b/internal/handler/first_run_handlers.go
@@ -4,10 +4,11 @@ import (
 	"log/slog"
 	"net/http"
 
+	"github.com/go-chi/chi/v5"
+
 	"github.com/clownware/alpine-go-performance-starter/internal/view"
 	"github.com/clownware/alpine-go-performance-starter/internal/view/partials"
 	"github.com/clownware/alpine-go-performance-starter/internal/webutil"
-	"github.com/go-chi/chi/v5"
 )
 
 // FirstRunHandlers registers first-run onboarding routes.

--- a/internal/handler/health_handler.go
+++ b/internal/handler/health_handler.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"runtime/debug"
 	"sync"
@@ -32,7 +33,7 @@ func InitHealth(db *pgxpool.Pool) {
 // Used by Dockerfile HEALTHCHECK — must return 200 with minimal overhead.
 func HealthHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte("OK"))
+	_, _ = w.Write([]byte("OK")) // liveness probe; nothing actionable if the write fails
 }
 
 // HealthDetailHandler returns a detailed JSON health check with dependency status.
@@ -82,5 +83,7 @@ func HealthDetailHandler(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(httpStatus)
-	json.NewEncoder(w).Encode(resp)
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		slog.Error("failed to encode health response", "error", err)
+	}
 }

--- a/internal/handler/items_handlers.go
+++ b/internal/handler/items_handlers.go
@@ -7,10 +7,11 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/go-chi/chi/v5"
+
 	"github.com/clownware/alpine-go-performance-starter/internal/view"
 	"github.com/clownware/alpine-go-performance-starter/internal/view/pages"
 	"github.com/clownware/alpine-go-performance-starter/internal/view/partials"
-	"github.com/go-chi/chi/v5"
 )
 
 const itemsPerPage = 5

--- a/internal/handler/profile_handler.go
+++ b/internal/handler/profile_handler.go
@@ -22,9 +22,9 @@ func ProfilePage(w http.ResponseWriter, r *http.Request) {
 
 	// For now, just display the email from the JWT
 	w.WriteHeader(http.StatusOK)
-	fmt.Fprintf(w, "<h1>User Profile</h1><p>Welcome, %s!</p><p>User ID: %s</p>", user.Email, user.ID)
+	_, _ = fmt.Fprintf(w, "<h1>User Profile</h1><p>Welcome, %s!</p><p>User ID: %s</p>", user.Email, user.ID)
 	// Add a logout button
-	fmt.Fprintf(w, `<form hx-post="/auth/logout" hx-target="body"><button type="submit">Logout</button></form>`)
+	_, _ = fmt.Fprint(w, `<form hx-post="/auth/logout" hx-target="body"><button type="submit">Logout</button></form>`)
 
 	log.Printf("[INFO] Displayed profile page for user: %s", user.Email)
 }

--- a/internal/middleware/auth_middleware.go
+++ b/internal/middleware/auth_middleware.go
@@ -5,9 +5,10 @@ import (
 	"log"
 	"net/http"
 
+	"github.com/supabase-community/gotrue-go/types"
+
 	"github.com/clownware/alpine-go-performance-starter/internal/auth"
 	"github.com/clownware/alpine-go-performance-starter/internal/view"
-	"github.com/supabase-community/gotrue-go/types"
 )
 
 // UserContextKey is the key used to store user information in the request context.

--- a/internal/repository/organization.go
+++ b/internal/repository/organization.go
@@ -3,8 +3,9 @@ package repository
 import (
 	"context"
 
-	"github.com/clownware/alpine-go-performance-starter/internal/database"
 	"github.com/google/uuid"
+
+	"github.com/clownware/alpine-go-performance-starter/internal/database"
 )
 
 // OrganizationRepository defines the interface for organization data access operations.

--- a/internal/repository/organization_member.go
+++ b/internal/repository/organization_member.go
@@ -3,8 +3,9 @@ package repository
 import (
 	"context"
 
-	"github.com/clownware/alpine-go-performance-starter/internal/database"
 	"github.com/google/uuid"
+
+	"github.com/clownware/alpine-go-performance-starter/internal/database"
 )
 
 // OrganizationMemberRepository defines the interface for organization member data access operations.

--- a/internal/repository/postgres/organization.go
+++ b/internal/repository/postgres/organization.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"errors"
 
-	"github.com/clownware/alpine-go-performance-starter/internal/database"
-	"github.com/clownware/alpine-go-performance-starter/internal/repository"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/clownware/alpine-go-performance-starter/internal/database"
+	"github.com/clownware/alpine-go-performance-starter/internal/repository"
 )
 
 // OrganizationRepo implements the repository.OrganizationRepository interface using PostgreSQL.

--- a/internal/repository/postgres/organization_member.go
+++ b/internal/repository/postgres/organization_member.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"errors"
 
-	"github.com/clownware/alpine-go-performance-starter/internal/database"
-	"github.com/clownware/alpine-go-performance-starter/internal/repository"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/clownware/alpine-go-performance-starter/internal/database"
+	"github.com/clownware/alpine-go-performance-starter/internal/repository"
 )
 
 // OrganizationMemberRepo implements the repository.OrganizationMemberRepository interface using PostgreSQL.

--- a/internal/repository/postgres/user.go
+++ b/internal/repository/postgres/user.go
@@ -5,12 +5,13 @@ import (
 	"errors"
 	"time"
 
-	"github.com/clownware/alpine-go-performance-starter/internal/database"
-	"github.com/clownware/alpine-go-performance-starter/internal/repository"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/clownware/alpine-go-performance-starter/internal/database"
+	"github.com/clownware/alpine-go-performance-starter/internal/repository"
 )
 
 // UserRepo implements the repository.UserRepository interface using PostgreSQL.

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"time"
 
-	"github.com/clownware/alpine-go-performance-starter/internal/database"
 	"github.com/google/uuid"
+
+	"github.com/clownware/alpine-go-performance-starter/internal/database"
 )
 
 // UserRepository defines the interface for user data access operations.

--- a/internal/repository/user_postgres.go
+++ b/internal/repository/user_postgres.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"time"
 
-	"github.com/clownware/alpine-go-performance-starter/internal/database"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/clownware/alpine-go-performance-starter/internal/database"
 )
 
 type userRepository struct {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -8,6 +8,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
 	"github.com/clownware/alpine-go-performance-starter/internal/auth"
 	"github.com/clownware/alpine-go-performance-starter/internal/config"
 	"github.com/clownware/alpine-go-performance-starter/internal/handler"
@@ -15,9 +19,6 @@ import (
 	"github.com/clownware/alpine-go-performance-starter/internal/repository"
 	"github.com/clownware/alpine-go-performance-starter/internal/view"
 	"github.com/clownware/alpine-go-performance-starter/internal/view/pages"
-	"github.com/go-chi/chi/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 // Server represents the main application server.

--- a/scripts/agentsmd/main.go
+++ b/scripts/agentsmd/main.go
@@ -82,7 +82,7 @@ func generate(root string) ([]byte, error) {
 			return nil, fmt.Errorf("reading source %s: %w", rel, err)
 		}
 		b.WriteString("\n---\n\n")
-		b.WriteString(fmt.Sprintf("<!-- source: %s -->\n\n", rel))
+		fmt.Fprintf(&b, "<!-- source: %s -->\n\n", rel)
 		b.WriteString(demoteHeadings(string(raw)))
 	}
 


### PR DESCRIPTION
## Why
Issue #18: CI didn't actually enforce the quality gate. Root cause found while wiring it: **`.golangci.yml` was v1 format** but CI (`golangci-lint-action@latest`) and the Taskfile both install **v2**, so the linter errored on load and silently did nothing — the same reason 25 files had drifted out of gofmt/goimports compliance.

## What
- **Migrate `.golangci.yml` to v2** (via `golangci-lint migrate`): gofmt/goimports become formatters; obsolete `gosimple`/`typecheck` dropped; `go` bumped to 1.25.
- **Fix the 25 issues** the linter surfaces once it runs:
  - goimports grouping across 15 files (auto-fixed)
  - errcheck (8): log encode failures via `slog` in the JSON handlers (matches the existing `view.Render` pattern); explicit ignore on the liveness probe + stub profile HTML
  - staticcheck (2): lowercase auth error string (ST1005); `fmt.Fprintf` over `WriteString(fmt.Sprintf)` in `scripts/agentsmd` (QF1012)
- **`task fmt`** now uses `golangci-lint fmt` (applies goimports).
- **CI: add a `security` job** running `govulncheck` — its own job so a stdlib advisory (fixed by bumping Go, not code) stays visible and isolated.

## Verification (local)
- `golangci-lint run ./...` → **0 issues**; `golangci-lint fmt --diff` → no diff
- `go test -race ./...` green; stripped binary **15.22 MB** (< 20 MB budget); `agents:check` in sync

## Note
`govulncheck` currently flags **stdlib advisories tied to the Go toolchain patch level** (e.g. an `html/template` XSS fixed in go1.26.2). These are resolved by bumping the CI Go version, not by code changes — the new job will surface them so they can be kept current. Filed as the operational half of #18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)