### PR TITLE
test: close handler and org-repo coverage gaps

### DIFF
--- a/internal/handler/auth_handlers_test.go
+++ b/internal/handler/auth_handlers_test.go
@@ -1,0 +1,242 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/clownware/alpine-go-performance-starter/internal/auth"
+)
+
+// newFakeGoTrue stands up an httptest server faking the GoTrue REST API and
+// returns an AuthClient pointed at it (the seam noted in ADR-023: the handlers
+// talk to a real supabase client, which talks HTTP to the fake).
+func newFakeGoTrue(t *testing.T, handler http.HandlerFunc) *auth.AuthClient {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	client, err := auth.NewAuthClient(srv.URL, "test-anon-key")
+	if err != nil {
+		t.Fatalf("NewAuthClient: %v", err)
+	}
+	return client
+}
+
+func formRequest(target, body string) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, target, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	return req
+}
+
+func TestAuthPage(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/auth/page", nil)
+	w := httptest.NewRecorder()
+
+	AuthPage(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("AuthPage() status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if w.Body.Len() == 0 {
+		t.Error("AuthPage() rendered an empty body")
+	}
+}
+
+func TestAuthLoginPost(t *testing.T) {
+	// user.id must be a valid UUID for gotrue-go's response decoding.
+	const sessionBody = `{"access_token":"tok","refresh_token":"ref","expires_in":3600,
+		"token_type":"bearer","user":{"id":"6d3f4c9a-92c8-4a2e-9b6e-0d6a3f1c2b4d"}}`
+
+	tests := []struct {
+		name         string
+		form         string
+		malformed    bool
+		gotrueStatus int
+		gotrueBody   string
+		wantStatus   int
+		wantRedirect string
+		wantToast    string
+	}{
+		{
+			name:       "malformed form body returns 400",
+			form:       "%zz",
+			malformed:  true,
+			wantStatus: http.StatusBadRequest,
+			wantToast:  "Failed to process form.",
+		},
+		{
+			name:       "missing email returns 400",
+			form:       "password=hunter22",
+			wantStatus: http.StatusBadRequest,
+			wantToast:  "Email and password cannot be empty.",
+		},
+		{
+			name:       "missing password returns 400",
+			form:       "email=a%40b.com",
+			wantStatus: http.StatusBadRequest,
+			wantToast:  "Email and password cannot be empty.",
+		},
+		{
+			name:         "invalid credentials return 401 with generic error",
+			form:         "email=a%40b.com&password=wrong",
+			gotrueStatus: http.StatusBadRequest,
+			gotrueBody:   `{"error":"invalid_grant","error_description":"Invalid login credentials"}`,
+			wantStatus:   http.StatusUnauthorized,
+			wantToast:    "Invalid login credentials.",
+		},
+		{
+			name:         "successful login redirects to profile",
+			form:         "email=a%40b.com&password=correct",
+			gotrueStatus: http.StatusOK,
+			gotrueBody:   sessionBody,
+			wantStatus:   http.StatusOK,
+			wantRedirect: "/profile",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotPath string
+			client := newFakeGoTrue(t, func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+				w.WriteHeader(tt.gotrueStatus)
+				_, _ = w.Write([]byte(tt.gotrueBody))
+			})
+			w := httptest.NewRecorder()
+
+			AuthLoginPost(client)(w, formRequest("/auth/login", tt.form))
+
+			if w.Code != tt.wantStatus {
+				t.Fatalf("AuthLoginPost() status = %d, want %d", w.Code, tt.wantStatus)
+			}
+			if tt.wantRedirect != "" {
+				if got := w.Header().Get("HX-Redirect"); got != tt.wantRedirect {
+					t.Errorf("HX-Redirect = %q, want %q", got, tt.wantRedirect)
+				}
+			}
+			if tt.wantToast != "" {
+				if got := w.Header().Get("HX-Trigger"); !strings.Contains(got, tt.wantToast) {
+					t.Errorf("HX-Trigger = %q, want it to contain %q", got, tt.wantToast)
+				}
+			}
+			if tt.gotrueStatus != 0 && gotPath != "/auth/v1/token" {
+				t.Errorf("gotrue request path = %q, want /auth/v1/token", gotPath)
+			}
+			// Validation failures must short-circuit before any network call.
+			if tt.gotrueStatus == 0 && gotPath != "" {
+				t.Errorf("gotrue was called (path %q) on a request that should fail validation", gotPath)
+			}
+		})
+	}
+}
+
+func TestAuthSignupPost(t *testing.T) {
+	tests := []struct {
+		name         string
+		form         string
+		gotrueStatus int
+		gotrueBody   string
+		wantStatus   int
+		wantToast    string
+	}{
+		{
+			name:       "malformed form body returns 400",
+			form:       "%zz",
+			wantStatus: http.StatusBadRequest,
+			wantToast:  "Failed to process form.",
+		},
+		{
+			name:       "missing fields return 400",
+			form:       "email=&password=",
+			wantStatus: http.StatusBadRequest,
+			wantToast:  "Email and password cannot be empty.",
+		},
+		{
+			name:         "gotrue rejection returns 409",
+			form:         "email=a%40b.com&password=short",
+			gotrueStatus: http.StatusUnprocessableEntity,
+			gotrueBody:   `{"msg":"User already registered"}`,
+			wantStatus:   http.StatusConflict,
+			wantToast:    "Signup failed.",
+		},
+		{
+			name:         "successful signup returns 200 with success toast",
+			form:         "email=new%40b.com&password=long-enough-pw",
+			gotrueStatus: http.StatusOK,
+			gotrueBody:   `{"id":"6d3f4c9a-92c8-4a2e-9b6e-0d6a3f1c2b4d","email":"new@b.com"}`,
+			wantStatus:   http.StatusOK,
+			wantToast:    "Signup successful!",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotPath string
+			client := newFakeGoTrue(t, func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+				w.WriteHeader(tt.gotrueStatus)
+				_, _ = w.Write([]byte(tt.gotrueBody))
+			})
+			w := httptest.NewRecorder()
+
+			AuthSignupPost(client)(w, formRequest("/auth/signup", tt.form))
+
+			if w.Code != tt.wantStatus {
+				t.Fatalf("AuthSignupPost() status = %d, want %d", w.Code, tt.wantStatus)
+			}
+			if got := w.Header().Get("HX-Trigger"); !strings.Contains(got, tt.wantToast) {
+				t.Errorf("HX-Trigger = %q, want it to contain %q", got, tt.wantToast)
+			}
+			if tt.gotrueStatus != 0 && gotPath != "/auth/v1/signup" {
+				t.Errorf("gotrue request path = %q, want /auth/v1/signup", gotPath)
+			}
+		})
+	}
+}
+
+func TestAuthLogoutPost(t *testing.T) {
+	tests := []struct {
+		name         string
+		gotrueStatus int
+		secureCookie bool
+	}{
+		{name: "successful logout clears cookies", gotrueStatus: http.StatusNoContent},
+		{name: "gotrue failure still logs out client-side", gotrueStatus: http.StatusInternalServerError},
+		{name: "production marks cleared cookies Secure", gotrueStatus: http.StatusNoContent, secureCookie: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newFakeGoTrue(t, func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.gotrueStatus)
+			})
+			w := httptest.NewRecorder()
+
+			AuthLogoutPost(client, tt.secureCookie)(w, httptest.NewRequest(http.MethodPost, "/auth/logout", nil))
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("AuthLogoutPost() status = %d, want %d", w.Code, http.StatusOK)
+			}
+			if got := w.Header().Get("HX-Redirect"); got != "/auth/page" {
+				t.Errorf("HX-Redirect = %q, want /auth/page", got)
+			}
+
+			cleared := map[string]bool{}
+			for _, c := range w.Result().Cookies() {
+				if c.MaxAge >= 0 {
+					t.Errorf("cookie %q MaxAge = %d, want negative (expired)", c.Name, c.MaxAge)
+				}
+				if c.Secure != tt.secureCookie {
+					t.Errorf("cookie %q Secure = %v, want %v", c.Name, c.Secure, tt.secureCookie)
+				}
+				cleared[c.Name] = true
+			}
+			for _, name := range []string{"sb-access-token", "sb-refresh-token"} {
+				if !cleared[name] {
+					t.Errorf("cookie %q was not cleared", name)
+				}
+			}
+		})
+	}
+}

