### PR TITLE
feat(deploy): release pipeline, fly.toml worked example, migrate-before-deploy

### DIFF
--- a/.claude/stack.md
+++ b/.claude/stack.md
@@ -69,6 +69,7 @@ Budgets are enforced in CI via `task test:performance` / `task test:binary-size`
 
 - **Default port:** `4000` (`HTTP_PORT`, see `internal/config/config.go`)
 - **Build:** `task build` → `./dist/app` (stripped). Multi-stage Dockerfile (Node→Tailwind, Go→templ+build, Alpine runtime).
+- **Release:** pushing a `v*` tag runs `.github/workflows/release.yml` — ghcr.io image (30MB budget gate), migrations before deploy, secret-gated Fly deploy. `fly.toml` at repo root is the ADR-025 worked example. `db-migrate.yml` validates migrations on a fresh Postgres before applying to production.
 - **Target (ADR-025):** single stateless container on a container host (Fly.io as the worked example) behind the Cloudflare proxy, which terminates TLS and serves as CDN. Cloudflare Workers is not an application runtime. Sessions are stateless (JWT cookies); backups are delegated to Supabase managed Postgres; production migrations are forward-only and run before deploy.
 
 ## Cross-tool spine

--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -1,24 +1,69 @@
+# Applies migrations to the production database when migration files change
+# on the default branch. A validation job runs the full migration chain
+# against a fresh Postgres first, so broken SQL never reaches production.
+# The production job skips gracefully when SUPABASE_DATABASE_URL is unset.
 name: DB Migrations
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
     paths:
       - 'migrations/**'
   workflow_dispatch:
 
 jobs:
