### PR TITLE
feat(auth): anonymous guest-mode backend — GoTrue sign-in, claims plumbing, TTL reaper

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,12 @@ DATABASE_URL=postgres://postgres:postgres@localhost:5432/alpine_saas?sslmode=dis
 # When unset, /metrics is open in development and hidden (404) in production.
 # METRICS_TOKEN=
 
+# Guest mode (ADR-024): anonymous Supabase identities for visitors.
+# Requires "anonymous sign-ins" enabled in the Supabase project settings.
+# GUEST_MODE_ENABLED=false
+# GUEST_TTL=720h          # unupgraded guest accounts are reaped after this age
+# REAPER_INTERVAL=1h      # how often the reaper pass runs
+
 # Supabase Credentials
 SUPABASE_URL="YOUR_SUPABASE_URL"
 SUPABASE_ANON_KEY="YOUR_SUPABASE_ANON_KEY"

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -15,7 +15,9 @@ import (
 
 	"github.com/clownware/alpine-go-performance-starter/internal/config"
 	_ "github.com/clownware/alpine-go-performance-starter/internal/database" // Keep for sqlc generated types, alias not needed directly here
+	"github.com/clownware/alpine-go-performance-starter/internal/jobs"
 	"github.com/clownware/alpine-go-performance-starter/internal/middleware"
+	"github.com/clownware/alpine-go-performance-starter/internal/repository/postgres"
 	"github.com/clownware/alpine-go-performance-starter/internal/server"
 )
 