--- a/internal/handler/first_run_handlers_test.go
+++ b/internal/handler/first_run_handlers_test.go
@@ -1,0 +1,135 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/clownware/alpine-go-performance-starter/internal/database"
+	"github.com/clownware/alpine-go-performance-starter/internal/repository"
+	"github.com/clownware/alpine-go-performance-starter/internal/webutil"
+)
+
+// fakeUserRepo implements only the UserRepository method the first-run flow
+// uses; the embedded interface panics on anything else, catching unexpected
+// repository calls.
+type fakeUserRepo struct {
+	repository.UserRepository
+	firstRunErr  error
+	gotUserID    uuid.UUID
+	gotComplete  bool
+	firstRunSeen bool
+}
+
+func (f *fakeUserRepo) UpdateFirstRunComplete(_ context.Context, id uuid.UUID, complete bool) error {
+	f.firstRunSeen = true
+	f.gotUserID = id
+	f.gotComplete = complete
+	return f.firstRunErr
+}
+
+func firstRunRequest(target string, user *database.User, repo repository.UserRepository) *http.Request {
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	ctx := req.Context()
+	if user != nil {
+		ctx = webutil.WithUser(ctx, user)
+	}
+	if repo != nil {
+		ctx = webutil.WithUserRepo(ctx, repo)
+	}
+	return req.WithContext(ctx)
+}
+
+func TestFirstRunStepsRequireAuth(t *testing.T) {
+	steps := []struct {
+		name    string
+		target  string
+		handler http.HandlerFunc
+	}{
+		{name: "welcome", target: "/first-run", handler: ShowFirstRunWelcome},
+		{name: "profile", target: "/first-run/profile", handler: ShowFirstRunProfile},
+		{name: "ctas", target: "/first-run/ctas", handler: ShowFirstRunCTAs},
+	}
+
+	for _, tt := range steps {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			tt.handler(w, firstRunRequest(tt.target, nil, nil))
+
+			if w.Code != http.StatusSeeOther {
+				t.Fatalf("status = %d, want %d", w.Code, http.StatusSeeOther)
+			}
+			if got := w.Header().Get("Location"); got != "/auth/page" {
+				t.Errorf("Location = %q, want /auth/page", got)
+			}
+		})
+	}
+}
+
+func TestFirstRunStepsRender(t *testing.T) {
+	user := &database.User{ID: uuid.New()}
+	steps := []struct {
+		name    string
+		target  string
+		handler http.HandlerFunc
+	}{
+		{name: "welcome", target: "/first-run", handler: ShowFirstRunWelcome},
+		{name: "profile", target: "/first-run/profile", handler: ShowFirstRunProfile},
+	}
+
+	for _, tt := range steps {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			tt.handler(w, firstRunRequest(tt.target, user, nil))
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+			}
+			if w.Body.Len() == 0 {
+				t.Error("rendered an empty body")
+			}
+		})
+	}
+}
+
+func TestShowFirstRunCTAs(t *testing.T) {
+	tests := []struct {
+		name       string
+		repoErr    error
+		wantStatus int
+	}{
+		{name: "marks onboarding complete and redirects", wantStatus: http.StatusSeeOther},
+		{name: "repository failure re-renders with 500", repoErr: errors.New("db down"), wantStatus: http.StatusInternalServerError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			user := &database.User{ID: uuid.New()}
+			repo := &fakeUserRepo{firstRunErr: tt.repoErr}
+			w := httptest.NewRecorder()
+
+			ShowFirstRunCTAs(w, firstRunRequest("/first-run/ctas", user, repo))
+
+			if w.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d", w.Code, tt.wantStatus)
+			}
+			if !repo.firstRunSeen {
+				t.Fatal("UpdateFirstRunComplete was not called")
+			}
+			if repo.gotUserID != user.ID || !repo.gotComplete {
+				t.Errorf("UpdateFirstRunComplete(%v, %v), want (%v, true)", repo.gotUserID, repo.gotComplete, user.ID)
+			}
+			if tt.wantStatus == http.StatusSeeOther {
+				if got := w.Header().Get("Location"); got != "/dashboard" {
+					t.Errorf("Location = %q, want /dashboard", got)
+				}
+			} else if w.Body.Len() == 0 {
+				t.Error("error path rendered an empty body")
+			}
+		})
+	}
+}

