### PR TITLE
test(repo): Postgres integration tests for quiz + flashcard repos

### DIFF
--- a/internal/database/querier.go
+++ b/internal/database/querier.go
@@ -19,6 +19,7 @@ type Querier interface {
 	CreateOrganization(ctx context.Context, arg CreateOrganizationParams) (Organization, error)
 	CreateOrganizationMember(ctx context.Context, arg CreateOrganizationMemberParams) (OrganizationMember, error)
 	CreateQuizAttempt(ctx context.Context, arg CreateQuizAttemptParams) (QuizAttempt, error)
+	CreateQuizQuestion(ctx context.Context, arg CreateQuizQuestionParams) (QuizQuestion, error)
 	CreateUser(ctx context.Context, arg CreateUserParams) (User, error)
 	DeleteFlashcard(ctx context.Context, arg DeleteFlashcardParams) error
 	DeleteOrganization(ctx context.Context, id uuid.UUID) error

--- a/internal/database/quiz.sql.go
+++ b/internal/database/quiz.sql.go
@@ -59,6 +59,47 @@ func (q *Queries) CreateQuizAttempt(ctx context.Context, arg CreateQuizAttemptPa
 	return i, err
 }
 
+const createQuizQuestion = `-- name: CreateQuizQuestion :one
+INSERT INTO quiz_questions (
+    slug, topic, prompt, choices, correct_index, explanation
+) VALUES (
+    $1, $2, $3, $4, $5, $6
+)
+RETURNING id, slug, topic, prompt, choices, correct_index, explanation, created_at
+`
+
+type CreateQuizQuestionParams struct {
+	Slug         string `json:"slug"`
+	Topic        string `json:"topic"`
+	Prompt       string `json:"prompt"`
+	Choices      []byte `json:"choices"`
+	CorrectIndex int32  `json:"correct_index"`
+	Explanation  string `json:"explanation"`
+}
+
+func (q *Queries) CreateQuizQuestion(ctx context.Context, arg CreateQuizQuestionParams) (QuizQuestion, error) {
+	row := q.db.QueryRow(ctx, createQuizQuestion,
+		arg.Slug,
+		arg.Topic,
+		arg.Prompt,
+		arg.Choices,
+		arg.CorrectIndex,
+		arg.Explanation,
+	)
+	var i QuizQuestion
+	err := row.Scan(
+		&i.ID,
+		&i.Slug,
+		&i.Topic,
+		&i.Prompt,
+		&i.Choices,
+		&i.CorrectIndex,
+		&i.Explanation,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
 const getQuizQuestion = `-- name: GetQuizQuestion :one
 SELECT id, slug, topic, prompt, choices, correct_index, explanation, created_at
 FROM quiz_questions

--- a/internal/repository/postgres/integration_test.go
+++ b/internal/repository/postgres/integration_test.go
@@ -1,0 +1,163 @@
+package postgres
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/clownware/alpine-go-performance-starter/internal/database"
+	"github.com/clownware/alpine-go-performance-starter/internal/repository"
+)
+
+// These tests round-trip the repositories against a real PostgreSQL. They run
+// in CI (where DATABASE_URL is set and migrations are applied) and skip locally
+// when DATABASE_URL is unset.
+//
+// NOTE: they verify query/CRUD behavior, NOT RLS isolation — the test connects
+// as the owner role and the service_role_bypass policy nullifies RLS for it.
+// RLS-scoping tests require the Supabase role model (anon/authenticated/
+// service_role) in the test harness; tracked as a follow-up.
+
+// withTx opens a transaction and rolls it back on cleanup so each test is
+// isolated and leaves no rows behind. The returned Queries run on the tx.
+func withTx(t *testing.T) (context.Context, *database.Queries) {
+	t.Helper()
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL not set; skipping integration test")
+	}
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		pool.Close()
+		t.Fatalf("begin: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = tx.Rollback(ctx)
+		pool.Close()
+	})
+	return ctx, database.New(tx)
+}
+
+func seedUser(ctx context.Context, t *testing.T, q *database.Queries) uuid.UUID {
+	t.Helper()
+	authID := uuid.NewString()
+	user, err := q.CreateUser(ctx, database.CreateUserParams{
+		Email:  authID + "@example.com",
+		AuthID: pgtype.Text{String: authID, Valid: true},
+	})
+	if err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	return user.ID
+}
+
+func seedQuestion(ctx context.Context, t *testing.T, q *database.Queries) database.QuizQuestion {
+	t.Helper()
+	question, err := q.CreateQuizQuestion(ctx, database.CreateQuizQuestionParams{
+		Slug:         "q-" + uuid.NewString(),
+		Topic:        "middleware",
+		Prompt:       "What runs first?",
+		Choices:      []byte(`["handler","middleware"]`),
+		CorrectIndex: 1,
+		Explanation:  "The router",
+	})
+	if err != nil {
+		t.Fatalf("seed question: %v", err)
+	}
+	return question
+}
+
+func TestQuizRepoIntegration(t *testing.T) {
+	ctx, q := withTx(t)
+	repo := NewQuizRepo(nil, q)
+	userID := seedUser(ctx, t, q)
+	question := seedQuestion(ctx, t, q)
+
+	// Record one correct and one incorrect attempt.
+	for _, correct := range []bool{true, false} {
+		if _, err := repo.RecordAttempt(ctx, database.CreateQuizAttemptParams{
+			UserID:        userID,
+			QuestionID:    question.ID,
+			SelectedIndex: 1,
+			IsCorrect:     correct,
+		}); err != nil {
+			t.Fatalf("RecordAttempt(correct=%v): %v", correct, err)
+		}
+	}
+
+	attempts, err := repo.ListAttemptsByUser(ctx, userID, 10, 0)
+	if err != nil {
+		t.Fatalf("ListAttemptsByUser: %v", err)
+	}
+	if len(attempts) != 2 {
+		t.Errorf("ListAttemptsByUser len = %d, want 2", len(attempts))
+	}
+
+	correctCount, err := repo.CountCorrectByUser(ctx, userID)
+	if err != nil {
+		t.Fatalf("CountCorrectByUser: %v", err)
+	}
+	if correctCount != 1 {
+		t.Errorf("CountCorrectByUser = %d, want 1", correctCount)
+	}
+
+	got, err := repo.GetQuestionBySlug(ctx, question.Slug)
+	if err != nil {
+		t.Fatalf("GetQuestionBySlug: %v", err)
+	}
+	if got.ID != question.ID {
+		t.Errorf("GetQuestionBySlug ID = %v, want %v", got.ID, question.ID)
+	}
+}
+
+func TestFlashcardRepoIntegration(t *testing.T) {
+	ctx, q := withTx(t)
+	repo := NewFlashcardRepo(nil, q)
+	userID := seedUser(ctx, t, q)
+	question := seedQuestion(ctx, t, q)
+
+	created, err := repo.Create(ctx, database.CreateFlashcardParams{
+		UserID:     userID,
+		QuestionID: pgtype.UUID{Bytes: question.ID, Valid: true},
+		Front:      "What runs first?",
+		Back:       "The router/middleware stack",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if created.IsKnown {
+		t.Error("new flashcard should default to is_known=false")
+	}
+
+	list, err := repo.ListByUser(ctx, userID)
+	if err != nil {
+		t.Fatalf("ListByUser: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("ListByUser len = %d, want 1", len(list))
+	}
+
+	updated, err := repo.SetKnown(ctx, created.ID, true)
+	if err != nil {
+		t.Fatalf("SetKnown: %v", err)
+	}
+	if !updated.IsKnown {
+		t.Error("SetKnown(true) did not set is_known")
+	}
+
+	if err := repo.Delete(ctx, created.ID, userID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := repo.Get(ctx, created.ID); err != repository.ErrNotFound {
+		t.Errorf("Get after delete err = %v, want ErrNotFound", err)
+	}
+}

--- a/migrations/000004_add_first_run_complete_to_users.down.sql
+++ b/migrations/000004_add_first_run_complete_to_users.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users DROP COLUMN IF EXISTS first_run_complete;

--- a/migrations/000004_add_first_run_complete_to_users.up.sql
+++ b/migrations/000004_add_first_run_complete_to_users.up.sql
@@ -1,0 +1,5 @@
+-- Add first_run_complete to users table.
+-- IF NOT EXISTS keeps this idempotent: in environments where the column was
+-- already added out-of-band (it predates this versioned migration), applying
+-- this is a safe no-op.
+ALTER TABLE users ADD COLUMN IF NOT EXISTS first_run_complete BOOLEAN NOT NULL DEFAULT FALSE;

--- a/migrations/20250501_add_first_run_complete_to_users.sql
+++ b/migrations/20250501_add_first_run_complete_to_users.sql
@@ -1,2 +1,0 @@
--- Add first_run_complete to users table
-ALTER TABLE users ADD COLUMN first_run_complete BOOLEAN NOT NULL DEFAULT FALSE;

--- a/sql/queries/quiz.sql
+++ b/sql/queries/quiz.sql
@@ -8,6 +8,14 @@ SELECT id, slug, topic, prompt, choices, correct_index, explanation, created_at
 FROM quiz_questions
 WHERE id = $1 LIMIT 1;
 
+-- name: CreateQuizQuestion :one
+INSERT INTO quiz_questions (
+    slug, topic, prompt, choices, correct_index, explanation
+) VALUES (
+    $1, $2, $3, $4, $5, $6
+)
+RETURNING id, slug, topic, prompt, choices, correct_index, explanation, created_at;
+
 -- name: GetQuizQuestionBySlug :one
 SELECT id, slug, topic, prompt, choices, correct_index, explanation, created_at
 FROM quiz_questions


### PR DESCRIPTION
Round-trips the new repositories against a real DB (runs in CI via the harness from #24, skips locally). Tx-per-test isolation. Adds a `CreateQuizQuestion` query for seeding. Verifies CRUD, not RLS (superuser bypasses it — RLS harness is a follow-up). Progresses #17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)