### PR TITLE
test(rls): prove flashcard RLS isolation + scope service_role_bypass TO service_role

### DIFF
--- a/internal/repository/postgres/rls_test.go
+++ b/internal/repository/postgres/rls_test.go
@@ -1,0 +1,97 @@
+package postgres
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/clownware/alpine-go-performance-starter/internal/database"
+	"github.com/clownware/alpine-go-performance-starter/internal/repository"
+)
+
+// seedUserWithAuth creates a user and returns both its id and its auth_id, so a
+// test can authenticate as that user via request.jwt.claim.sub.
+func seedUserWithAuth(ctx context.Context, t *testing.T, q *database.Queries) (uuid.UUID, string) {
+	t.Helper()
+	authID := uuid.NewString()
+	user, err := q.CreateUser(ctx, database.CreateUserParams{
+		Email:  authID + "@example.com",
+		AuthID: pgtype.Text{String: authID, Valid: true},
+	})
+	if err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	return user.ID, authID
+}
+
+// TestFlashcardRLSIsolation proves the RLS self-access policy: an authenticated
+// user cannot read another user's flashcards. This is the same mechanism that
+// scopes anonymous guests (a guest is just a user row whose auth_id is the
+// anonymous auth.uid()).
+//
+// Seeding happens as the owner role (RLS bypassed); the actual assertions run
+// after SET ROLE authenticated, so RLS is enforced.
+func TestFlashcardRLSIsolation(t *testing.T) {
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL not set; skipping integration test")
+	}
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer pool.Close()
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	q := database.New(tx)
+	userA, authA := seedUserWithAuth(ctx, t, q)
+	userB, _ := seedUserWithAuth(ctx, t, q)
+
+	cardA, err := q.CreateFlashcard(ctx, database.CreateFlashcardParams{UserID: userA, Front: "a-front", Back: "a-back"})
+	if err != nil {
+		t.Fatalf("create card A: %v", err)
+	}
+	cardB, err := q.CreateFlashcard(ctx, database.CreateFlashcardParams{UserID: userB, Front: "b-front", Back: "b-back"})
+	if err != nil {
+		t.Fatalf("create card B: %v", err)
+	}
+
+	// Become authenticated user A. SET LOCAL is rolled back with the tx.
+	if _, err := tx.Exec(ctx, "SET LOCAL ROLE authenticated"); err != nil {
+		t.Fatalf("set role authenticated: %v", err)
+	}
+	if _, err := tx.Exec(ctx, "SELECT set_config('request.jwt.claim.sub', $1, true)", authA); err != nil {
+		t.Fatalf("set jwt claim: %v", err)
+	}
+
+	repo := NewFlashcardRepo(nil, q)
+
+	// A can read its own card.
+	if _, err := repo.Get(ctx, cardA.ID); err != nil {
+		t.Errorf("user A reading own card: err = %v, want nil", err)
+	}
+
+	// A cannot read B's card — RLS hides it (returns no rows → ErrNotFound).
+	if _, err := repo.Get(ctx, cardB.ID); err != repository.ErrNotFound {
+		t.Errorf("user A reading B's card: err = %v, want ErrNotFound (RLS not enforced?)", err)
+	}
+
+	// Listing B's cards as A yields nothing, even though the query filters by
+	// B's id — RLS denies the rows.
+	list, err := repo.ListByUser(ctx, userB)
+	if err != nil {
+		t.Fatalf("list B's cards as A: %v", err)
+	}
+	if len(list) != 0 {
+		t.Errorf("user A listing B's cards = %d rows, want 0", len(list))
+	}
+}

--- a/migrations/000002_add_basic_rls.up.sql
+++ b/migrations/000002_add_basic_rls.up.sql
@@ -78,18 +78,24 @@ ALTER TABLE users FORCE ROW LEVEL SECURITY;
 ALTER TABLE organizations FORCE ROW LEVEL SECURITY;
 ALTER TABLE organization_members FORCE ROW LEVEL SECURITY;
 
--- Create policy to allow service role to bypass RLS (for backend operations)
+-- Create policy to allow the service role to bypass RLS (for backend operations).
+-- Scoped TO service_role so it does NOT apply to anon/authenticated — otherwise
+-- a permissive USING(true) for ALL roles would OR-override the self-access
+-- policies and nullify RLS.
 CREATE POLICY service_role_bypass ON users
-    FOR ALL 
+    FOR ALL
+    TO service_role
     USING (true)
     WITH CHECK (true);
 
 CREATE POLICY service_role_bypass ON organizations
-    FOR ALL 
+    FOR ALL
+    TO service_role
     USING (true)
     WITH CHECK (true);
 
 CREATE POLICY service_role_bypass ON organization_members