-  migrate:
+  validate:
+    name: Validate migrations against fresh Postgres
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: migrate_check
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v4
+
+      - name: Bootstrap auth stub (vanilla Postgres lacks Supabase's auth schema)
+        run: |
+          sudo apt-get update && sudo apt-get install -y --no-install-recommends postgresql-client
+          PGPASSWORD=postgres psql -h localhost -U postgres -d migrate_check -f sql/test/auth_stub.sql
 
       - name: Install golang-migrate
         run: |
           curl -L https://github.com/golang-migrate/migrate/releases/download/v4.19.1/migrate.linux-amd64.tar.gz | tar xvz
           sudo mv migrate /usr/local/bin/
 
+      - name: Migrate up
+        run: migrate -path migrations -database "postgres://postgres:postgres@localhost:5432/migrate_check?sslmode=disable" up
+
+  migrate:
+    name: Apply to production
+    runs-on: ubuntu-latest
+    needs: validate
+    env:
+      DATABASE_URL: ${{ secrets.SUPABASE_DATABASE_URL }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Skip when no database secret is configured
+        if: env.DATABASE_URL == ''
+        run: echo "SUPABASE_DATABASE_URL not set — skipping production migrations."
+
+      - name: Install golang-migrate
+        if: env.DATABASE_URL != ''
+        run: |
+          curl -L https://github.com/golang-migrate/migrate/releases/download/v4.19.1/migrate.linux-amd64.tar.gz | tar xvz
+          sudo mv migrate /usr/local/bin/
+
       - name: Run migrations
-        env:
-          DATABASE_URL: ${{ secrets.SUPABASE_DATABASE_URL }}
+        if: env.DATABASE_URL != ''
         run: migrate -path migrations -database "$DATABASE_URL" up

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,110 @@
+# Release pipeline (ADR-025): on a version tag, build and publish the Docker
+# image, enforce the 30MB image budget (ADR-000), apply migrations BEFORE
+# deploying (ADR-025 §5), then deploy the demo instance. Migration and deploy
+# jobs skip gracefully when the corresponding secrets are not configured, so
+# forks can tag releases without a Supabase/Fly account.
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  image:
+    name: Build & Push Image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build image (local, for budget check)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          tags: local/app:budget-check
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Enforce 30MB image budget (ADR-000)
+        run: |
+          SIZE=$(docker image inspect local/app:budget-check --format='{{.Size}}')
+          MAX=$((30 * 1024 * 1024))
+          echo "Image size: $SIZE bytes (budget: $MAX)"
+          if [ "$SIZE" -gt "$MAX" ]; then
+            echo "::error::Docker image ($SIZE bytes) exceeds the 30MB budget (ADR-000)"
+            exit 1
+          fi
+
+      - name: Push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:sha-${{ github.sha }}
+          cache-from: type=gha
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+
+  migrate:
+    name: Apply Migrations
+    runs-on: ubuntu-latest
+    needs: image
+    env:
+      DATABASE_URL: ${{ secrets.SUPABASE_DATABASE_URL }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Skip when no database secret is configured
+        if: env.DATABASE_URL == ''
+        run: echo "SUPABASE_DATABASE_URL not set — skipping production migrations."
+
+      - name: Install golang-migrate
+        if: env.DATABASE_URL != ''
+        run: |
+          curl -L https://github.com/golang-migrate/migrate/releases/download/v4.19.1/migrate.linux-amd64.tar.gz | tar xvz
+          sudo mv migrate /usr/local/bin/
+
+      - name: Run migrations (before deploy, ADR-025 §5)
+        if: env.DATABASE_URL != ''
+        run: migrate -path migrations -database "$DATABASE_URL" up
+
+  deploy:
+    name: Deploy (Fly.io example)
+    runs-on: ubuntu-latest
+    needs: migrate
+    env:
+      FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Skip when no Fly token is configured
+        if: env.FLY_API_TOKEN == ''
+        run: echo "FLY_API_TOKEN not set — skipping deploy."
+
+      - name: Set up flyctl
+        if: env.FLY_API_TOKEN != ''
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy
+        if: env.FLY_API_TOKEN != ''
+        run: flyctl deploy --remote-only --image ghcr.io/${{ github.repository }}:${{ github.ref_name }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,6 +208,7 @@ Budgets are enforced in CI via `task test:performance` / `task test:binary-size`
 
 - **Default port:** `4000` (`HTTP_PORT`, see `internal/config/config.go`)
 - **Build:** `task build` → `./dist/app` (stripped). Multi-stage Dockerfile (Node→Tailwind, Go→templ+build, Alpine runtime).
+- **Release:** pushing a `v*` tag runs `.github/workflows/release.yml` — ghcr.io image (30MB budget gate), migrations before deploy, secret-gated Fly deploy. `fly.toml` at repo root is the ADR-025 worked example. `db-migrate.yml` validates migrations on a fresh Postgres before applying to production.
 - **Target (ADR-025):** single stateless container on a container host (Fly.io as the worked example) behind the Cloudflare proxy, which terminates TLS and serves as CDN. Cloudflare Workers is not an application runtime. Sessions are stateless (JWT cookies); backups are delegated to Supabase managed Postgres; production migrations are forward-only and run before deploy.
 
 ### Cross-tool spine

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-07-05
+
+Deployment-readiness release: the 2026-07-05 audit's findings implemented end
+to end — decided deployment topology, security hardening, runtime RLS
+enforcement, unified logging, guest-mode backend, and a release pipeline.
+
+### Added
+- **ADR-025 Deployment Target**: stateless container behind the Cloudflare
+  proxy (Fly.io worked example, `fly.toml` at repo root); edge-terminated TLS;
+  stateless JWT-cookie sessions; Supabase-delegated backups; forward-only
+  pre-deploy migrations
+- **ADR-026 Logging Standardization**: stdlib `log/slog` everywhere
+- **CSRF protection** (ADR-014 §3): double-submit-cookie middleware, token via
+  `hx-headers` on `<body>` plus hidden-field fallback in all POST forms
+- **Runtime RLS enforcement** (ADR-004): every repository call carries the
+  requester's JWT identity onto the connection (`SET LOCAL ROLE` +
+  `request.jwt.claims`); CI integration tests prove cross-user isolation
+  through the production path
+- **Anonymous guest-mode backend** (ADR-024): server-side GoTrue anonymous
+  sign-in, `is_anonymous` claim plumbing, `GuestSession` middleware, TTL
+  reaper with GoTrue-side cleanup (`GUEST_MODE_ENABLED`, `GUEST_TTL`,
+  `REAPER_INTERVAL`)
+- **User provisioning**: `UserLoader` middleware JIT-creates the `users` row
+  on first authenticated request (RLS `WITH CHECK` proves ownership); fixes
+  the first-run onboarding flow
+- Tiered rate limiting: 5/min per IP on login/signup atop the global limiter
+- HTTP server timeouts (read/write/idle/read-header); env-tunable pgxpool
+  (`DB_MAX_CONNS` etc.); `config.Validate()` fail-fast at boot
+- `/metrics` guard: bearer `METRICS_TOKEN`, hidden in production when unset
+- HSTS emitted when `ENV=production`; gzip compression middleware
+- Release workflow: ghcr.io image publish with a 30MB image-budget gate,
+  migrations applied before deploy, secret-gated Fly.io deploy
+- DB migration workflow now validates the full chain against a fresh Postgres
+  before touching production (and actually triggers — it watched the wrong
+  branch)
+- Migrations 000005 (rescope `service_role_bypass` for pre-fix deployments)
+  and 000006 (`users.is_anonymous`)
+
+### Changed
+- ADR-024 accepted (demo direction + anonymous sign-in mechanism); ADR-001/013
+  amended per ADR-025/026; ADR-014's OWASP table corrected to audited reality
+- Logging: env-driven setup — JSON in production, `LOG_LEVEL` (default info);
+  auth logs no longer contain email addresses (ADR-014 §7)
+- Go toolchain pinned to a patched release; pgx upgraded (govulncheck clean)
+
+### Removed
+- zerolog dependency; dead `profile_handler.go`; stub `user_postgres.go`
+  (nil-returning methods and a hand-written SQL string)
+
 ## [0.2.0] - 2026-04-05
 
 ### Added

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,37 @@
+# Worked-example deployment config (ADR-025 §6). Fly.io is an example, not a
+# requirement — the Docker image built by ./Dockerfile is the portable
+# contract; any container host works. Run behind Cloudflare-proxied DNS in
+# Full (strict) mode: TLS terminates at the edge, the app serves plain HTTP
+# on HTTP_PORT inside the private network (ADR-025 §2).
+#
+# Secrets (DATABASE_URL, SUPABASE_*, METRICS_TOKEN) go through
+# `fly secrets set` — never in this file (ADR-015).
+
+app = "alpine-go-performance-starter"
+primary_region = "ewr"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  ENV = "production"
+  HTTP_PORT = "4000"
+
+[http_service]
+  internal_port = 4000
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+
+  [[http_service.checks]]
+    interval = "30s"
+    timeout = "3s"
+    grace_period = "5s"
+    method = "GET"
+    path = "/healthz"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  # Steady-state budget is 128MB (ADR-000); 256MB leaves headroom for spikes.
+  memory = "256mb"


### PR DESCRIPTION
## What

Phase 5 (final infrastructure phase) of the deployment-readiness plan (follows #34): the ship path. Tagging `v0.3.0` after this merge will build and publish the image, gate it on the 30MB budget, and — once secrets are configured — migrate then deploy.

## Why

ADR-025 decided the topology; nothing implemented it: CI never built an image, `db-migrate.yml` pushed straight to production with no validation (and, it turns out, never actually ran — it watched the `main` branch while the repo's default is `master`), and there was no release process at all.

## How

- **`release.yml`** (on `v*` tags): build → **enforce the 30MB image budget** (ADR-000) → push `ghcr.io/clownware/alpine-go-performance-starter` (`vX.Y.Z`, `latest`, `sha-*`) → GitHub release with generated notes → **migrations before deploy** (ADR-025 §5) → Fly.io deploy of the exact pushed image. The migrate and deploy jobs check their secrets (`SUPABASE_DATABASE_URL`, `FLY_API_TOKEN`) and skip gracefully when absent, so forks can cut releases without accounts.
- **`db-migrate.yml`**: branch bug fixed (`main` → `master`), plus a new validation job that applies the entire migration chain (with the auth stub) to a fresh Postgres before the production job runs.
- **`fly.toml`**: the one worked-example config ADR-025 §6 permits — `/healthz` checks, `ENV=production`, 256MB VM (128MB steady-state budget with headroom). Secrets go through `fly secrets set`, never the file.
- **CHANGELOG 0.3.0** written; stack.md release facts updated; AGENTS.md regenerated.

## After merge

I'll tag `v0.3.0`, which exercises the image-build/budget/release path immediately. The migrate/deploy jobs will skip until you add `SUPABASE_DATABASE_URL` and `FLY_API_TOKEN` repo secrets (plus `fly apps create` for the demo instance).

## Testing

- [x] `task ci` green end-to-end
- [x] Workflow YAML validated; migrate/deploy jobs are skip-safe without secrets
- [x] Image budget check mirrors the enforced binary-size pattern
- [ ] Live deploy pending repo secrets (documented above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)