@@ -105,6 +107,18 @@ func main() {
 	// Start memory metrics collector (updates every 30 seconds)
 	middleware.StartMemoryMetricsCollector(30 * time.Second)
 	slog.Info("Memory metrics collector started")
+
+	// Guest mode: reap expired anonymous accounts (ADR-024). Auth-side
+	// cleanup runs only when the service role key is configured.
+	if cfg.GuestModeEnabled {
+		var deleteAuthUser jobs.AuthUserDeleter
+		if ac := srv.AuthClient(); ac != nil && ac.HasServiceRoleKey() {
+			deleteAuthUser = ac.AdminDeleteUser
+		}
+		reaper := jobs.NewReaper(postgres.NewReaperRepo(db), deleteAuthUser, cfg.GuestTTL, cfg.ReaperInterval)
+		reaper.Start(ctx)
+		slog.Info("Anonymous-user reaper started", "ttl", cfg.GuestTTL, "interval", cfg.ReaperInterval)
+	}
 
 	// Set up the HTTP server
 	addr := fmt.Sprintf(":%s", cfg.HTTPPort)

--- a/internal/auth/anon.go
+++ b/internal/auth/anon.go
@@ -1,0 +1,137 @@
+package auth
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// AnonSession is the GoTrue session returned by an anonymous sign-in.
+type AnonSession struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresIn    int    `json:"expires_in"`
+	User         struct {
+		ID          string `json:"id"`
+		IsAnonymous bool   `json:"is_anonymous"`
+	} `json:"user"`
+}
+
+// anonHTTPClient bounds the server-side GoTrue call so a slow auth service
+// cannot hold guest page loads indefinitely.
+var anonHTTPClient = &http.Client{Timeout: 10 * time.Second}
+
+// SignInAnonymously creates a real but anonymous Supabase identity via the
+// GoTrue REST endpoint — a credential-less POST /auth/v1/signup, the same
+// call supabase-js signInAnonymously() makes (ADR-024; gotrue-go v1.2.1 has
+// no anonymous method). Requires "anonymous sign-ins" enabled in Supabase.
+func (a *AuthClient) SignInAnonymously(ctx context.Context) (*AnonSession, error) {
+	if a.baseURL == "" || a.anonKey == "" {
+		return nil, fmt.Errorf("anonymous sign-in: auth client not configured")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		strings.TrimRight(a.baseURL, "/")+"/auth/v1/signup", bytes.NewReader([]byte(`{}`)))
+	if err != nil {
+		return nil, fmt.Errorf("anonymous sign-in: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("apikey", a.anonKey)
+	req.Header.Set("Authorization", "Bearer "+a.anonKey)
+
+	resp, err := anonHTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("anonymous sign-in: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("anonymous sign-in: read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("anonymous sign-in: gotrue returned %d: %s", resp.StatusCode, truncate(string(body), 200))
+	}
+
+	var session AnonSession
+	if err := json.Unmarshal(body, &session); err != nil {
+		return nil, fmt.Errorf("anonymous sign-in: decode response: %w", err)
+	}
+	if session.AccessToken == "" {
+		return nil, fmt.Errorf("anonymous sign-in: response contained no access token")
+	}
+	return &session, nil
+}
+
+// WithServiceRoleKey attaches the service-role key, enabling admin REST
+// calls (GoTrue-side deletion of reaped guests). Chainable.
+func (a *AuthClient) WithServiceRoleKey(key string) *AuthClient {
+	a.serviceRoleKey = key
+	return a
+}
+
+// HasServiceRoleKey reports whether admin operations are available.
+func (a *AuthClient) HasServiceRoleKey() bool {
+	return a.serviceRoleKey != ""
+}
+
+// AdminDeleteUser deletes a GoTrue auth user by id via the admin REST API.
+// Used by the anonymous-user reaper (ADR-024); requires the service role key.
+func (a *AuthClient) AdminDeleteUser(ctx context.Context, userID string) error {
+	if a.serviceRoleKey == "" {
+		return fmt.Errorf("admin delete user: service role key not configured")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete,
+		strings.TrimRight(a.baseURL, "/")+"/auth/v1/admin/users/"+userID, nil)
+	if err != nil {
+		return fmt.Errorf("admin delete user: build request: %w", err)
+	}
+	req.Header.Set("apikey", a.serviceRoleKey)
+	req.Header.Set("Authorization", "Bearer "+a.serviceRoleKey)
+
+	resp, err := anonHTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("admin delete user: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusNotFound {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+		return fmt.Errorf("admin delete user: gotrue returned %d: %s", resp.StatusCode, truncate(string(body), 200))
+	}
+	return nil
+}
+
+// TokenClaims extracts the sub and is_anonymous claims from a JWT payload
+// WITHOUT verifying the signature — callers must only use it on tokens
+// already validated (AuthMiddleware validates via GoTrue GetUser first).
+func TokenClaims(accessToken string) (sub string, isAnonymous bool, err error) {
+	parts := strings.Split(accessToken, ".")
+	if len(parts) != 3 {
+		return "", false, fmt.Errorf("token claims: not a JWT")
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "", false, fmt.Errorf("token claims: decode payload: %w", err)
+	}
+	var claims struct {
+		Sub         string `json:"sub"`
+		IsAnonymous bool   `json:"is_anonymous"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return "", false, fmt.Errorf("token claims: parse payload: %w", err)
+	}
+	return claims.Sub, claims.IsAnonymous, nil
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}

--- a/internal/auth/anon_test.go
+++ b/internal/auth/anon_test.go
@@ -1,0 +1,146 @@
+package auth
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSignInAnonymously(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     int
+		body       string
+		wantErr    bool
+		wantSub    string
+		checkAnon  bool
+		wantIsAnon bool
+	}{
+		{
+			name:   "successful anonymous session",
+			status: http.StatusOK,
+			body: `{"access_token":"tok-abc","refresh_token":"ref-abc","expires_in":3600,
+				"user":{"id":"user-123","is_anonymous":true}}`,
+			wantSub:    "user-123",
+			checkAnon:  true,
+			wantIsAnon: true,
+		},
+		{
+			name:    "gotrue error (anonymous sign-ins disabled)",
+			status:  http.StatusUnprocessableEntity,
+			body:    `{"msg":"Anonymous sign-ins are disabled"}`,
+			wantErr: true,
+		},
+		{
+			name:    "missing access token",
+			status:  http.StatusOK,
+			body:    `{"user":{"id":"user-123"}}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotPath, gotAPIKey string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+				gotAPIKey = r.Header.Get("apikey")
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer srv.Close()
+
+			client := &AuthClient{baseURL: srv.URL, anonKey: "anon-key"}
+			session, err := client.SignInAnonymously(context.Background())
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("SignInAnonymously() = nil error, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("SignInAnonymously() error: %v", err)
+			}
+			if gotPath != "/auth/v1/signup" {
+				t.Errorf("request path = %q, want /auth/v1/signup", gotPath)
+			}
+			if gotAPIKey != "anon-key" {
+				t.Errorf("apikey header = %q, want anon-key", gotAPIKey)
+			}
+			if session.User.ID != tt.wantSub {
+				t.Errorf("user id = %q, want %q", session.User.ID, tt.wantSub)
+			}
+			if tt.checkAnon && session.User.IsAnonymous != tt.wantIsAnon {
+				t.Errorf("is_anonymous = %v, want %v", session.User.IsAnonymous, tt.wantIsAnon)
+			}
+		})
+	}
+}
+
+func TestSignInAnonymously_Unconfigured(t *testing.T) {
+	client := &AuthClient{}
+	if _, err := client.SignInAnonymously(context.Background()); err == nil {
+		t.Error("unconfigured client should error, not panic or call out")
+	}
+}
+
+// makeJWT builds an unsigned JWT with the given payload for claim parsing tests.
+func makeJWT(t *testing.T, payload map[string]any) string {
+	t.Helper()
+	b, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	head := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"HS256"}`))
+	return head + "." + base64.RawURLEncoding.EncodeToString(b) + ".sig"
+}
+
+func TestTokenClaims(t *testing.T) {
+	tests := []struct {
+		name     string
+		token    string
+		wantSub  string
+		wantAnon bool
+		wantErr  bool
+	}{
+		{
+			name:     "anonymous token",
+			token:    "", // filled below
+			wantSub:  "abc-123",
+			wantAnon: true,
+		},
+		{
+			name:    "not a jwt",
+			token:   "just-an-opaque-string",
+			wantErr: true,
+		},
+		{
+			name:    "garbage payload",
+			token:   "a.!!!.c",
+			wantErr: true,
+		},
+	}
+	tests[0].token = makeJWT(t, map[string]any{"sub": "abc-123", "is_anonymous": true})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sub, isAnon, err := TokenClaims(tt.token)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("TokenClaims() = nil error, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("TokenClaims() error: %v", err)
+			}
+			if sub != tt.wantSub || isAnon != tt.wantAnon {
+				t.Errorf("TokenClaims() = (%q, %v), want (%q, %v)", sub, isAnon, tt.wantSub, tt.wantAnon)
+			}
+		})
+	}
+}

--- a/internal/auth/client.go
+++ b/internal/auth/client.go
@@ -9,6 +9,13 @@ import (
 // AuthClient wraps the Supabase client.
 type AuthClient struct {
 	Client *supabase.Client // Store the Supabase client directly
+
+	// baseURL/anonKey are kept for direct GoTrue REST calls the client
+	// library doesn't cover (anonymous sign-in, ADR-024). serviceRoleKey
+	// is optional and enables admin calls (reaper auth-side cleanup).
+	baseURL        string
+	anonKey        string
+	serviceRoleKey string
 }
 
 // NewAuthClient creates and initializes a new Supabase client.
@@ -24,5 +31,5 @@ func NewAuthClient(supabaseURL, supabaseAnonKey string) (*AuthClient, error) {
 		return nil, err
 	}
 
-	return &AuthClient{Client: sbClient}, nil
+	return &AuthClient{Client: sbClient, baseURL: supabaseURL, anonKey: supabaseAnonKey}, nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,6 +29,15 @@ type Config struct {
 	DBMinConns        int32         `envconfig:"DB_MIN_CONNS" default:"2"`
 	DBMaxConnLifetime time.Duration `envconfig:"DB_MAX_CONN_LIFETIME" default:"30m"`
 	DBMaxConnIdleTime time.Duration `envconfig:"DB_MAX_CONN_IDLE_TIME" default:"5m"`
+
+	// Guest mode (ADR-024): anonymous Supabase identities for visitors.
+	// Requires "anonymous sign-ins" enabled in the Supabase project.
+	GuestModeEnabled bool `envconfig:"GUEST_MODE_ENABLED" default:"false"`
+	// GuestTTL is how long an unupgraded anonymous account lives before the
+	// reaper removes it (measured from creation).
+	GuestTTL time.Duration `envconfig:"GUEST_TTL" default:"720h"`
+	// ReaperInterval is how often the reaper pass runs.
+	ReaperInterval time.Duration `envconfig:"REAPER_INTERVAL" default:"1h"`
 }
 
 // Load loads configuration from environment variables.
@@ -71,6 +80,17 @@ func (c *Config) Validate() error {
 	}
 	if c.DBMinConns < 0 || c.DBMinConns > c.DBMaxConns {
 		return fmt.Errorf("DB_MIN_CONNS %d invalid: must be between 0 and DB_MAX_CONNS (%d)", c.DBMinConns, c.DBMaxConns)
+	}
+	if c.GuestModeEnabled {
+		if c.SupabaseURL == "" {
+			return fmt.Errorf("GUEST_MODE_ENABLED requires SUPABASE_URL and SUPABASE_ANON_KEY (guests are real Supabase identities)")
+		}
+		if c.GuestTTL <= 0 {
+			return fmt.Errorf("GUEST_TTL %v invalid: must be positive", c.GuestTTL)
+		}
+		if c.ReaperInterval <= 0 {
+			return fmt.Errorf("REAPER_INTERVAL %v invalid: must be positive", c.ReaperInterval)
+		}
 	}
 	return nil
 }

--- a/internal/config/config_validate_test.go
+++ b/internal/config/config_validate_test.go
@@ -38,6 +38,24 @@ func TestValidate(t *testing.T) {
 		}, ""},
 		{"zero max conns", func(c *Config) { c.DBMaxConns = 0 }, "DB_MAX_CONNS"},
 		{"min conns above max", func(c *Config) { c.DBMinConns = 50 }, "DB_MIN_CONNS"},
+		{"guest mode without supabase", func(c *Config) {
+			c.GuestModeEnabled = true
+			c.GuestTTL = time.Hour
+			c.ReaperInterval = time.Hour
+		}, "GUEST_MODE_ENABLED"},
+		{"guest mode with zero ttl", func(c *Config) {
+			c.GuestModeEnabled = true
+			c.SupabaseURL = "https://x.supabase.co"
+			c.SupabaseAnonKey = "anon"
+			c.ReaperInterval = time.Hour
+		}, "GUEST_TTL"},
+		{"guest mode fully configured is valid", func(c *Config) {
+			c.GuestModeEnabled = true
+			c.SupabaseURL = "https://x.supabase.co"
+			c.SupabaseAnonKey = "anon"
+			c.GuestTTL = 720 * time.Hour
+			c.ReaperInterval = time.Hour
+		}, ""},
 	}
 
 	for _, tt := range tests {

--- a/internal/database/models.go
+++ b/internal/database/models.go
@@ -74,4 +74,5 @@ type User struct {
 	CreatedAt        time.Time          `json:"created_at"`
 	UpdatedAt        time.Time          `json:"updated_at"`
 	FirstRunComplete bool               `json:"first_run_complete"`
+	IsAnonymous      bool               `json:"is_anonymous"`
 }

--- a/internal/database/querier.go
+++ b/internal/database/querier.go
@@ -6,6 +6,7 @@ package database
 
 import (
 	"context"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -21,6 +22,10 @@ type Querier interface {
 	CreateQuizAttempt(ctx context.Context, arg CreateQuizAttemptParams) (QuizAttempt, error)
 	CreateQuizQuestion(ctx context.Context, arg CreateQuizQuestionParams) (QuizQuestion, error)
 	CreateUser(ctx context.Context, arg CreateUserParams) (User, error)
+	// Reaps anonymous guest accounts older than the TTL (ADR-024). Upgraded
+	// accounts have is_anonymous=false and are exempt. Flashcards and quiz
+	// attempts cascade via their user_id foreign keys.
+	DeleteExpiredAnonymousUsers(ctx context.Context, createdAt time.Time) ([]DeleteExpiredAnonymousUsersRow, error)
 	DeleteFlashcard(ctx context.Context, arg DeleteFlashcardParams) error
 	DeleteOrganization(ctx context.Context, id uuid.UUID) error
 	DeleteOrganizationMember(ctx context.Context, arg DeleteOrganizationMemberParams) error

--- a/internal/database/users.sql.go
+++ b/internal/database/users.sql.go
@@ -7,6 +7,7 @@ package database
 
 import (
 	"context"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -18,11 +19,12 @@ INSERT INTO users (
     name,
     avatar_url,
     auth_id,
-    first_run_complete
+    first_run_complete,
+    is_anonymous
 ) VALUES (
-    $1, $2, $3, $4, $5
+    $1, $2, $3, $4, $5, $6
 )
-RETURNING id, email, name, avatar_url, auth_id, is_active, last_login_at, created_at, updated_at, first_run_complete
+RETURNING id, email, name, avatar_url, auth_id, is_active, last_login_at, created_at, updated_at, first_run_complete, is_anonymous
 `
 
 type CreateUserParams struct {
@@ -31,6 +33,7 @@ type CreateUserParams struct {
 	AvatarUrl        pgtype.Text `json:"avatar_url"`
 	AuthID           pgtype.Text `json:"auth_id"`
 	FirstRunComplete bool        `json:"first_run_complete"`
+	IsAnonymous      bool        `json:"is_anonymous"`
 }
 
 func (q *Queries) CreateUser(ctx context.Context, arg CreateUserParams) (User, error) {
@@ -40,6 +43,7 @@ func (q *Queries) CreateUser(ctx context.Context, arg CreateUserParams) (User, e
 		arg.AvatarUrl,
 		arg.AuthID,
 		arg.FirstRunComplete,
+		arg.IsAnonymous,
 	)
 	var i User
 	err := row.Scan(
@@ -53,8 +57,43 @@ func (q *Queries) CreateUser(ctx context.Context, arg CreateUserParams) (User, e
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.FirstRunComplete,
+		&i.IsAnonymous,
 	)
 	return i, err
+}
+
+const deleteExpiredAnonymousUsers = `-- name: DeleteExpiredAnonymousUsers :many
+DELETE FROM users
+WHERE is_anonymous AND created_at < $1
+RETURNING id, auth_id
+`
+
+type DeleteExpiredAnonymousUsersRow struct {
+	ID     uuid.UUID   `json:"id"`
+	AuthID pgtype.Text `json:"auth_id"`
+}
+
+// Reaps anonymous guest accounts older than the TTL (ADR-024). Upgraded
+// accounts have is_anonymous=false and are exempt. Flashcards and quiz
+// attempts cascade via their user_id foreign keys.
+func (q *Queries) DeleteExpiredAnonymousUsers(ctx context.Context, createdAt time.Time) ([]DeleteExpiredAnonymousUsersRow, error) {
+	rows, err := q.db.Query(ctx, deleteExpiredAnonymousUsers, createdAt)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []DeleteExpiredAnonymousUsersRow{}
+	for rows.Next() {
+		var i DeleteExpiredAnonymousUsersRow
+		if err := rows.Scan(&i.ID, &i.AuthID); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const deleteUser = `-- name: DeleteUser :exec
@@ -69,7 +108,7 @@ func (q *Queries) DeleteUser(ctx context.Context, id uuid.UUID) error {
 }
 
 const getUser = `-- name: GetUser :one
-SELECT id, email, name, avatar_url, auth_id, is_active, last_login_at, created_at, updated_at, first_run_complete
+SELECT id, email, name, avatar_url, auth_id, is_active, last_login_at, created_at, updated_at, first_run_complete, is_anonymous
 FROM users
 WHERE id = $1 LIMIT 1
 `
@@ -88,12 +127,13 @@ func (q *Queries) GetUser(ctx context.Context, id uuid.UUID) (User, error) {
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.FirstRunComplete,
+		&i.IsAnonymous,
 	)
 	return i, err
 }
 
 const getUserByAuthID = `-- name: GetUserByAuthID :one
-SELECT id, email, name, avatar_url, auth_id, is_active, last_login_at, created_at, updated_at, first_run_complete
+SELECT id, email, name, avatar_url, auth_id, is_active, last_login_at, created_at, updated_at, first_run_complete, is_anonymous
 FROM users
 WHERE auth_id = $1 LIMIT 1
 `
@@ -112,12 +152,13 @@ func (q *Queries) GetUserByAuthID(ctx context.Context, authID pgtype.Text) (User
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.FirstRunComplete,
+		&i.IsAnonymous,
 	)
 	return i, err
 }
 
 const getUserByEmail = `-- name: GetUserByEmail :one
-SELECT id, email, name, avatar_url, auth_id, is_active, last_login_at, created_at, updated_at, first_run_complete
+SELECT id, email, name, avatar_url, auth_id, is_active, last_login_at, created_at, updated_at, first_run_complete, is_anonymous
 FROM users
 WHERE email = $1 LIMIT 1
 `
@@ -136,12 +177,13 @@ func (q *Queries) GetUserByEmail(ctx context.Context, email string) (User, error
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.FirstRunComplete,
+		&i.IsAnonymous,
 	)
 	return i, err
 }
 
 const listUsers = `-- name: ListUsers :many
-SELECT id, email, name, avatar_url, auth_id, is_active, last_login_at, created_at, updated_at, first_run_complete
+SELECT id, email, name, avatar_url, auth_id, is_active, last_login_at, created_at, updated_at, first_run_complete, is_anonymous
 FROM users
 ORDER BY created_at DESC
 LIMIT $1 OFFSET $2
@@ -172,6 +214,7 @@ func (q *Queries) ListUsers(ctx context.Context, arg ListUsersParams) ([]User, e
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.FirstRunComplete,
+			&i.IsAnonymous,
 		); err != nil {
 			return nil, err
 		}
@@ -211,7 +254,7 @@ func (q *Queries) SetUserFirstRunComplete(ctx context.Context, arg SetUserFirstR
 
 const updateUser = `-- name: UpdateUser :one
 UPDATE users
-SET 
+SET
     email = COALESCE($2, email),
     name = COALESCE($3, name),
     avatar_url = COALESCE($4, avatar_url),
@@ -220,7 +263,7 @@ SET
     last_login_at = COALESCE($7, last_login_at),
     updated_at = NOW()
 WHERE id = $1
-RETURNING id, email, name, avatar_url, auth_id, is_active, last_login_at, created_at, updated_at, first_run_complete
+RETURNING id, email, name, avatar_url, auth_id, is_active, last_login_at, created_at, updated_at, first_run_complete, is_anonymous
 `
 
 type UpdateUserParams struct {
@@ -255,6 +298,7 @@ func (q *Queries) UpdateUser(ctx context.Context, arg UpdateUserParams) (User, e
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.FirstRunComplete,
+		&i.IsAnonymous,
 	)
 	return i, err
 }

--- a/internal/jobs/reaper.go
+++ b/internal/jobs/reaper.go
@@ -1,0 +1,88 @@
+// Package jobs holds background workers. Per the minimal-dependency ethos
+// (ADR-000) these are plain goroutines with tickers, not a job framework —
+// the starter's background needs are periodic maintenance, not queues.
+package jobs
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/clownware/alpine-go-performance-starter/internal/database"
+)
+
+// ReaperStore deletes expired anonymous users (implemented by
+// postgres.ReaperRepo with a service_role-scoped transaction).
+type ReaperStore interface {
+	DeleteExpiredAnonymousUsers(ctx context.Context, olderThan time.Time) ([]database.DeleteExpiredAnonymousUsersRow, error)
+}
+
+// AuthUserDeleter removes the corresponding GoTrue auth user; nil disables
+// auth-side cleanup (e.g. no service role key configured).
+type AuthUserDeleter func(ctx context.Context, authID string) error
+
+// Reaper periodically deletes anonymous guest accounts older than the TTL
+// (ADR-024). Guests who upgrade become non-anonymous and are exempt; age is
+// measured from account creation, so an unupgraded guest is reaped after TTL
+// regardless of activity — the demo makes no retention promise to guests.
+type Reaper struct {
+	store          ReaperStore
+	deleteAuthUser AuthUserDeleter
+	ttl            time.Duration
+	interval       time.Duration
+}
+
+// NewReaper builds a Reaper. deleteAuthUser may be nil.
+func NewReaper(store ReaperStore, deleteAuthUser AuthUserDeleter, ttl, interval time.Duration) *Reaper {
+	return &Reaper{store: store, deleteAuthUser: deleteAuthUser, ttl: ttl, interval: interval}
+}
+
+// Start runs the reap loop until ctx is cancelled. An immediate first pass
+// runs on start so restarts don't postpone overdue cleanup by a full interval.
+func (r *Reaper) Start(ctx context.Context) {
+	go func() {
+		if _, err := r.RunOnce(ctx); err != nil {
+			slog.Error("Anonymous-user reaper pass failed", "error", err)
+		}
+		ticker := time.NewTicker(r.interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if _, err := r.RunOnce(ctx); err != nil {
+					slog.Error("Anonymous-user reaper pass failed", "error", err)
+				}
+			}
+		}
+	}()
+}
+
+// RunOnce performs a single reap pass and returns how many users were removed.
+func (r *Reaper) RunOnce(ctx context.Context) (int, error) {
+	cutoff := time.Now().Add(-r.ttl)
+	reaped, err := r.store.DeleteExpiredAnonymousUsers(ctx, cutoff)
+	if err != nil {
+		return 0, err
+	}
+	if len(reaped) == 0 {
+		return 0, nil
+	}
+
+	if r.deleteAuthUser != nil {
+		for _, row := range reaped {
+			if !row.AuthID.Valid || row.AuthID.String == "" {
+				continue
+			}
+			// Best-effort: app rows are already gone; a failed GoTrue
+			// deletion just leaves an orphaned (empty) auth user.
+			if err := r.deleteAuthUser(ctx, row.AuthID.String); err != nil {
+				slog.Warn("Failed to delete GoTrue auth user for reaped guest", "auth_id", row.AuthID.String, "error", err)
+			}
+		}
+	}
+
+	slog.Info("Reaped expired anonymous users", "count", len(reaped), "cutoff", cutoff)
+	return len(reaped), nil
+}

--- a/internal/jobs/reaper_test.go
+++ b/internal/jobs/reaper_test.go
@@ -1,0 +1,124 @@
+package jobs
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/clownware/alpine-go-performance-starter/internal/database"
+)
+
+type fakeReaperStore struct {
+	rows      []database.DeleteExpiredAnonymousUsersRow
+	err       error
+	gotCutoff time.Time
+}
+
+func (f *fakeReaperStore) DeleteExpiredAnonymousUsers(ctx context.Context, olderThan time.Time) ([]database.DeleteExpiredAnonymousUsersRow, error) {
+	f.gotCutoff = olderThan
+	return f.rows, f.err
+}
+
+func reapedRow(authID string) database.DeleteExpiredAnonymousUsersRow {
+	return database.DeleteExpiredAnonymousUsersRow{
+		ID:     uuid.New(),
+		AuthID: pgtype.Text{String: authID, Valid: authID != ""},
+	}
+}
+
+func TestReaperRunOnce(t *testing.T) {
+	tests := []struct {
+		name          string
+		store         *fakeReaperStore
+		withDeleter   bool
+		deleterErr    error
+		wantCount     int
+		wantErr       bool
+		wantAuthCalls []string
+	}{
+		{
+			name:      "nothing expired",
+			store:     &fakeReaperStore{},
+			wantCount: 0,
+		},
+		{
+			name: "reaps and cleans auth users",
+			store: &fakeReaperStore{rows: []database.DeleteExpiredAnonymousUsersRow{
+				reapedRow("auth-1"), reapedRow("auth-2"), reapedRow(""),
+			}},
+			withDeleter:   true,
+			wantCount:     3,
+			wantAuthCalls: []string{"auth-1", "auth-2"}, // empty auth_id skipped
+		},
+		{
+			name: "auth deletion failure is best-effort, not fatal",
+			store: &fakeReaperStore{rows: []database.DeleteExpiredAnonymousUsersRow{
+				reapedRow("auth-1"),
+			}},
+			withDeleter:   true,
+			deleterErr:    errors.New("gotrue down"),
+			wantCount:     1,
+			wantAuthCalls: []string{"auth-1"},
+		},
+		{
+			name: "no deleter configured still reaps app rows",
+			store: &fakeReaperStore{rows: []database.DeleteExpiredAnonymousUsersRow{
+				reapedRow("auth-1"),
+			}},
+			wantCount: 1,
+		},
+		{
+			name:    "store failure propagates",
+			store:   &fakeReaperStore{err: errors.New("db down")},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var authCalls []string
+			var deleter AuthUserDeleter
+			if tt.withDeleter {
+				deleter = func(ctx context.Context, authID string) error {
+					authCalls = append(authCalls, authID)
+					return tt.deleterErr
+				}
+			}
+
+			ttl := 30 * 24 * time.Hour
+			r := NewReaper(tt.store, deleter, ttl, time.Hour)
+			count, err := r.RunOnce(context.Background())
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("RunOnce() = nil error, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("RunOnce() error: %v", err)
+			}
+			if count != tt.wantCount {
+				t.Errorf("count = %d, want %d", count, tt.wantCount)
+			}
+			if len(authCalls) != len(tt.wantAuthCalls) {
+				t.Fatalf("auth deletions = %v, want %v", authCalls, tt.wantAuthCalls)
+			}
+			for i, want := range tt.wantAuthCalls {
+				if authCalls[i] != want {
+					t.Errorf("auth deletion %d = %q, want %q", i, authCalls[i], want)
+				}
+			}
+
+			// Cutoff must be ~now-ttl.
+			wantCutoff := time.Now().Add(-ttl)
+			if diff := tt.store.gotCutoff.Sub(wantCutoff); diff < -time.Minute || diff > time.Minute {
+				t.Errorf("cutoff = %v, want ~%v", tt.store.gotCutoff, wantCutoff)
+			}
+		})
+	}
+}

--- a/internal/middleware/auth_middleware.go
+++ b/internal/middleware/auth_middleware.go
@@ -73,9 +73,16 @@ func AuthMiddleware(authClient *auth.AuthClient) func(next http.Handler) http.Ha
 			// 4. Attach the validated identity as claims so the repository
 			// layer applies it to database connections and RLS evaluates
 			// against this user (ADR-004; see repository/postgres/scope.go).
+			// is_anonymous comes from the token payload — safe to decode
+			// unverified here because GetUser above validated the token.
+			_, isAnonymous, err := auth.TokenClaims(accessToken)
+			if err != nil {
+				slog.Warn("Failed to parse token claims; treating session as non-anonymous", "error", err)
+			}
 			ctx = webutil.WithAuthClaims(ctx, webutil.AuthClaims{
-				Sub:  user.ID.String(),
-				Role: webutil.RoleAuthenticated,
+				Sub:         user.ID.String(),
+				Role:        webutil.RoleAuthenticated,
+				IsAnonymous: isAnonymous,
 			})
 
 			// 5. Call next handler

--- a/internal/middleware/guest_session.go
+++ b/internal/middleware/guest_session.go
@@ -1,0 +1,70 @@
+package middleware
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/clownware/alpine-go-performance-starter/internal/auth"
+)
+
+// anonSigner is the slice of AuthClient GuestSession needs; an interface so
+// tests can fake the GoTrue call.
+type anonSigner interface {
+	SignInAnonymously(ctx context.Context) (*auth.AnonSession, error)
+}
+
+// GuestSession issues an anonymous Supabase identity to cookie-less visitors
+// (ADR-024 guest mode): the server performs the GoTrue anonymous sign-in and
+// sets the same httpOnly session cookies the login flow uses, so downstream
+// AuthMiddleware and RLS treat guests exactly like registered users.
+//
+// Failure is non-fatal by design — the page still renders unauthenticated
+// and a warning is logged (a GoTrue outage must not take down public pages).
+func GuestSession(signer anonSigner, secureCookie bool) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if c, err := r.Cookie("sb-access-token"); err == nil && c.Value != "" {
+				next.ServeHTTP(w, r) // already has a session (guest or registered)
+				return
+			}
+
+			session, err := signer.SignInAnonymously(r.Context())
+			if err != nil {
+				slog.Warn("Guest sign-in failed; continuing unauthenticated", "error", err)
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			access := &http.Cookie{
+				Name:     "sb-access-token",
+				Value:    session.AccessToken,
+				Path:     "/",
+				MaxAge:   session.ExpiresIn,
+				HttpOnly: true,
+				Secure:   secureCookie,
+				SameSite: http.SameSiteLaxMode,
+			}
+			refresh := &http.Cookie{
+				Name:     "sb-refresh-token",
+				Value:    session.RefreshToken,
+				Path:     "/",
+				MaxAge:   int((30 * 24 * time.Hour).Seconds()),
+				HttpOnly: true,
+				Secure:   secureCookie,
+				SameSite: http.SameSiteLaxMode,
+			}
+			http.SetCookie(w, access)
+			http.SetCookie(w, refresh)
+
+			// Make the new session visible to downstream middleware in THIS
+			// request (AuthMiddleware reads the request cookie jar).
+			r.AddCookie(access)
+			r.AddCookie(refresh)
+
+			slog.Info("Issued anonymous guest session", "sub", session.User.ID)
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/internal/middleware/guest_session_test.go
+++ b/internal/middleware/guest_session_test.go
@@ -1,0 +1,103 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/clownware/alpine-go-performance-starter/internal/auth"
+)
+
+type fakeSigner struct {
+	session *auth.AnonSession
+	err     error
+	calls   int
+}
+
+func (f *fakeSigner) SignInAnonymously(ctx context.Context) (*auth.AnonSession, error) {
+	f.calls++
+	return f.session, f.err
+}
+
+func anonSession() *auth.AnonSession {
+	s := &auth.AnonSession{AccessToken: "guest-tok", RefreshToken: "guest-ref", ExpiresIn: 3600}
+	s.User.ID = "guest-123"
+	s.User.IsAnonymous = true
+	return s
+}
+
+func TestGuestSession(t *testing.T) {
+	tests := []struct {
+		name           string
+		existingCookie string
+		signer         *fakeSigner
+		wantCalls      int
+		wantCookie     bool
+		wantDownstream string // access token visible to downstream handler
+	}{
+		{
+			name:           "cookie-less visitor gets a guest session",
+			signer:         &fakeSigner{session: anonSession()},
+			wantCalls:      1,
+			wantCookie:     true,
+			wantDownstream: "guest-tok",
+		},
+		{
+			name:           "existing session untouched",
+			existingCookie: "already-signed-in",
+			signer:         &fakeSigner{session: anonSession()},
+			wantCalls:      0,
+			wantDownstream: "already-signed-in",
+		},
+		{
+			name:      "gotrue failure degrades to unauthenticated",
+			signer:    &fakeSigner{err: errors.New("gotrue down")},
+			wantCalls: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var downstreamToken string
+			var downstreamStatus = http.StatusOK
+			h := GuestSession(tt.signer, false)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if c, err := r.Cookie("sb-access-token"); err == nil {
+					downstreamToken = c.Value
+				}
+				w.WriteHeader(downstreamStatus)
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, "/learn", nil)
+			if tt.existingCookie != "" {
+				req.AddCookie(&http.Cookie{Name: "sb-access-token", Value: tt.existingCookie})
+			}
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200 (guest failures must not break pages)", rec.Code)
+			}
+			if tt.signer.calls != tt.wantCalls {
+				t.Errorf("SignInAnonymously calls = %d, want %d", tt.signer.calls, tt.wantCalls)
+			}
+			if downstreamToken != tt.wantDownstream {
+				t.Errorf("downstream access token = %q, want %q", downstreamToken, tt.wantDownstream)
+			}
+
+			var gotSetCookie bool
+			for _, c := range rec.Result().Cookies() {
+				if c.Name == "sb-access-token" && c.Value != "" {
+					gotSetCookie = true
+					if !c.HttpOnly {
+						t.Error("guest access cookie must be HttpOnly")
+					}
+				}
+			}
+			if gotSetCookie != tt.wantCookie {
+				t.Errorf("Set-Cookie sb-access-token present = %v, want %v", gotSetCookie, tt.wantCookie)
+			}
+		})
+	}
+}