--- a/internal/handler/profile_handlers_test.go
+++ b/internal/handler/profile_handlers_test.go
@@ -1,0 +1,135 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supabase-community/gotrue-go/types"
+
+	"github.com/clownware/alpine-go-performance-starter/internal/middleware"
+)
+
+// withAuthUser stores a gotrue user in the request context the way
+// middleware.AuthMiddleware does.
+func withAuthUser(r *http.Request, user *types.UserResponse) *http.Request {
+	return r.WithContext(context.WithValue(r.Context(), middleware.ContextUserKey, user))
+}
+
+func TestUserNameFromContext(t *testing.T) {
+	tests := []struct {
+		name string
+		user *types.UserResponse
+		want string
+	}{
+		{name: "no user in context", user: nil, want: "User"},
+		{
+			name: "full_name metadata wins",
+			user: &types.UserResponse{User: types.User{
+				Email:        "ada@example.com",
+				UserMetadata: map[string]interface{}{"full_name": "Ada Lovelace", "name": "Ada"},
+			}},
+			want: "Ada Lovelace",
+		},
+		{
+			name: "name metadata second",
+			user: &types.UserResponse{User: types.User{
+				Email:        "grace@example.com",
+				UserMetadata: map[string]interface{}{"name": "Grace Hopper"},
+			}},
+			want: "Grace Hopper",
+		},
+		{
+			name: "email fallback",
+			user: &types.UserResponse{User: types.User{Email: "fallback@example.com"}},
+			want: "fallback@example.com",
+		},
+		{name: "empty user falls back to User", user: &types.UserResponse{}, want: "User"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/profile", nil)
+			if tt.user != nil {
+				req = withAuthUser(req, tt.user)
+			}
+			if got := userNameFromContext(req); got != tt.want {
+				t.Errorf("userNameFromContext() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProfileView(t *testing.T) {
+	tests := []struct {
+		name string
+		user *types.UserResponse
+	}{
+		{name: "anonymous context"},
+		{name: "authenticated user", user: &types.UserResponse{User: types.User{Email: "ada@example.com"}}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/profile", nil)
+			if tt.user != nil {
+				req = withAuthUser(req, tt.user)
+			}
+			w := httptest.NewRecorder()
+
+			ProfileView(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("ProfileView() status = %d, want %d", w.Code, http.StatusOK)
+			}
+			if w.Body.Len() == 0 {
+				t.Error("ProfileView() rendered an empty body")
+			}
+		})
+	}
+}
+
+func TestProfileUpdate(t *testing.T) {
+	tests := []struct {
+		name         string
+		form         string
+		htmx         bool
+		wantStatus   int
+		wantLocation string
+		wantTrigger  bool
+	}{
+		{name: "malformed form body returns 400", form: "%zz", wantStatus: http.StatusBadRequest},
+		{name: "empty name via htmx re-renders form with 422", form: "name=+", htmx: true, wantStatus: http.StatusUnprocessableEntity},
+		{name: "empty name without htmx re-renders page with 422", form: "name=", wantStatus: http.StatusUnprocessableEntity},
+		{name: "valid name via htmx returns form with trigger", form: "name=Ada", htmx: true, wantStatus: http.StatusOK, wantTrigger: true},
+		{name: "valid name without htmx redirects", form: "name=Ada", wantStatus: http.StatusSeeOther, wantLocation: "/profile"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := formRequest("/profile", tt.form)
+			if tt.htmx {
+				req.Header.Set("HX-Request", "true")
+			}
+			w := httptest.NewRecorder()
+
+			ProfileUpdate(w, req)
+
+			if w.Code != tt.wantStatus {
+				t.Fatalf("ProfileUpdate() status = %d, want %d", w.Code, tt.wantStatus)
+			}
+			if tt.wantLocation != "" {
+				if got := w.Header().Get("Location"); got != tt.wantLocation {
+					t.Errorf("Location = %q, want %q", got, tt.wantLocation)
+				}
+			}
+			if tt.wantTrigger && w.Header().Get("HX-Trigger") == "" {
+				t.Error("HX-Trigger not set on successful htmx update")
+			}
+			if tt.wantStatus == http.StatusUnprocessableEntity && w.Body.Len() == 0 {
+				t.Error("validation failure rendered an empty body")
+			}
+		})
+	}
+}

--- a/internal/repository/postgres/org_repo_test.go
+++ b/internal/repository/postgres/org_repo_test.go
@@ -1,0 +1,188 @@
+package postgres
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/clownware/alpine-go-performance-starter/internal/database"
+	"github.com/clownware/alpine-go-performance-starter/internal/repository"
+)
+
+func TestOrganizationRepoIntegration(t *testing.T) {
+	ctx, q := withTx(t)
+	repo := NewOrganizationRepo(nil, q)
+
+	slug := "org-" + uuid.NewString()
+	created, err := repo.Create(ctx, database.CreateOrganizationParams{
+		Name: "Acme",
+		Slug: slug,
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if !created.IsActive.Bool {
+		t.Error("new organization should default to is_active=true")
+	}
+
+	byID, err := repo.Get(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if byID.Slug != slug {
+		t.Errorf("Get slug = %q, want %q", byID.Slug, slug)
+	}
+
+	bySlug, err := repo.GetBySlug(ctx, slug)
+	if err != nil {
+		t.Fatalf("GetBySlug: %v", err)
+	}
+	if bySlug.ID != created.ID {
+		t.Errorf("GetBySlug id = %v, want %v", bySlug.ID, created.ID)
+	}
+
+	updated, err := repo.Update(ctx, database.UpdateOrganizationParams{
+		ID:       created.ID,
+		Name:     "Acme Renamed",
+		Slug:     slug,
+		PlanType: pgtype.Text{String: "pro", Valid: true},
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if updated.Name != "Acme Renamed" || updated.PlanType.String != "pro" {
+		t.Errorf("Update = (%q, %q), want (Acme Renamed, pro)", updated.Name, updated.PlanType.String)
+	}
+
+	if err := repo.Delete(ctx, created.ID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	afterDelete, err := repo.Get(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("Get after delete: %v", err)
+	}
+	if afterDelete.IsActive.Bool {
+		t.Error("Delete should soft-delete (is_active=false)")
+	}
+
+	if _, err := repo.Get(ctx, uuid.New()); err != repository.ErrNotFound {
+		t.Errorf("Get(missing) err = %v, want ErrNotFound", err)
+	}
+	if _, err := repo.GetBySlug(ctx, "missing-"+uuid.NewString()); err != repository.ErrNotFound {
+		t.Errorf("GetBySlug(missing) err = %v, want ErrNotFound", err)
+	}
+	if _, err := repo.Update(ctx, database.UpdateOrganizationParams{ID: uuid.New(), Name: "x", Slug: "x-" + uuid.NewString()}); err != repository.ErrNotFound {
+		t.Errorf("Update(missing) err = %v, want ErrNotFound", err)
+	}
+}
+
+func seedOrg(ctx context.Context, t *testing.T, repo *OrganizationRepo, name string) *database.Organization {
+	t.Helper()
+	org, err := repo.Create(ctx, database.CreateOrganizationParams{
+		Name: name,
+		Slug: name + "-" + uuid.NewString(),
+	})
+	if err != nil {
+		t.Fatalf("seed org %s: %v", name, err)
+	}
+	return org
+}
+
+func TestOrganizationMemberRepoIntegration(t *testing.T) {
+	ctx, q := withTx(t)
+	orgRepo := NewOrganizationRepo(nil, q)
+	memberRepo := NewOrganizationMemberRepo(nil, q)
+	userID := seedUser(ctx, t, q)
+
+	orgA := seedOrg(ctx, t, orgRepo, "org-a")
+	orgB := seedOrg(ctx, t, orgRepo, "org-b")
+
+	memberA, err := memberRepo.Create(ctx, database.CreateOrganizationMemberParams{
+		OrganizationID:        orgA.ID,
+		UserID:                userID,
+		Role:                  "owner",
+		IsPrimaryOrganization: pgtype.Bool{Bool: true, Valid: true},
+	})
+	if err != nil {
+		t.Fatalf("Create member A: %v", err)
+	}
+	if _, err := memberRepo.Create(ctx, database.CreateOrganizationMemberParams{
+		OrganizationID: orgB.ID,
+		UserID:         userID,
+		Role:           "member",
+	}); err != nil {
+		t.Fatalf("Create member B: %v", err)
+	}
+
+	byID, err := memberRepo.Get(ctx, memberA.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if byID.Role != "owner" {
+		t.Errorf("Get role = %q, want owner", byID.Role)
+	}
+
+	byUserAndOrg, err := memberRepo.GetByUserAndOrg(ctx, userID, orgA.ID)
+	if err != nil {
+		t.Fatalf("GetByUserAndOrg: %v", err)
+	}
+	if byUserAndOrg.ID != memberA.ID {
+		t.Errorf("GetByUserAndOrg id = %v, want %v", byUserAndOrg.ID, memberA.ID)
+	}
+
+	count, err := memberRepo.Count(ctx, orgA.ID)
+	if err != nil {
+		t.Fatalf("Count: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("Count = %d, want 1", count)
+	}
+
+	members, err := memberRepo.List(ctx, orgA.ID, 10, 0)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(members) != 1 {
+		t.Errorf("List len = %d, want 1", len(members))
+	}
+
+	userOrgs, err := orgRepo.ListForUser(ctx, userID, 10, 0)
+	if err != nil {
+		t.Fatalf("ListForUser: %v", err)
+	}
+	if len(userOrgs) != 2 {
+		t.Errorf("ListForUser len = %d, want 2", len(userOrgs))
+	}
+
+	// Flip the primary org and verify both sides of the two-step update (ADR-005).
+	if err := memberRepo.SetPrimary(ctx, userID, orgB.ID); err != nil {
+		t.Fatalf("SetPrimary: %v", err)
+	}
+	primary, err := orgRepo.GetPrimaryForUser(ctx, userID)
+	if err != nil {
+		t.Fatalf("GetPrimaryForUser: %v", err)
+	}
+	if primary.ID != orgB.ID {
+		t.Errorf("GetPrimaryForUser = %v, want %v (org B)", primary.ID, orgB.ID)
+	}
+	demoted, err := memberRepo.GetByUserAndOrg(ctx, userID, orgA.ID)
+	if err != nil {
+		t.Fatalf("GetByUserAndOrg after SetPrimary: %v", err)
+	}
+	if demoted.IsPrimaryOrganization.Bool {
+		t.Error("org A membership should no longer be primary after SetPrimary(org B)")
+	}
+
+	if err := memberRepo.Delete(ctx, userID, orgA.ID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := memberRepo.GetByUserAndOrg(ctx, userID, orgA.ID); err != repository.ErrNotFound {
+		t.Errorf("GetByUserAndOrg after delete err = %v, want ErrNotFound", err)
+	}
+
+	if _, err := memberRepo.Get(ctx, uuid.New()); err != repository.ErrNotFound {
+		t.Errorf("Get(missing) err = %v, want ErrNotFound", err)
+	}
+}


### PR DESCRIPTION
## What

Closes the remaining test-coverage gaps from #17: auth handlers, profile handlers, first-run handlers, and organization/organization-member repositories.

Closes #17

## Why

ADR-023 sets the priority order — handlers and auth first, repositories next. The RLS and user-repo halves of #17 landed in PRs #25/#26/#31/#32; this PR covers everything that remained. It also matters for sequencing: #37 will retire the Items domain and its tests, which are currently a third of all handler tests.

## How

- **Auth handlers** (`auth_handlers_test.go`): uses the seam noted in #17 — handlers exercise the real supabase/gotrue client pointed at an `httptest` server faking the GoTrue REST API (`/auth/v1/token`, `/signup`, `/logout`). Covers validation short-circuits (asserting no network call is made), generic-error responses on bad credentials, HX-Redirect/HX-Trigger contracts, and cookie-clearing on logout including the `secureCookie` production flag (ADR-025 posture).
- **Profile handlers** (`profile_handlers_test.go`): table-driven coverage of `userNameFromContext` fallback order (full_name → name → email → "User"), plus HTMX vs non-HTMX render/redirect paths and 422 validation re-renders.
- **First-run handlers** (`first_run_handlers_test.go`): auth-gating redirects for all three steps, and `ShowFirstRunCTAs` success/failure via a fake `UserRepository` that records the `UpdateFirstRunComplete` call.
- **Org repositories** (`org_repo_test.go`): integration tests on the existing `withTx` harness — org CRUD with soft-delete semantics, member CRUD, `ErrNotFound` mapping, and the two-step `SetPrimary` atomic flip (ADR-005), verified from both the promoted and demoted side.

## Testing

- [x] Quality checks pass — `task ci` green (lint, tests, AGENTS.md sync, 15.19 MB binary within budget, govulncheck clean)
- [x] Integration tests executed against a real `postgres:15` with the auth stub + all migrations applied (CI-equivalent setup), all passing
- [x] Handler tests pass with `-race`

## Checklist

- [x] Changes are in scope for this branch (test-only; no production code touched)
- [x] No security vulnerabilities introduced
- [x] `gofmt` clean, golangci-lint passing
- [x] Tests added for previously untested functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)
