### PR TITLE
fix(ci): deploy via Fly registry mirror — GHCR private images are unpullable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,6 +105,32 @@ jobs:
         if: env.FLY_API_TOKEN != ''
         uses: superfly/flyctl-actions/setup-flyctl@dfdfedc86b296f5e5384f755a18bf400409a15d0 # v1.4
 
+      # Fly can only pull public images or its own registry. GHCR packages
+      # default to private (and stay private on forks), so deploying straight
+      # from ghcr.io fails with "Authentication required" — v0.3.0 and v0.4.0
+      # both died here. Mirror the exact image that passed the budget check
+      # into registry.fly.io and deploy that; GHCR remains the published
+      # artifact of record.
+      - name: Log in to GHCR
+        if: env.FLY_API_TOKEN != ''
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Mirror image to the Fly registry
+        if: env.FLY_API_TOKEN != ''
+        run: |
+          APP=$(sed -n 's/^app *= *"\(.*\)"/\1/p' fly.toml)
+          SRC="ghcr.io/${{ github.repository }}:${{ github.ref_name }}"
+          DST="registry.fly.io/${APP}:${{ github.ref_name }}"
+          docker pull "$SRC"
+          docker tag "$SRC" "$DST"
+          flyctl auth docker
+          docker push "$DST"
+          echo "DEPLOY_IMAGE=$DST" >> "$GITHUB_ENV"
+
       - name: Deploy
         if: env.FLY_API_TOKEN != ''
-        run: flyctl deploy --remote-only --image ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+        run: flyctl deploy --image "$DEPLOY_IMAGE"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-07-12
+
+### Fixed
+- Release pipeline deploy step: Fly cannot pull private GHCR images, so
+  `flyctl deploy --image ghcr.io/...` failed with "Authentication required"
+  (v0.3.0 and v0.4.0 both died here; v0.3.1's jobs skipped). The deploy job
+  now mirrors the budget-checked image into `registry.fly.io` and deploys
+  that — works with private packages and on forks; GHCR remains the
+  published artifact
+
 ## [0.4.0] - 2026-07-12
 
 The ADR-024 demo application, live end to end: the visible product finally


### PR DESCRIPTION
## What

Fixes the release pipeline's deploy step and adds the 0.4.1 changelog entry.

## Why

`flyctl deploy --image ghcr.io/...` fails with *"Authentication required to access image"* — Fly can only pull public images or its own registry, and the GHCR package is private (the default, and what every fork will have). This step has failed on **every release that actually reached it**: v0.3.0 and v0.4.0 (v0.3.1's 19-second "success" skipped the jobs). Production migrations for v0.4.0 applied fine; only the deploy died.

## How

The deploy job now logs into GHCR with `GITHUB_TOKEN`, pulls the exact image that passed the 30MB budget check, retags it as `registry.fly.io/<app>:<tag>` (app name read from `fly.toml`), pushes via `flyctl auth docker`, and deploys that image. GHCR remains the published artifact of record; no new secrets required (the app-scoped deploy token can push to the app's registry).

Alternative rejected: making the GHCR package public fixes this repo but leaves the pipeline broken for every fork, and package visibility shouldn't be a deploy prerequisite.

After merge: tagging `v0.4.1` to ship the ADR-024 demo (the `v0.4.0` tag is frozen on the broken workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)