--- a/internal/middleware/user_loader.go
+++ b/internal/middleware/user_loader.go
@@ -32,7 +32,7 @@ func UserLoader(repo repository.UserRepository) func(http.Handler) http.Handler 
 
 			user, err := repo.GetByAuthID(r.Context(), claims.Sub)
 			if errors.Is(err, repository.ErrNotFound) {
-				user, err = provisionUser(r, repo, claims.Sub)
+				user, err = provisionUser(r, repo, claims)
 			}
 			if err != nil {
 				slog.Error("Failed to load user row", "sub", claims.Sub, "error", err)
@@ -47,10 +47,14 @@ func UserLoader(repo repository.UserRepository) func(http.Handler) http.Handler 
 }
 
 // provisionUser creates the users row for a first-time authenticated visitor,
-// copying identity fields from the validated gotrue user in context.
-func provisionUser(r *http.Request, repo repository.UserRepository, sub string) (*database.User, error) {
+// copying identity fields from the validated gotrue user in context. The
+// is_anonymous flag mirrors the JWT claim so the TTL reaper can distinguish
+// guests from registered users (ADR-024).
+func provisionUser(r *http.Request, repo repository.UserRepository, claims webutil.AuthClaims) (*database.User, error) {
+	sub := claims.Sub
 	params := database.CreateUserParams{
-		AuthID: pgtype.Text{String: sub, Valid: true},
+		AuthID:      pgtype.Text{String: sub, Valid: true},
+		IsAnonymous: claims.IsAnonymous,
 	}
 	if gotrueUser, ok := GetUserFromContext(r.Context()); ok {
 		params.Email = gotrueUser.Email

--- a/internal/repository/postgres/reaper.go
+++ b/internal/repository/postgres/reaper.go
@@ -1,0 +1,50 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/clownware/alpine-go-performance-starter/internal/database"
+)
+
+// ReaperRepo performs system-job deletions of expired anonymous users
+// (ADR-024). Unlike the request-scoped repos, it runs as service_role — the
+// system identity the service_role_bypass policies exist for — because no
+// user's RLS scope may delete other users' rows. This is deliberately NOT
+// part of inScope's role allowlist: request paths must never assume
+// service_role.
+type ReaperRepo struct {
+	db *pgxpool.Pool
+}
+
+// NewReaperRepo creates a ReaperRepo.
+func NewReaperRepo(db *pgxpool.Pool) *ReaperRepo {
+	return &ReaperRepo{db: db}
+}
+
+// DeleteExpiredAnonymousUsers removes anonymous users created before the
+// cutoff and returns the deleted rows (auth_ids feed GoTrue-side cleanup).
+// Flashcards and quiz attempts cascade via foreign keys.
+func (r *ReaperRepo) DeleteExpiredAnonymousUsers(ctx context.Context, olderThan time.Time) ([]database.DeleteExpiredAnonymousUsersRow, error) {
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("reaper: begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if _, err := tx.Exec(ctx, "SET LOCAL ROLE service_role"); err != nil {
+		return nil, fmt.Errorf("reaper: set service_role: %w", err)
+	}
+
+	rows, err := database.New(tx).DeleteExpiredAnonymousUsers(ctx, olderThan)
+	if err != nil {
+		return nil, fmt.Errorf("reaper: delete expired anonymous users: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("reaper: commit: %w", err)
+	}
+	return rows, nil
+}

--- a/internal/repository/postgres/reaper_integration_test.go
+++ b/internal/repository/postgres/reaper_integration_test.go
@@ -1,0 +1,96 @@
+package postgres
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/clownware/alpine-go-performance-starter/internal/database"
+)
+
+// TestReaperRepoIntegration proves the reaper deletes only expired anonymous
+// users — cascading their flashcards — while sparing recent guests and
+// registered users, running under the service_role identity.
+func TestReaperRepoIntegration(t *testing.T) {
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL not set; skipping integration test")
+	}
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	q := database.New(pool)
+
+	seed := func(isAnonymous bool, age time.Duration) uuid.UUID {
+		t.Helper()
+		authID := uuid.NewString()
+		user, err := q.CreateUser(ctx, database.CreateUserParams{
+			Email:       authID + "@example.com",
+			AuthID:      pgtype.Text{String: authID, Valid: true},
+			IsAnonymous: isAnonymous,
+		})
+		if err != nil {
+			t.Fatalf("seed user: %v", err)
+		}
+		if _, err := pool.Exec(ctx, "UPDATE users SET created_at = NOW() - $1::interval WHERE id = $2",
+			age.String(), user.ID); err != nil {
+			t.Fatalf("age user: %v", err)
+		}
+		if _, err := q.CreateFlashcard(ctx, database.CreateFlashcardParams{
+			UserID: user.ID, Front: "f", Back: "b",
+		}); err != nil {
+			t.Fatalf("seed flashcard: %v", err)
+		}
+		return user.ID
+	}
+
+	expiredGuest := seed(true, 40*24*time.Hour)   // reaped
+	recentGuest := seed(true, 1*24*time.Hour)     // survives (younger than TTL)
+	oldRegistered := seed(false, 90*24*time.Hour) // survives (not anonymous)
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, "DELETE FROM users WHERE id = ANY($1)",
+			[]uuid.UUID{expiredGuest, recentGuest, oldRegistered})
+	})
+
+	repo := NewReaperRepo(pool)
+	reaped, err := repo.DeleteExpiredAnonymousUsers(ctx, time.Now().Add(-30*24*time.Hour))
+	if err != nil {
+		t.Fatalf("DeleteExpiredAnonymousUsers: %v", err)
+	}
+
+	reapedIDs := map[uuid.UUID]bool{}
+	for _, row := range reaped {
+		reapedIDs[row.ID] = true
+	}
+	if !reapedIDs[expiredGuest] {
+		t.Error("expired guest was not reaped")
+	}
+	if reapedIDs[recentGuest] {
+		t.Error("recent guest was reaped — TTL not respected")
+	}
+	if reapedIDs[oldRegistered] {
+		t.Error("registered user was reaped — is_anonymous not respected")
+	}
+
+	var userExists, cardExists bool
+	if err := pool.QueryRow(ctx, "SELECT EXISTS(SELECT 1 FROM users WHERE id = $1)", expiredGuest).Scan(&userExists); err != nil {
+		t.Fatal(err)
+	}
+	if err := pool.QueryRow(ctx, "SELECT EXISTS(SELECT 1 FROM flashcards WHERE user_id = $1)", expiredGuest).Scan(&cardExists); err != nil {
+		t.Fatal(err)
+	}
+	if userExists {
+		t.Error("expired guest row still present")
+	}
+	if cardExists {
+		t.Error("expired guest's flashcards did not cascade")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -42,6 +42,9 @@ func New(cfg *config.Config, db *pgxpool.Pool) (*Server, error) {
 			slog.Error("Failed to create Supabase auth client", "error", err)
 			return nil, fmt.Errorf("failed to create auth client: %w", err)
 		}
+		if cfg.SupabaseServiceRoleKey != "" {
+			authClient.WithServiceRoleKey(cfg.SupabaseServiceRoleKey)
+		}
 		slog.Info("Supabase auth client initialized")
 	} else {
 		slog.Warn("Supabase credentials not set — auth disabled")
@@ -216,6 +219,12 @@ func (s *Server) setupRoutes() {
 // ServeHTTP implements the http.Handler interface, making Server usable with http.ListenAndServe.
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	s.router.ServeHTTP(w, r)
+}
+
+// AuthClient exposes the Supabase auth client (nil when auth is disabled)
+// for background jobs that need admin operations (e.g. the guest reaper).
+func (s *Server) AuthClient() *auth.AuthClient {
+	return s.authClient
 }
 
 func homeHandler(w http.ResponseWriter, r *http.Request) {

--- a/migrations/000006_add_is_anonymous_to_users.down.sql
+++ b/migrations/000006_add_is_anonymous_to_users.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_users_anonymous_created;
+ALTER TABLE users DROP COLUMN IF EXISTS is_anonymous;

--- a/migrations/000006_add_is_anonymous_to_users.up.sql
+++ b/migrations/000006_add_is_anonymous_to_users.up.sql
@@ -1,0 +1,10 @@
+-- Anonymous guest identities (ADR-024): guests are real users rows whose
+-- auth identity is a Supabase anonymous sign-in. The flag mirrors the JWT's
+-- is_anonymous claim at provisioning time and flips to false on the
+-- data-preserving upgrade. The TTL reaper deletes anonymous users whose
+-- account age exceeds the guest TTL (upgrading exempts them).
+
+ALTER TABLE users ADD COLUMN is_anonymous boolean NOT NULL DEFAULT false;
+
+-- The reaper scans by age over anonymous rows only.
+CREATE INDEX idx_users_anonymous_created ON users (created_at) WHERE is_anonymous;

--- a/sql/queries/users.sql
+++ b/sql/queries/users.sql
@@ -1,20 +1,20 @@
 -- name: GetUser :one
-SELECT id, email, name, avatar_url, auth_id, is_active, last_login_at, created_at, updated_at, first_run_complete
+SELECT id, email, name, avatar_url, auth_id, is_active, last_login_at, created_at, updated_at, first_run_complete, is_anonymous
 FROM users
 WHERE id = $1 LIMIT 1;
 
 -- name: GetUserByEmail :one
-SELECT id, email, name, avatar_url, auth_id, is_active, last_login_at, created_at, updated_at, first_run_complete
+SELECT id, email, name, avatar_url, auth_id, is_active, last_login_at, created_at, updated_at, first_run_complete, is_anonymous
 FROM users
 WHERE email = $1 LIMIT 1;
 
 -- name: GetUserByAuthID :one
-SELECT id, email, name, avatar_url, auth_id, is_active, last_login_at, created_at, updated_at, first_run_complete
+SELECT id, email, name, avatar_url, auth_id, is_active, last_login_at, created_at, updated_at, first_run_complete, is_anonymous
 FROM users
 WHERE auth_id = $1 LIMIT 1;
 
 -- name: ListUsers :many
-SELECT id, email, name, avatar_url, auth_id, is_active, last_login_at, created_at, updated_at, first_run_complete
+SELECT id, email, name, avatar_url, auth_id, is_active, last_login_at, created_at, updated_at, first_run_complete, is_anonymous
 FROM users
 ORDER BY created_at DESC
 LIMIT $1 OFFSET $2;
@@ -25,15 +25,16 @@ INSERT INTO users (
     name,
     avatar_url,
     auth_id,
-    first_run_complete
+    first_run_complete,
+    is_anonymous
 ) VALUES (
-    $1, $2, $3, $4, $5
+    $1, $2, $3, $4, $5, $6
 )
-RETURNING id, email, name, avatar_url, auth_id, is_active, last_login_at, created_at, updated_at, first_run_complete;
+RETURNING id, email, name, avatar_url, auth_id, is_active, last_login_at, created_at, updated_at, first_run_complete, is_anonymous;
 
 -- name: UpdateUser :one
 UPDATE users
-SET 
+SET
     email = COALESCE($2, email),
     name = COALESCE($3, name),
     avatar_url = COALESCE($4, avatar_url),
@@ -42,7 +43,7 @@ SET
     last_login_at = COALESCE($7, last_login_at),
     updated_at = NOW()
 WHERE id = $1
-RETURNING id, email, name, avatar_url, auth_id, is_active, last_login_at, created_at, updated_at, first_run_complete;
+RETURNING id, email, name, avatar_url, auth_id, is_active, last_login_at, created_at, updated_at, first_run_complete, is_anonymous;
 
 -- name: DeleteUser :exec
 UPDATE users
@@ -57,3 +58,11 @@ WHERE id = $1;
 UPDATE users
 SET first_run_complete = $2, updated_at = NOW()
 WHERE id = $1;
+
+-- name: DeleteExpiredAnonymousUsers :many
+-- Reaps anonymous guest accounts older than the TTL (ADR-024). Upgraded
+-- accounts have is_anonymous=false and are exempt. Flashcards and quiz
+-- attempts cascade via their user_id foreign keys.
+DELETE FROM users
+WHERE is_anonymous AND created_at < $1
+RETURNING id, auth_id;

--- a/sql/schema/schema.sql
+++ b/sql/schema/schema.sql
@@ -24,7 +24,8 @@ CREATE TABLE users (
     last_login_at TIMESTAMPTZ,
     created_at TIMESTAMPTZ NOT NULL,
     updated_at TIMESTAMPTZ NOT NULL,
-    first_run_complete BOOLEAN NOT NULL DEFAULT FALSE
+    first_run_complete BOOLEAN NOT NULL DEFAULT FALSE,
+    is_anonymous BOOLEAN NOT NULL DEFAULT FALSE
 );
 
 -- Organization members table


### PR DESCRIPTION
## What

Phase 3 (backend half) of the deployment-readiness plan (follows #33): everything ADR-024's anonymous guest mode needs below the UI — the server-side GoTrue anonymous sign-in, `is_anonymous` flowing through claims → RLS scoping → provisioning, and the TTL reaper. The `/learn` pages, explainer, and `/patterns` showcase land separately once the design phase opens.

## Why

ADR-024 (Accepted) requires visitors to get a real but anonymous Supabase identity so the demo genuinely exercises auth + RLS with zero signup friction — and requires the safety rails (TTL reaper, `is_anonymous` gating hooks) to ship with it, not after.

## How

- **`SignInAnonymously`**: credential-less `POST /auth/v1/signup` straight against GoTrue REST — `gotrue-go v1.2.1` has no anonymous method (decision recorded in ADR-024 at acceptance). Tested against an `httptest` fake GoTrue.
- **`TokenClaims`**: decodes `sub`/`is_anonymous` from the JWT payload *without* signature verification — safe by construction because `AuthMiddleware` has already validated the token via GoTrue `GetUser`. The claim now rides `webutil.AuthClaims` into RLS scoping and user provisioning.
- **`GuestSession` middleware**: cookie-less visitor → server-side anonymous sign-in → same httpOnly session cookies as the login flow, so downstream `AuthMiddleware`/RLS treat guests identically to registered users. GoTrue failure degrades to an unauthenticated page render, never an error page. Wired to routes when the demo surface lands.
- **Migration 000006**: `users.is_anonymous` (mirrors the claim at JIT provisioning; the upgrade flow flips it to false) plus a partial index for the reaper scan.
- **`jobs.Reaper`**: a plain ticker goroutine (deliberately no job framework — minimal-dependency ethos). Reaps unupgraded guests older than `GUEST_TTL` measured from creation; flashcards/attempts cascade via FKs. Best-effort GoTrue admin deletion when `SUPABASE_SERVICE_ROLE_KEY` is set — that config field finally has a caller.
- **`postgres.ReaperRepo`** runs its deletion as `service_role` — the system-job identity the `service_role_bypass` policies exist for — intentionally *outside* `inScope`'s request-role allowlist, which stays restricted to `authenticated`/`anon`.
- **Config**: `GUEST_MODE_ENABLED` (default off), `GUEST_TTL` (720h), `REAPER_INTERVAL` (1h), validated as a group; documented in `.env.example`.

Not E2E-verified against a live Supabase project (no credentials in this environment) — the request shape follows supabase-js's `signInAnonymously()`; ADR-024 notes live verification happens during demo integration.

## Testing

- [x] Unit: anonymous sign-in success/disabled/malformed matrix vs fake GoTrue; JWT claim decode incl. garbage inputs; GuestSession matrix (issue / passthrough / degrade); reaper RunOnce matrix (empty, cascade to auth deletion, best-effort failure, no deleter, store error); config validation for the guest group
- [x] Integration (CI): expired guest reaped with flashcards cascading; recent guest and old registered user survive; runs under `service_role`
- [x] `task ci` green end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)