### PR TITLE
fix(db): move RLS helper out of Supabase-reserved auth schema

### DIFF
--- a/migrations/000002_add_basic_rls.down.sql
+++ b/migrations/000002_add_basic_rls.down.sql
@@ -10,7 +10,7 @@ DROP POLICY IF EXISTS organizations_member_select ON organizations;
 DROP POLICY IF EXISTS users_self_access ON users;
 
 -- Drop the helper function
-DROP FUNCTION IF EXISTS auth.user_is_organization_member(uuid);
+DROP FUNCTION IF EXISTS public.user_is_organization_member(uuid);
 
 -- Disable RLS on all tables
 ALTER TABLE users DISABLE ROW LEVEL SECURITY;

--- a/migrations/000002_add_basic_rls.up.sql
+++ b/migrations/000002_add_basic_rls.up.sql
@@ -4,7 +4,7 @@ ALTER TABLE organizations ENABLE ROW LEVEL SECURITY;
 ALTER TABLE organization_members ENABLE ROW LEVEL SECURITY;
 
 -- Create a function to check if the current user has access to an organization
-CREATE OR REPLACE FUNCTION auth.user_is_organization_member(org_id uuid)
+CREATE OR REPLACE FUNCTION public.user_is_organization_member(org_id uuid)
 RETURNS boolean AS $$
 DECLARE
     current_auth_id text;
@@ -41,7 +41,7 @@ CREATE POLICY users_self_access ON users
 -- Allow all users to see organization details if they are a member
 CREATE POLICY organizations_member_select ON organizations
     FOR SELECT
-    USING (auth.user_is_organization_member(id));
+    USING (public.user_is_organization_member(id));
 
 -- Only organization owners or admins can modify organization details
 CREATE POLICY organizations_owner_or_admin_update ON organizations
@@ -59,7 +59,7 @@ CREATE POLICY organizations_owner_or_admin_update ON organizations
 -- Users can see organization members if they are a member of the organization
 CREATE POLICY org_members_select ON organization_members
     FOR SELECT
-    USING (auth.user_is_organization_member(organization_id));
+    USING (public.user_is_organization_member(organization_id));
 
 -- Only organization owners can add/remove members
 CREATE POLICY org_members_owner_modify ON organization_members


### PR DESCRIPTION
## Why

Production migrations fail on hosted Supabase with `permission denied for schema auth` (first seen in db-migrate run 29176663960, the #38 deploy-path verification). Migration 000002 creates `auth.user_is_organization_member()`, but Supabase reserves the `auth` schema — it is owned by `supabase_admin` and the `postgres` role cannot create objects in it.

CI never caught this: the vanilla-Postgres auth stub (`sql/test/auth_stub.sql`) creates the `auth` schema itself, so it is writable there.

## What

- `auth.user_is_organization_member` → `public.user_is_organization_member` in 000002 up/down (4 lines; the function body and the two policies referencing it).
- `auth.uid()` calls are untouched — that's Supabase's own function and stays in `auth`.

## Verification

- Fresh Postgres 16 + auth stub: all 6 migrations apply cleanly
- `migrate down -all` → re-`up` round-trips
- Helper confirmed in `public` schema via pg_proc
- Full RLS/integration test suite green against the migrated schema; `task ci` green

## Deploy note

The failed run left production dirty at version 2; clearing it via SQL editor (`UPDATE schema_migrations SET version = 1, dirty = false;`) is required before the post-merge migration run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)