-    FOR ALL 
+    FOR ALL
+    TO service_role
     USING (true)
     WITH CHECK (true);

--- a/migrations/000003_add_quiz_flashcards.up.sql
+++ b/migrations/000003_add_quiz_flashcards.up.sql
@@ -69,6 +69,7 @@ ALTER TABLE quiz_attempts FORCE ROW LEVEL SECURITY;
 ALTER TABLE flashcards FORCE ROW LEVEL SECURITY;
 
 -- Service-role bypass for backend operations and seeding (mirrors 000002).
-CREATE POLICY service_role_bypass ON quiz_questions FOR ALL USING (true) WITH CHECK (true);
-CREATE POLICY service_role_bypass ON quiz_attempts FOR ALL USING (true) WITH CHECK (true);
-CREATE POLICY service_role_bypass ON flashcards FOR ALL USING (true) WITH CHECK (true);
+-- Scoped TO service_role so it doesn't nullify the self-access policies.
+CREATE POLICY service_role_bypass ON quiz_questions FOR ALL TO service_role USING (true) WITH CHECK (true);
+CREATE POLICY service_role_bypass ON quiz_attempts FOR ALL TO service_role USING (true) WITH CHECK (true);
+CREATE POLICY service_role_bypass ON flashcards FOR ALL TO service_role USING (true) WITH CHECK (true);

--- a/sql/test/auth_stub.sql
+++ b/sql/test/auth_stub.sql
@@ -1,17 +1,19 @@
--- Test/CI-only stub of Supabase's auth schema.
+-- Test/CI-only stub of Supabase's auth schema and roles.
 --
--- Supabase provides the `auth` schema and `auth.uid()` (which reads the JWT
--- `sub` claim). Vanilla PostgreSQL — the CI service container and local dev
--- databases — does not, so the RLS migrations (000002, 000003) fail with
--- `schema "auth" does not exist`.
+-- Supabase provides the `auth` schema, `auth.uid()` (which reads the JWT `sub`
+-- claim), and the anon/authenticated/service_role roles. Vanilla PostgreSQL —
+-- the CI service container and local dev databases — does not, so the RLS
+-- migrations fail (`schema "auth" does not exist`) and RLS can't be exercised.
 --
 -- Apply this BEFORE running migrations against a non-Supabase database. Do NOT
 -- turn it into a migration: a migration would override Supabase's real
--- auth.uid() in production and break RLS there.
+-- auth.uid()/roles in production.
 --
--- Tests set the current user with:
---   SET LOCAL request.jwt.claim.sub = '<users.auth_id>';
--- and reset with RESET request.jwt.claim.sub; (or a fresh connection).
+-- RLS tests then do, on a transaction:
+--   SET LOCAL ROLE authenticated;
+--   SELECT set_config('request.jwt.claim.sub', '<users.auth_id>', true);
+-- so auth.uid() resolves to that user and RLS is enforced (authenticated is a
+-- non-superuser without BYPASSRLS).
 
 CREATE SCHEMA IF NOT EXISTS auth;
 
@@ -21,3 +23,28 @@ CREATE SCHEMA IF NOT EXISTS auth;
 CREATE OR REPLACE FUNCTION auth.uid() RETURNS text
     LANGUAGE sql STABLE
     AS $$ SELECT nullif(current_setting('request.jwt.claim.sub', true), '') $$;
+
+-- Supabase roles. service_role bypasses RLS (matches Supabase); anon and
+-- authenticated are subject to it.
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'anon') THEN
+        CREATE ROLE anon NOLOGIN;
+    END IF;
+    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'authenticated') THEN
+        CREATE ROLE authenticated NOLOGIN;
+    END IF;
+    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'service_role') THEN
+        CREATE ROLE service_role NOLOGIN BYPASSRLS;
+    END IF;
+END $$;
+
+GRANT USAGE ON SCHEMA public, auth TO anon, authenticated, service_role;
+
+-- Tables/sequences are created later by the migration runner (this connection's
+-- user). Default privileges auto-grant them to the Supabase roles; RLS policies
+-- then do the actual restriction.
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO anon, authenticated, service_role;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+    GRANT USAGE, SELECT ON SEQUENCES TO anon, authenticated, service_role;


### PR DESCRIPTION
Models Supabase's roles in the test harness (anon/authenticated/service_role + grants) and scopes the `service_role_bypass` policies `TO service_role` (they previously nullified RLS for all roles). Adds an RLS isolation test: authenticated user A can read its own flashcard but gets ErrNotFound/empty for user B's — the same mechanism that scopes anonymous guests. Closes the RLS half of #17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)