### PR TITLE
fix(ux): Phase A — revive Alpine under CSP, navigation, login redirect, quiz seeds

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "api",
+      "runtimeExecutable": "go",
+      "runtimeArgs": ["run", "./cmd/api"],
+      "port": 4000
+    }
+  ]
+}

--- a/docs/adr/ADR-014-Security-Patterns-and-Threat-Model.md
+++ b/docs/adr/ADR-014-Security-Patterns-and-Threat-Model.md
@@ -280,6 +280,10 @@ func securityHeadersMiddleware(next http.Handler) http.Handler {
         w.Header().Set("X-XSS-Protection", "1; mode=block")
         
         // Content Security Policy
+        // (Amended 2026-07-12: the live policy is stricter than this sketch —
+        // script-src is 'self' 'unsafe-eval', with inline scripts forbidden.
+        // 'unsafe-eval' is required by Alpine 3's expression engine; see
+        // ADR-028-CSP-Alpine-Compatibility.)
         w.Header().Set("Content-Security-Policy", 
             "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'")
         

--- a/docs/adr/ADR-028-CSP-Alpine-Compatibility.md
+++ b/docs/adr/ADR-028-CSP-Alpine-Compatibility.md
@@ -1,0 +1,74 @@
+# ADR-028: CSP Compatibility with Alpine.js
+
+**Date**: 2026-07-12
+
+## Status
+
+Accepted
+
+## Context
+
+The Content-Security-Policy shipped by `internal/middleware/security.go` locks
+`script-src` to `'self'`. The comment reasoned that HTMX and Alpine.js are
+self-hosted script *files*, so nothing more was needed. That reasoning covered
+script **loading** but not script **evaluation**: Alpine 3's expression engine
+compiles every `x-data`, `x-show`, `x-on`, and `x-init` attribute with the
+`Function` constructor, which CSP treats as `eval`. Without `'unsafe-eval'`,
+every Alpine expression throws
+`Alpine Expression Error: ... 'unsafe-eval' is not an allowed source`.
+
+The failure was invisible while the demo was hardcoded stubs. The 2026-07-12
+design review of the ADR-024 surfaces found the entire Alpine layer dead in
+every environment: the dark-mode toggle (and its persistence), the user menu,
+toast notifications, the showcase source tabs, inline validation, bulk
+selection, and the flashcard flip. Two inline `<script>` blocks in the base
+layout (the loading-indicator wiring and an `alpine:init` placeholder) were
+also silently blocked, because `script-src` without `'unsafe-inline'` or a
+nonce forbids inline script bodies.
+
+This is a direct conflict between two Accepted ADRs: ADR-014 (strict CSP) and
+ADR-007/ADR-012 (Alpine.js is the sanctioned client-interactivity layer).
+
+## Decision
+
+1. **Add `'unsafe-eval'` to `script-src`** — the policy becomes
+   `script-src 'self' 'unsafe-eval'`. This is Alpine's documented supported
+   posture for the standard build.
+2. **Keep inline scripts forbidden** — `script-src` does not gain
+   `'unsafe-inline'`. The base layout's inline `<script>` blocks move into the
+   self-hosted `app.js`; templates may only ship behavior as Alpine attributes
+   or external files. A server test pins this (no `<script>` without `src`).
+3. All other directives are unchanged (`default-src 'self'`,
+   `form-action 'self'`, `frame-ancestors 'none'`, …).
+
+## Consequences
+
+- Alpine works; the ADR-007/012 frontend bet is functional again.
+- `'unsafe-eval'` weakens CSP as a defense-in-depth layer: an attacker who can
+  already inject markup could evaluate expressions. The primary XSS defense in
+  this stack is templ's contextual auto-escaping (ADR-017) plus input
+  validation (ADR-014 §2); CSP remains effective against foreign-origin
+  script injection, inline handlers, and clickjacking.
+- The no-inline-scripts rule becomes testable and tested — future templates
+  cannot quietly reintroduce inline `<script>`.
+
+## Alternatives Considered
+
+- **Alpine CSP build (`@alpinejs/csp`).** Eval-free, but it forbids inline
+  expressions entirely — every `x-data="{ open: false }"` in the codebase
+  (and in the pattern showcase's teaching material) would need to become a
+  registered `Alpine.data()` component. That rewrites the exact idiom the
+  starter exists to demonstrate, and the showcase would then teach a
+  non-standard Alpine dialect. Rejected.
+- **Nonce-based script-src.** Nonces authorize inline script *blocks*, not
+  `Function`-constructor evaluation — it does not fix Alpine, only the two
+  inline scripts, which move to `app.js` anyway. Rejected as insufficient.
+- **Drop Alpine for vanilla JS.** Contradicts ADR-007/ADR-012 and the
+  product's HTMX+Alpine positioning. Rejected.
+
+## References
+
+- [ADR-007](ADR-007-Frontend-Stack-Selection.md), [ADR-012](ADR-012-Routing-and-UI-Patterns.md) — Alpine's role
+- [ADR-014](ADR-014-Security-Patterns-and-Threat-Model.md) — the CSP this amends (amendment note added there)
+- [ADR-017](ADR-017-Templ-Adoption.md) — templ escaping as the primary XSS defense
+- Alpine.js docs, "Content Security Policy" — the standard build requires `'unsafe-eval'`

--- a/internal/middleware/auth_middleware.go
+++ b/internal/middleware/auth_middleware.go
@@ -19,6 +19,19 @@ const ( // Renamed key to avoid potential conflict with other string values
 	ContextUserKey UserContextKey = "user"
 )
 
+// toLogin sends an unauthenticated requester to the login page. Browsers get
+// a real redirect (a plain-text 401 is a dead end for a person following a
+// link); HTMX requests get the 401 + HX-Redirect contract instead, because
+// HTMX treats a 3xx as a fragment to swap, not a navigation (ADR-028 review).
+func toLogin(w http.ResponseWriter, r *http.Request) {
+	if view.IsHTMXRequest(r) {
+		view.SetHXRedirect(w, "/auth/page")
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+	http.Redirect(w, r, "/auth/page", http.StatusSeeOther)
+}
+
 // AuthMiddleware validates the JWT token from Supabase. secureCookie marks the
 // cookies it clears on a failed validation Secure, matching how the login and
 // CSRF cookies are issued (ADR-025: TLS terminates at the edge, so r.TLS is nil
@@ -28,47 +41,25 @@ func AuthMiddleware(authClient *auth.AuthClient, secureCookie bool) func(next ht
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// 1. Get token from cookie
 			cookie, err := r.Cookie("sb-access-token") // Default Supabase cookie name
-			if err != nil {
-				slog.Debug("Unauthorized: no access token cookie", "error", err)
-				// If HTMX request, maybe return a trigger to redirect, otherwise 401
-				if view.IsHTMXRequest(r) {
-					view.SetHXRedirect(w, "/auth/page") // Redirect to login
-					w.WriteHeader(http.StatusUnauthorized)
-				} else {
-					http.Error(w, "Unauthorized", http.StatusUnauthorized)
-				}
+			if err != nil || cookie.Value == "" {
+				slog.Debug("Unauthenticated: no access token cookie")
+				toLogin(w, r)
 				return
 			}
-
 			accessToken := cookie.Value
-			if accessToken == "" {
-				slog.Debug("Unauthorized: access token cookie is empty")
-				if view.IsHTMXRequest(r) {
-					view.SetHXRedirect(w, "/auth/page")
-					w.WriteHeader(http.StatusUnauthorized)
-				} else {
-					http.Error(w, "Unauthorized", http.StatusUnauthorized)
-				}
-				return
-			}
 
 			// 2. Validate token by getting user info
 			// The GetUser method implicitly validates the token.
 			// We use the underlying gotrue client here.
 			user, err := authClient.Client.Auth.WithToken(accessToken).GetUser()
 			if err != nil {
-				slog.Warn("Unauthorized: token validation failed", "error", err)
+				slog.Warn("Unauthenticated: token validation failed", "error", err)
 				// Clear potentially invalid cookies and redirect. Mirror the
 				// full attribute set used when issuing them so the browser
 				// reliably matches and drops the cookie.
 				http.SetCookie(w, &http.Cookie{Name: "sb-access-token", Value: "", Path: "/", MaxAge: -1, HttpOnly: true, Secure: secureCookie, SameSite: http.SameSiteLaxMode})
 				http.SetCookie(w, &http.Cookie{Name: "sb-refresh-token", Value: "", Path: "/", MaxAge: -1, HttpOnly: true, Secure: secureCookie, SameSite: http.SameSiteLaxMode})
-				if view.IsHTMXRequest(r) {
-					view.SetHXRedirect(w, "/auth/page")
-					w.WriteHeader(http.StatusUnauthorized)
-				} else {
-					http.Error(w, "Unauthorized", http.StatusUnauthorized)
-				}
+				toLogin(w, r)
 				return
 			}
 

--- a/internal/middleware/auth_middleware_test.go
+++ b/internal/middleware/auth_middleware_test.go
@@ -1,0 +1,82 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestAuthMiddleware_UnauthenticatedNavigation pins the ADR-028/Phase-A UX
+// fix: a browser user navigating to a protected page without a session gets
+// redirected to the login page, not a plain-text 401. The HTMX path keeps
+// its 401 + HX-Redirect contract (HTMX won't follow a 3xx to swap a page).
+// All rows exercise the no-cookie path, which never touches GoTrue, so a nil
+// auth client is safe.
+func TestAuthMiddleware_UnauthenticatedNavigation(t *testing.T) {
+	tests := []struct {
+		name           string
+		method         string
+		htmx           bool
+		emptyCookie    bool // cookie present but empty value
+		wantStatus     int
+		wantLocation   string
+		wantHXRedirect string
+	}{
+		{
+			name:         "browser GET redirects to login",
+			method:       http.MethodGet,
+			wantStatus:   http.StatusSeeOther,
+			wantLocation: "/auth/page",
+		},
+		{
+			name:         "browser POST redirects to login",
+			method:       http.MethodPost,
+			wantStatus:   http.StatusSeeOther,
+			wantLocation: "/auth/page",
+		},
+		{
+			name:         "empty cookie value behaves like no cookie",
+			method:       http.MethodGet,
+			emptyCookie:  true,
+			wantStatus:   http.StatusSeeOther,
+			wantLocation: "/auth/page",
+		},
+		{
+			name:           "HTMX request keeps 401 with HX-Redirect",
+			method:         http.MethodGet,
+			htmx:           true,
+			wantStatus:     http.StatusUnauthorized,
+			wantHXRedirect: "/auth/page",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				t.Error("next handler must not run without a session")
+			})
+			h := AuthMiddleware(nil, false)(next)
+
+			req := httptest.NewRequest(tt.method, "/learn/quiz", nil)
+			if tt.emptyCookie {
+				req.AddCookie(&http.Cookie{Name: "sb-access-token", Value: ""})
+			}
+			if tt.htmx {
+				req.Header.Set("HX-Request", "true")
+			}
+			rec := httptest.NewRecorder()
+
+			h.ServeHTTP(rec, req)
+
+			if rec.Code != tt.wantStatus {
+				t.Fatalf("%s status = %d, want %d", tt.method, rec.Code, tt.wantStatus)
+			}
+			if got := rec.Header().Get("Location"); got != tt.wantLocation {
+				t.Errorf("Location = %q, want %q", got, tt.wantLocation)
+			}
+			if got := rec.Header().Get("HX-Redirect"); got != tt.wantHXRedirect {
+				t.Errorf("HX-Redirect = %q, want %q", got, tt.wantHXRedirect)
+			}
+		})
+	}
+}

--- a/internal/middleware/security.go
+++ b/internal/middleware/security.go
@@ -11,8 +11,10 @@ import "net/http"
 //
 // CSP note: 'unsafe-inline' is required for style-src because Tailwind CSS
 // generates utility classes that may be applied via style attributes.
-// script-src is locked to 'self' only — HTMX and Alpine.js are loaded as
-// script files, not inline scripts, so unsafe-inline is not needed for scripts.
+// script-src carries 'unsafe-eval' because Alpine 3 compiles x-data/x-show
+// expressions with the Function constructor (ADR-028) — without it every
+// Alpine behavior fails silently. Inline <script> blocks stay forbidden
+// (no 'unsafe-inline' for scripts): behavior lives in self-hosted files.
 func SecurityHeaders(isProd bool) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -25,7 +27,7 @@ func SecurityHeaders(isProd bool) func(http.Handler) http.Handler {
 			w.Header().Set("Permissions-Policy", "camera=(), microphone=(), geolocation=()")
 			w.Header().Set("Content-Security-Policy",
 				"default-src 'self'; "+
-					"script-src 'self'; "+
+					"script-src 'self' 'unsafe-eval'; "+
 					"style-src 'self' 'unsafe-inline'; "+
 					"img-src 'self' data:; "+
 					"font-src 'self'; "+

--- a/internal/middleware/security_test.go
+++ b/internal/middleware/security_test.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -49,5 +50,35 @@ func TestSecurityHeaders(t *testing.T) {
 				t.Errorf("Strict-Transport-Security = %q, want unset outside production", hsts)
 			}
 		})
+	}
+}
+
+// TestSecurityHeaders_CSPAllowsAlpineEval pins the ADR-028 decision: Alpine 3
+// evaluates x-data/x-show expressions with the Function constructor, so
+// script-src must include 'unsafe-eval' or every Alpine behavior in the app
+// (dark mode, menus, toasts, tabs) fails silently. Inline scripts stay
+// forbidden — script-src must NOT gain 'unsafe-inline'.
+func TestSecurityHeaders_CSPAllowsAlpineEval(t *testing.T) {
+	h := SecurityHeaders(false)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	csp := rec.Header().Get("Content-Security-Policy")
+	scriptSrc := ""
+	for _, directive := range strings.Split(csp, ";") {
+		if d := strings.TrimSpace(directive); strings.HasPrefix(d, "script-src ") {
+			scriptSrc = d
+		}
+	}
+	if scriptSrc == "" {
+		t.Fatalf("CSP %q has no script-src directive", csp)
+	}
+	if !strings.Contains(scriptSrc, "'unsafe-eval'") {
+		t.Errorf("script-src = %q, must include 'unsafe-eval' (Alpine expression engine, ADR-028)", scriptSrc)
+	}
+	if strings.Contains(scriptSrc, "'unsafe-inline'") {
+		t.Errorf("script-src = %q, must NOT include 'unsafe-inline' (ADR-028 keeps inline scripts forbidden)", scriptSrc)
 	}
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -3,6 +3,8 @@ package server
 import (
 	"net/http"
 	"net/http/httptest"
+	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/clownware/go-performance-starter/internal/config"
@@ -136,5 +138,41 @@ func TestServer_HSTSGating(t *testing.T) {
 				t.Errorf("ENV=%s: HSTS present = %v, want %v", tt.env, got, tt.wantHSTS)
 			}
 		})
+	}
+}
+
+// TestServer_NavAndBrand pins the Phase-A UX fixes: the header carries the
+// real project name and links to every demo surface (the /learn hrefs are
+// static layout markup, so they render even when auth is disabled), and no
+// page ships inline <script> blocks — script-src forbids them (ADR-028), so
+// behavior must live in external files.
+func TestServer_NavAndBrand(t *testing.T) {
+	srv := newTestServer(t, "development")
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET / status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+
+	for _, want := range []string{
+		"Go Performance Starter",
+		`href="/patterns"`,
+		`href="/learn/quiz"`,
+		`href="/learn/flashcards"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("GET / body missing %q", want)
+		}
+	}
+	if strings.Contains(body, "Micro SaaS Starter") {
+		t.Error("GET / still carries the stale 'Micro SaaS Starter' brand")
+	}
+
+	// Every <script> must have a src attribute; inline bodies are CSP-blocked.
+	for _, m := range regexp.MustCompile(`<script[^>]*>`).FindAllString(body, -1) {
+		if !strings.Contains(m, "src=") {
+			t.Errorf("inline script tag %q would be blocked by script-src 'self' (ADR-028)", m)
+		}
 	}
 }

--- a/internal/view/layouts/base.templ
+++ b/internal/view/layouts/base.templ
@@ -111,31 +111,25 @@ templ Base(props view.BaseProps) {
 				</div>
 			</main>
 			@footer(props)
-			<!-- App scripts -->
+			<!-- App scripts: all behavior lives in external files or Alpine
+			     attributes; inline script blocks are CSP-forbidden (ADR-028) -->
 			<script src="/static/js/app.js" defer></script>
 			@htmxLoadingIndicator()
 			@toastNotifications()
-			<!-- Alpine.js initialization -->
-			<script>
-				document.addEventListener('alpine:init', () => {
-					// Alpine.js data and components can be registered here
-				});
-			</script>
 		</body>
 	</html>
 }
 
 templ header(props view.BaseProps) {
-	<header class="bg-surface text-text dark:bg-surface-dark dark:text-text-dark shadow">
+	<header class="bg-surface text-text dark:bg-surface-dark dark:text-text-dark shadow" x-data="{ navOpen: false }">
 		<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
 			<div class="flex justify-between items-center">
 				<div class="flex items-center space-x-4">
 					<a href="/" class="text-xl font-bold text-primary-600">
-						Micro SaaS Starter
+						Go Performance Starter
 					</a>
-					<nav class="hidden md:flex space-x-4" role="navigation">
-						<a href="/" class="px-3 py-2 rounded-md text-sm font-medium text-text hover:bg-gray-100 dark:text-text-dark dark:hover:bg-gray-800" aria-current="page">Home</a>
-						<a href="/dashboard" class="px-3 py-2 rounded-md text-sm font-medium text-text hover:bg-gray-100 dark:text-text-dark dark:hover:bg-gray-800">Dashboard</a>
+					<nav class="hidden md:flex space-x-4" role="navigation" aria-label="Primary">
+						@navLinks()
 					</nav>
 				</div>
 				<div class="flex items-center space-x-4">
@@ -146,11 +140,39 @@ templ header(props view.BaseProps) {
 						} else {
 							<a href="/auth/page" class="px-3 py-2 rounded-md text-sm font-medium text-text hover:bg-gray-100 dark:text-text-dark dark:hover:bg-gray-800">Sign In</a>
 						}
+						<button
+							type="button"
+							class="md:hidden rounded-md p-2 text-text dark:text-text-dark hover:bg-gray-100 dark:hover:bg-gray-800 focus:outline-hidden focus:ring-2 focus:ring-primary"
+							@click="navOpen = !navOpen"
+							:aria-expanded="navOpen.toString()"
+							aria-controls="mobile-nav"
+							aria-label="Toggle navigation"
+						>
+							<svg x-show="!navOpen" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
+							</svg>
+							<svg x-show="navOpen" x-cloak class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+							</svg>
+						</button>
 					</div>
 				</div>
 			</div>
+			<nav id="mobile-nav" x-show="navOpen" x-cloak @click.away="navOpen = false" class="md:hidden mt-3 flex flex-col gap-1 pb-2" role="navigation" aria-label="Primary">
+				@navLinks()
+			</nav>
 		</div>
 	</header>
+}
+
+// navLinks is the shared primary navigation, rendered in both the desktop
+// bar and the mobile disclosure panel.
+templ navLinks() {
+	<a href="/" class="px-3 py-2 rounded-md text-sm font-medium text-text hover:bg-gray-100 dark:text-text-dark dark:hover:bg-gray-800">Home</a>
+	<a href="/patterns" class="px-3 py-2 rounded-md text-sm font-medium text-text hover:bg-gray-100 dark:text-text-dark dark:hover:bg-gray-800">Patterns</a>
+	<a href="/learn/quiz" class="px-3 py-2 rounded-md text-sm font-medium text-text hover:bg-gray-100 dark:text-text-dark dark:hover:bg-gray-800">Quiz</a>
+	<a href="/learn/flashcards" class="px-3 py-2 rounded-md text-sm font-medium text-text hover:bg-gray-100 dark:text-text-dark dark:hover:bg-gray-800">Flashcards</a>
+	<a href="/dashboard" class="px-3 py-2 rounded-md text-sm font-medium text-text hover:bg-gray-100 dark:text-text-dark dark:hover:bg-gray-800">Dashboard</a>
 }
 
 templ darkModeToggle() {
@@ -211,18 +233,13 @@ templ footer(props view.BaseProps) {
 	</footer>
 }
 
+// htmxLoadingIndicator is the overlay app.js toggles on htmx:beforeRequest /
+// htmx:afterRequest (the listeners live there — inline scripts are
+// CSP-forbidden per ADR-028).
 templ htmxLoadingIndicator() {
 	<div id="global-loading" class="hidden fixed inset-0 bg-gray-800/50 flex items-center justify-center z-50">
 		<div class="text-white font-semibold">Loading...</div>
 	</div>
-	<script>
-		document.body.addEventListener('htmx:beforeRequest', function() {
-			document.getElementById('global-loading').classList.remove('hidden');
-		});
-		document.body.addEventListener('htmx:afterRequest', function() {
-			document.getElementById('global-loading').classList.add('hidden');
-		});
-	</script>
 }
 
 templ toastNotifications() {

--- a/internal/view/layouts/base_templ.go
+++ b/internal/view/layouts/base_templ.go
@@ -180,7 +180,7 @@ func Base(props view.BaseProps) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<!-- App scripts --><script src=\"/static/js/app.js\" defer></script>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<!-- App scripts: all behavior lives in external files or Alpine\n\t\t\t     attributes; inline script blocks are CSP-forbidden (ADR-028) --><script src=\"/static/js/app.js\" defer></script>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -192,7 +192,7 @@ func Base(props view.BaseProps) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<!-- Alpine.js initialization --><script>\n\t\t\t\tdocument.addEventListener('alpine:init', () => {\n\t\t\t\t\t// Alpine.js data and components can be registered here\n\t\t\t\t});\n\t\t\t</script></body></html>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</body></html>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -221,7 +221,15 @@ func header(props view.BaseProps) templ.Component {
 			templ_7745c5c3_Var6 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<header class=\"bg-surface text-text dark:bg-surface-dark dark:text-text-dark shadow\"><div class=\"max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4\"><div class=\"flex justify-between items-center\"><div class=\"flex items-center space-x-4\"><a href=\"/\" class=\"text-xl font-bold text-primary-600\">Micro SaaS Starter</a><nav class=\"hidden md:flex space-x-4\" role=\"navigation\"><a href=\"/\" class=\"px-3 py-2 rounded-md text-sm font-medium text-text hover:bg-gray-100 dark:text-text-dark dark:hover:bg-gray-800\" aria-current=\"page\">Home</a> <a href=\"/dashboard\" class=\"px-3 py-2 rounded-md text-sm font-medium text-text hover:bg-gray-100 dark:text-text-dark dark:hover:bg-gray-800\">Dashboard</a></nav></div><div class=\"flex items-center space-x-4\"><div class=\"flex items-center gap-6\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<header class=\"bg-surface text-text dark:bg-surface-dark dark:text-text-dark shadow\" x-data=\"{ navOpen: false }\"><div class=\"max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4\"><div class=\"flex justify-between items-center\"><div class=\"flex items-center space-x-4\"><a href=\"/\" class=\"text-xl font-bold text-primary-600\">Go Performance Starter</a><nav class=\"hidden md:flex space-x-4\" role=\"navigation\" aria-label=\"Primary\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = navLinks().Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "</nav></div><div class=\"flex items-center space-x-4\"><div class=\"flex items-center gap-6\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -235,12 +243,51 @@ func header(props view.BaseProps) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<a href=\"/auth/page\" class=\"px-3 py-2 rounded-md text-sm font-medium text-text hover:bg-gray-100 dark:text-text-dark dark:hover:bg-gray-800\">Sign In</a>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<a href=\"/auth/page\" class=\"px-3 py-2 rounded-md text-sm font-medium text-text hover:bg-gray-100 dark:text-text-dark dark:hover:bg-gray-800\">Sign In</a> ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</div></div></div></div></header>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<button type=\"button\" class=\"md:hidden rounded-md p-2 text-text dark:text-text-dark hover:bg-gray-100 dark:hover:bg-gray-800 focus:outline-hidden focus:ring-2 focus:ring-primary\" @click=\"navOpen = !navOpen\" :aria-expanded=\"navOpen.toString()\" aria-controls=\"mobile-nav\" aria-label=\"Toggle navigation\"><svg x-show=\"!navOpen\" class=\"h-6 w-6\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" aria-hidden=\"true\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M4 6h16M4 12h16M4 18h16\"></path></svg> <svg x-show=\"navOpen\" x-cloak class=\"h-6 w-6\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" aria-hidden=\"true\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M6 18L18 6M6 6l12 12\"></path></svg></button></div></div></div><nav id=\"mobile-nav\" x-show=\"navOpen\" x-cloak @click.away=\"navOpen = false\" class=\"md:hidden mt-3 flex flex-col gap-1 pb-2\" role=\"navigation\" aria-label=\"Primary\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = navLinks().Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</nav></div></header>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// navLinks is the shared primary navigation, rendered in both the desktop
+// bar and the mobile disclosure panel.
+func navLinks() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var7 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var7 == nil {
+			templ_7745c5c3_Var7 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<a href=\"/\" class=\"px-3 py-2 rounded-md text-sm font-medium text-text hover:bg-gray-100 dark:text-text-dark dark:hover:bg-gray-800\">Home</a> <a href=\"/patterns\" class=\"px-3 py-2 rounded-md text-sm font-medium text-text hover:bg-gray-100 dark:text-text-dark dark:hover:bg-gray-800\">Patterns</a> <a href=\"/learn/quiz\" class=\"px-3 py-2 rounded-md text-sm font-medium text-text hover:bg-gray-100 dark:text-text-dark dark:hover:bg-gray-800\">Quiz</a> <a href=\"/learn/flashcards\" class=\"px-3 py-2 rounded-md text-sm font-medium text-text hover:bg-gray-100 dark:text-text-dark dark:hover:bg-gray-800\">Flashcards</a> <a href=\"/dashboard\" class=\"px-3 py-2 rounded-md text-sm font-medium text-text hover:bg-gray-100 dark:text-text-dark dark:hover:bg-gray-800\">Dashboard</a>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -264,12 +311,12 @@ func darkModeToggle() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var7 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var7 == nil {
-			templ_7745c5c3_Var7 = templ.NopComponent
+		templ_7745c5c3_Var8 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var8 == nil {
+			templ_7745c5c3_Var8 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<button @click=\"dark = !dark\" :aria-pressed=\"dark\" :class=\"dark ? 'bg-primary text-white' : 'bg-surface text-primary'\" class=\"rounded-full p-2 border-2 border-primary focus:outline-hidden focus:ring-2 focus:ring-primary transition-colors shadow-sm\" title=\"Toggle dark mode\"><img x-show=\"!dark\" x-cloak src=\"/static/img/emblem-black.svg\" alt=\"Enable dark mode\" class=\"h-5 w-5\"> <img x-show=\"dark\" x-cloak src=\"/static/img/emblem-white.svg\" alt=\"Enable light mode\" class=\"h-5 w-5\"></button>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "<button @click=\"dark = !dark\" :aria-pressed=\"dark\" :class=\"dark ? 'bg-primary text-white' : 'bg-surface text-primary'\" class=\"rounded-full p-2 border-2 border-primary focus:outline-hidden focus:ring-2 focus:ring-primary transition-colors shadow-sm\" title=\"Toggle dark mode\"><img x-show=\"!dark\" x-cloak src=\"/static/img/emblem-black.svg\" alt=\"Enable dark mode\" class=\"h-5 w-5\"> <img x-show=\"dark\" x-cloak src=\"/static/img/emblem-white.svg\" alt=\"Enable light mode\" class=\"h-5 w-5\"></button>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -293,38 +340,38 @@ func userMenu(userName string) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var8 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var8 == nil {
-			templ_7745c5c3_Var8 = templ.NopComponent
+		templ_7745c5c3_Var9 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var9 == nil {
+			templ_7745c5c3_Var9 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "<div x-data=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var9 string
-		templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(userMenuData())
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/layouts/base.templ`, Line: 170, Col: 29}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "\" class=\"relative\"><button @click=\"open = !open\" class=\"flex items-center focus:outline-hidden focus:ring-2 focus:ring-primary\" aria-haspopup=\"true\" :aria-expanded=\"open.toString()\" aria-controls=\"user-menu-dropdown\"><span class=\"mr-2 text-text dark:text-text-dark\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<div x-data=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var10 string
-		templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(userName)
+		templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(userMenuData())
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/layouts/base.templ`, Line: 178, Col: 62}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/layouts/base.templ`, Line: 192, Col: 29}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</span> <svg class=\"w-4 h-4 transform transition-transform\" :class=\"{ 'rotate-180': open }\" xmlns=\"http://www.w3.org/2000/svg\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M19 9l-7 7-7-7\"></path></svg></button><div x-show=\"open\" @keydown.escape.window=\"open = false\" @click.away=\"open = false\" class=\"absolute right-0 mt-2 w-48 bg-surface text-text dark:bg-surface-dark dark:text-text-dark shadow-lg rounded-md py-2 z-50\" role=\"menu\" id=\"user-menu-dropdown\" tabindex=\"-1\"><a href=\"/profile\" class=\"block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-800\" role=\"menuitem\" tabindex=\"-1\">Profile</a> <a href=\"/auth/logout\" class=\"block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-800\" role=\"menuitem\" tabindex=\"-1\">Logout</a></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "\" class=\"relative\"><button @click=\"open = !open\" class=\"flex items-center focus:outline-hidden focus:ring-2 focus:ring-primary\" aria-haspopup=\"true\" :aria-expanded=\"open.toString()\" aria-controls=\"user-menu-dropdown\"><span class=\"mr-2 text-text dark:text-text-dark\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var11 string
+		templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(userName)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/layouts/base.templ`, Line: 200, Col: 62}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "</span> <svg class=\"w-4 h-4 transform transition-transform\" :class=\"{ 'rotate-180': open }\" xmlns=\"http://www.w3.org/2000/svg\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M19 9l-7 7-7-7\"></path></svg></button><div x-show=\"open\" @keydown.escape.window=\"open = false\" @click.away=\"open = false\" class=\"absolute right-0 mt-2 w-48 bg-surface text-text dark:bg-surface-dark dark:text-text-dark shadow-lg rounded-md py-2 z-50\" role=\"menu\" id=\"user-menu-dropdown\" tabindex=\"-1\"><a href=\"/profile\" class=\"block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-800\" role=\"menuitem\" tabindex=\"-1\">Profile</a> <a href=\"/auth/logout\" class=\"block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-800\" role=\"menuitem\" tabindex=\"-1\">Logout</a></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -348,25 +395,25 @@ func footer(props view.BaseProps) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var11 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var11 == nil {
-			templ_7745c5c3_Var11 = templ.NopComponent
+		templ_7745c5c3_Var12 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var12 == nil {
+			templ_7745c5c3_Var12 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<footer class=\"bg-surface text-text dark:bg-surface-dark dark:text-text-dark border-t border-gray-200 dark:border-gray-800\"><div class=\"max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6\"><div class=\"flex flex-col md:flex-row justify-between items-center\"><p class=\"text-gray-500 dark:text-gray-400 text-sm\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "<footer class=\"bg-surface text-text dark:bg-surface-dark dark:text-text-dark border-t border-gray-200 dark:border-gray-800\"><div class=\"max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6\"><div class=\"flex flex-col md:flex-row justify-between items-center\"><p class=\"text-gray-500 dark:text-gray-400 text-sm\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var12 string
-		templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(footerCopyright(props.CurrentYear))
+		var templ_7745c5c3_Var13 string
+		templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(footerCopyright(props.CurrentYear))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/layouts/base.templ`, Line: 203, Col: 41}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/layouts/base.templ`, Line: 225, Col: 41}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "</p><div class=\"flex space-x-4 mt-4 md:mt-0\"><a href=\"/terms\" class=\"text-sm text-gray-500 hover:text-text dark:text-gray-400 dark:hover:text-text-dark\">Terms</a> <a href=\"/privacy\" class=\"text-sm text-gray-500 hover:text-text dark:text-gray-400 dark:hover:text-text-dark\">Privacy</a></div></div></div></footer>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "</p><div class=\"flex space-x-4 mt-4 md:mt-0\"><a href=\"/terms\" class=\"text-sm text-gray-500 hover:text-text dark:text-gray-400 dark:hover:text-text-dark\">Terms</a> <a href=\"/privacy\" class=\"text-sm text-gray-500 hover:text-text dark:text-gray-400 dark:hover:text-text-dark\">Privacy</a></div></div></div></footer>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -374,6 +421,9 @@ func footer(props view.BaseProps) templ.Component {
 	})
 }
 
+// htmxLoadingIndicator is the overlay app.js toggles on htmx:beforeRequest /
+// htmx:afterRequest (the listeners live there — inline scripts are
+// CSP-forbidden per ADR-028).
 func htmxLoadingIndicator() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
@@ -390,12 +440,12 @@ func htmxLoadingIndicator() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var13 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var13 == nil {
-			templ_7745c5c3_Var13 = templ.NopComponent
+		templ_7745c5c3_Var14 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var14 == nil {
+			templ_7745c5c3_Var14 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "<div id=\"global-loading\" class=\"hidden fixed inset-0 bg-gray-800/50 flex items-center justify-center z-50\"><div class=\"text-white font-semibold\">Loading...</div></div><script>\n\t\tdocument.body.addEventListener('htmx:beforeRequest', function() {\n\t\t\tdocument.getElementById('global-loading').classList.remove('hidden');\n\t\t});\n\t\tdocument.body.addEventListener('htmx:afterRequest', function() {\n\t\t\tdocument.getElementById('global-loading').classList.add('hidden');\n\t\t});\n\t</script>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "<div id=\"global-loading\" class=\"hidden fixed inset-0 bg-gray-800/50 flex items-center justify-center z-50\"><div class=\"text-white font-semibold\">Loading...</div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -419,38 +469,38 @@ func toastNotifications() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var14 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var14 == nil {
-			templ_7745c5c3_Var14 = templ.NopComponent
+		templ_7745c5c3_Var15 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var15 == nil {
+			templ_7745c5c3_Var15 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "<div x-data=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var15 string
-		templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(toastData())
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/layouts/base.templ`, Line: 230, Col: 22}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "\" x-init=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "<div x-data=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var16 string
-		templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(toastInit())
+		templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(toastData())
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/layouts/base.templ`, Line: 231, Col: 22}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/layouts/base.templ`, Line: 247, Col: 22}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "\" class=\"fixed bottom-4 right-4 z-50 flex flex-col space-y-3 items-end\" aria-live=\"polite\" aria-atomic=\"true\"><template x-for=\"toast in toasts\" :key=\"toast.id\"><div x-show=\"true\" x-transition:enter=\"transition ease-out duration-300\" x-transition:enter-start=\"opacity-0 translate-y-4\" x-transition:enter-end=\"opacity-100 translate-y-0\" x-transition:leave=\"transition ease-in duration-200\" x-transition:leave-start=\"opacity-100\" x-transition:leave-end=\"opacity-0\" :class=\"{\n\t\t\t\t\t'bg-green-600 text-white': toast.type === 'success',\n\t\t\t\t\t'bg-red-600 text-white': toast.type === 'error',\n\t\t\t\t\t'bg-yellow-500 text-black': toast.type === 'warning'\n\t\t\t\t}\" class=\"shadow-lg rounded px-4 py-2 min-w-[200px] flex items-center gap-2 animate-fade\" role=\"status\"><template x-if=\"toast.type === 'success'\"><span aria-hidden=\"true\">&#10003;</span></template><template x-if=\"toast.type === 'error'\"><span aria-hidden=\"true\">!</span></template><template x-if=\"toast.type === 'warning'\"><span aria-hidden=\"true\">&#9888;</span></template><span x-text=\"toast.msg\"></span></div></template></div><style>\n\t\t@keyframes fade {\n\t\t\tfrom { opacity: 0; }\n\t\t\tto { opacity: 1; }\n\t\t}\n\t\t.animate-fade {\n\t\t\tanimation: fade 0.5s;\n\t\t}\n\t</style>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "\" x-init=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var17 string
+		templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(toastInit())
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/layouts/base.templ`, Line: 248, Col: 22}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "\" class=\"fixed bottom-4 right-4 z-50 flex flex-col space-y-3 items-end\" aria-live=\"polite\" aria-atomic=\"true\"><template x-for=\"toast in toasts\" :key=\"toast.id\"><div x-show=\"true\" x-transition:enter=\"transition ease-out duration-300\" x-transition:enter-start=\"opacity-0 translate-y-4\" x-transition:enter-end=\"opacity-100 translate-y-0\" x-transition:leave=\"transition ease-in duration-200\" x-transition:leave-start=\"opacity-100\" x-transition:leave-end=\"opacity-0\" :class=\"{\n\t\t\t\t\t'bg-green-600 text-white': toast.type === 'success',\n\t\t\t\t\t'bg-red-600 text-white': toast.type === 'error',\n\t\t\t\t\t'bg-yellow-500 text-black': toast.type === 'warning'\n\t\t\t\t}\" class=\"shadow-lg rounded px-4 py-2 min-w-[200px] flex items-center gap-2 animate-fade\" role=\"status\"><template x-if=\"toast.type === 'success'\"><span aria-hidden=\"true\">&#10003;</span></template><template x-if=\"toast.type === 'error'\"><span aria-hidden=\"true\">!</span></template><template x-if=\"toast.type === 'warning'\"><span aria-hidden=\"true\">&#9888;</span></template><span x-text=\"toast.msg\"></span></div></template></div><style>\n\t\t@keyframes fade {\n\t\t\tfrom { opacity: 0; }\n\t\t\tto { opacity: 1; }\n\t\t}\n\t\t.animate-fade {\n\t\t\tanimation: fade 0.5s;\n\t\t}\n\t</style>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/migrations/000007_seed_quiz_questions.down.sql
+++ b/migrations/000007_seed_quiz_questions.down.sql
@@ -1,0 +1,14 @@
+-- Remove the seeded quiz questions (attempts/flashcards cascade or null out
+-- per the FKs in 000003).
+DELETE FROM quiz_questions WHERE slug IN (
+    'chi-middleware-order',
+    'rate-limit-tiers',
+    'typed-props',
+    'progressive-enhancement',
+    'rls-scoping',
+    'sqlc-repositories',
+    'templ-compilation',
+    'htmx-fragments',
+    'performance-budgets',
+    'guest-identities'
+);

--- a/migrations/000007_seed_quiz_questions.up.sql
+++ b/migrations/000007_seed_quiz_questions.up.sql
@@ -1,0 +1,87 @@
+-- Seed the architecture quiz (ADR-024): the questions ARE the explainer's
+-- teachable spine — two per topic across the request's journey through the
+-- stack (routing → handlers → database/RLS → frontend → performance/auth).
+-- Idempotent by slug so re-running (or a pre-existing row) is harmless.
+
+INSERT INTO quiz_questions (slug, topic, prompt, choices, correct_index, explanation) VALUES
+(
+    'chi-middleware-order',
+    'routing',
+    'Where is the HTTP middleware stack assembled?',
+    '["In internal/server via chi''s Use chain, in a deliberate order", "Each handler wraps itself in what it needs", "In the reverse proxy config", "A code generator wires it at build time"]',
+    0,
+    'setupMiddleware in internal/server/server.go composes security headers, request ID, client-IP resolution, rate limiting, compression, metrics, logging, recovery, timeout, and CSRF — and the order matters (the rate limiter must see the real client IP, so RealIP runs first).'
+),
+(
+    'rate-limit-tiers',
+    'routing',
+    'How do sensitive endpoints get stricter rate limits than the rest of the app?',
+    '["A second RateLimiter middleware wraps just that route group, on top of the global one", "The global limiter is tuned down for everyone", "They don''t — one limit fits all", "A CDN handles it"]',
+    0,
+    'The global limiter guards everything; credential endpoints and the anonymous-writable /learn group each add a stricter tier by wrapping their chi route group with another RateLimiter (ADR-014, ADR-024).'
+),
+(
+    'typed-props',
+    'handlers',
+    'How does a handler pass data into a template?',
+    '["A typed props struct compiled by templ", "map[string]interface{}", "A JSON string the template parses", "Package-level template variables"]',
+    0,
+    'Every view takes a typed props struct — templ compiles templates to Go, so a missing or mistyped field is a build error, and map[string]interface{} is forbidden (ADR-017).'
+),
+(
+    'progressive-enhancement',
+    'handlers',
+    'What happens to the quiz answer form when JavaScript is disabled?',
+    '["It posts normally and the server renders a full result page", "It breaks — HTMX is required", "Nothing happens silently", "A bundled SPA takes over"]',
+    0,
+    'Every mutation is a plain POST form; HTMX is an enhancement that swaps just the card when available. Pages must work without JS (ADR-007, ADR-012).'
+),
+(
+    'rls-scoping',
+    'database',
+    'What stops one user from reading another user''s flashcards?',
+    '["Postgres Row Level Security, evaluated from the request''s JWT claims", "A WHERE clause every handler must remember to add", "Filtering in Go after the query", "Nothing — it''s a demo"]',
+    0,
+    'Repository methods run inside a transaction that applies the requester''s JWT claims (SET LOCAL ROLE + request.jwt.claims), so auth.uid()-based policies scope every query at the database layer (ADR-004).'
+),
+(
+    'sqlc-repositories',
+    'database',
+    'How does SQL enter this codebase?',
+    '["Written in sql/queries/ and compiled to typed Go by sqlc, behind repository interfaces", "String concatenation in handlers", "An ORM builds it at runtime", "Stored procedures only"]',
+    0,
+    'sqlc generates type-checked Go from the queries in sql/queries/; handlers only see repository interfaces, so hand-written SQL strings never appear in request code (ADR-003).'
+),
+(
+    'templ-compilation',
+    'frontend',
+    'What is a templ template at build time?',
+    '["Type-checked Go code", "A text file parsed on every request", "JSX transpiled to JavaScript", "A YAML schema"]',
+    0,
+    'templ generates Go source from .templ files — rendering is a compiled function call with contextual auto-escaping, not runtime string templating (ADR-017).'
+),
+(
+    'htmx-fragments',
+    'frontend',
+    'How does the pattern showcase update the page without a reload?',
+    '["Handlers return HTML fragments that HTMX swaps into a target element", "JSON APIs plus client-side rendering", "WebSockets push a virtual DOM", "Hidden iframes"]',
+    0,
+    'The server stays the single source of rendered HTML: an hx-get/hx-post returns a fragment and hx-target/hx-swap places it — no client templating layer (ADR-007, ADR-012).'
+),
+(
+    'performance-budgets',
+    'performance',
+    'Where do the performance budgets live, and where do they bite?',
+    '["Constants in internal/performance/, enforced by task ci", "A wiki page nobody reads", "Only in the README", "They''re aspirational everywhere"]',
+    0,
+    'ADR-000 classifies every budget as Enforced, Monitored, or Aspirational: binary size, Docker image size, and gzipped JS/CSS fail CI on violation via task ci; response times are observed via Prometheus.'
+),
+(
+    'guest-identities',
+    'auth',
+    'What identity does an anonymous demo visitor get?',
+    '["A real Supabase user, created server-side via GoTrue anonymous sign-in", "A cookie-only fake session", "A shared demo account", "None — reads only"]',
+    0,
+    'Guests are real anonymous identities so RLS and per-user CRUD are genuinely exercised — the same users_self_access policy covers guests and registered accounts, and a TTL reaper cleans up inactive ones (ADR-024).'
+)
+ON CONFLICT (slug) DO NOTHING;

--- a/web/static/css/input.css
+++ b/web/static/css/input.css
@@ -43,6 +43,14 @@
 /* Semantic color CSS variables (dark mode switching) */
 @import "./semantic-colors.css";
 
+/* Alpine.js: hide x-cloak elements until Alpine initializes — without this
+   rule the attribute does nothing and hidden panels flash on load. */
+@layer base {
+  [x-cloak] {
+    display: none !important;
+  }
+}
+
 /* Restore v3 default border color behavior */
 @layer base {
   *,

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -31,3 +31,15 @@ document.addEventListener('htmx:afterSwap', (event) => {
 document.addEventListener('DOMContentLoaded', () => {
   console.log('Go Performance Starter loaded');
 });
+
+// Global HTMX loading indicator — the overlay markup lives in the base
+// layout; the listeners live here because inline <script> is CSP-forbidden
+// (ADR-028). Events bubble to document, so this covers swapped content too.
+document.addEventListener('htmx:beforeRequest', () => {
+  const el = document.getElementById('global-loading');
+  if (el) el.classList.remove('hidden');
+});
+document.addEventListener('htmx:afterRequest', () => {
+  const el = document.getElementById('global-loading');
+  if (el) el.classList.add('hidden');
+});


### PR DESCRIPTION
## What

Phase A of the post-merge UX/design review: makes the demo actually *work* in a browser. Fixes the CSP/Alpine conflict that silently killed all client interactivity, adds the missing navigation, replaces the unauthenticated 401 dead-end with a login redirect, and seeds the quiz.

## Why

The 2026-07-12 design review found `script-src 'self'` blocks Alpine 3's expression engine — every Alpine behavior (dark mode, user menu, toasts, source tabs, validation, flip cards) failed silently in **all** environments, and the base layout's two inline `<script>` blocks were CSP-blocked too. Separately: the new demo surfaces had no nav links (and mobile had no nav at all), direct navigation to `/learn/*` returned plain-text `401 Unauthorized`, the header still said "Micro SaaS Starter", and `quiz_questions` had no rows.

## How

- **[ADR-028](docs/adr/ADR-028-CSP-Alpine-Compatibility.md)** (new, with an amendment note in ADR-014): `script-src` becomes `'self' 'unsafe-eval'` — Alpine's documented supported posture. Inline scripts stay forbidden, now **pinned by a server test** (no `<script>` without `src`); the loading-indicator wiring moved to `app.js` and the `alpine:init` placeholder was deleted. templ auto-escaping remains the primary XSS defense; the CSP-build and nonce alternatives are recorded and rejected in the ADR.
- **`[x-cloak] { display: none !important }`** added — the attribute was used in three places but the rule never existed.
- **AuthMiddleware**: browser requests without a session `303` to `/auth/page`; HTMX keeps `401` + `HX-Redirect`. Table-driven middleware test added (nil client is safe on the no-cookie path).
- **Header**: brand corrected to "Go Performance Starter"; primary nav gains Patterns / Quiz / Flashcards; mobile gets an accessible disclosure hamburger (`aria-expanded`/`aria-controls`, `@click.away`).
- **Migration 000007** seeds ten quiz questions — two per explainer topic (routing, handlers, database/RLS, frontend, performance/auth), `ON CONFLICT (slug) DO NOTHING` so it's idempotent; the down migration deletes by slug.

## Testing

- [x] Failing tests first (ADR-020/023): CSP `unsafe-eval` assertion, auth-redirect table, nav/brand/no-inline-scripts server test
- [x] `task ci` green (race tests incl. RLS integration, binary 15.36MB/20MB, JS 32.0KB/50KB + CSS 7.7KB/30KB gzipped, govulncheck clean)
- [x] Verified live in a browser: dark mode toggles + persists, source tabs switch, mobile menu opens with correct ARIA, `/learn/quiz` redirects to login, console free of CSP errors, seed rows present

## Found Work (not in this PR)

- **Static assets have no cache-busting**: CSS/JS ship `Cache-Control: max-age=31536000` on stable URLs, so returning visitors keep stale assets after every deploy (bit me during verification). Needs fingerprinting or a version query param — proposing it for Phase B alongside the token work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)