### PR TITLE
fix(assets): version-stamped static URLs — deploys bust the 1-year cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-07-12
+
+### Fixed
+- Static assets are cached for a year but shipped unversioned URLs, so
+  every deploy stranded returning browsers on stale CSS/JS (the cause of
+  three separate misrenders during the 0.5.x design work). Asset references
+  now carry a `?v=` stamp — the build version in releases, a process-start
+  stamp in dev — implementing the versioned-asset assumption ADR-016 was
+  built on
+
 ## [0.5.1] - 2026-07-12
 
 ### Fixed

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/clownware/go-performance-starter/internal/middleware"
 	"github.com/clownware/go-performance-starter/internal/repository/postgres"
 	"github.com/clownware/go-performance-starter/internal/server"
+	"github.com/clownware/go-performance-starter/internal/view"
 )
 
 // version is set at build time via -ldflags "-X main.version=..."
@@ -46,6 +47,10 @@ func main() {
 	// level from LOG_LEVEL (default info)
 	setupLogger(os.Getenv("ENV"), os.Getenv("LOG_LEVEL"))
 	slog.Info("Starting Go Performance Starter", "version", version)
+
+	// Stamp static asset URLs with the build version so each release busts
+	// the 1-year asset cache (ADR-016); dev builds keep a process-start stamp.
+	view.SetAssetVersion(version)
 
 	// Create context that listens for termination signals
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -214,3 +214,23 @@ func TestServer_HomeDirectoryAndBrand(t *testing.T) {
 		t.Error("page references the retired Pezza emblem assets")
 	}
 }
+
+// TestServer_AssetCacheBusting proves rendered pages reference static assets
+// through version-stamped URLs: /static ships a 1-year Cache-Control, so an
+// unstamped reference strands every returning browser on stale CSS/JS after
+// a deploy (ADR-016 assumed versioned assets; this pins the implementation).
+func TestServer_AssetCacheBusting(t *testing.T) {
+	srv := newTestServer(t, "development")
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET / status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+
+	for _, asset := range []string{"app.css", "semantic-colors.css", "htmx.min.js", "alpine.min.js", "app.js"} {
+		if !strings.Contains(body, asset+"?v=") {
+			t.Errorf("asset %s referenced without a cache-busting ?v= stamp", asset)
+		}
+	}
+}

--- a/internal/view/assets.go
+++ b/internal/view/assets.go
@@ -1,0 +1,28 @@
+package view
+
+import (
+	"net/url"
+	"strconv"
+	"time"
+)
+
+// assetVersion stamps static asset URLs so the aggressive /static
+// Cache-Control (1 year, ADR-016) can never strand a returning browser on
+// stale CSS/JS. Releases override it with the build version at boot; the
+// process-start default means dev-server restarts bust caches too.
+var assetVersion = strconv.FormatInt(time.Now().Unix(), 10)
+
+// SetAssetVersion overrides the asset stamp with the build version (main's
+// -X main.version ldflag). Blank and "dev" are not real versions — they keep
+// the process-start default rather than erasing the stamp.
+func SetAssetVersion(v string) {
+	if v == "" || v == "dev" {
+		return
+	}
+	assetVersion = url.QueryEscape(v)
+}
+
+// AssetURL returns the versioned URL for a static asset path.
+func AssetURL(path string) string {
+	return path + "?v=" + assetVersion
+}

--- a/internal/view/assets_test.go
+++ b/internal/view/assets_test.go
@@ -1,0 +1,59 @@
+package view
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestAssetURL pins the cache-busting contract ADR-016 assumes but never
+// implemented: static asset URLs carry a version query so the 1-year
+// Cache-Control can't strand clients on stale CSS/JS across deploys.
+func TestAssetURL(t *testing.T) {
+	tests := []struct {
+		name       string
+		setVersion string // applied via SetAssetVersion when non-empty
+		path       string
+		wantSuffix string // exact suffix when a version is set
+	}{
+		{
+			name:       "release version stamps the URL",
+			setVersion: "v0.5.2",
+			path:       "/static/css/app.css",
+			wantSuffix: "/static/css/app.css?v=v0.5.2",
+		},
+		{
+			name:       "dirty build versions are query-escaped",
+			setVersion: "v0.5.2-3-gabc123 dirty",
+			path:       "/static/js/app.js",
+			wantSuffix: "/static/js/app.js?v=v0.5.2-3-gabc123+dirty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			SetAssetVersion(tt.setVersion)
+			if got := AssetURL(tt.path); got != tt.wantSuffix {
+				t.Errorf("AssetURL(%q) = %q, want %q", tt.path, got, tt.wantSuffix)
+			}
+		})
+	}
+}
+
+// TestAssetURL_Defaults: whatever the current stamp is (process-start default
+// in dev builds), blank and "dev" pseudo-versions must never erase it.
+func TestAssetURL_Defaults(t *testing.T) {
+	SetAssetVersion("") // no-op: keeps the current stamp
+	got := AssetURL("/static/css/app.css")
+	if !strings.HasPrefix(got, "/static/css/app.css?v=") {
+		t.Fatalf("AssetURL without version = %q, want a ?v= stamp from process start", got)
+	}
+	if strings.TrimPrefix(got, "/static/css/app.css?v=") == "" {
+		t.Error("default asset version is empty")
+	}
+
+	before := AssetURL("/static/js/app.js")
+	SetAssetVersion("dev") // ldflags default: not a real version, keep the stamp
+	if after := AssetURL("/static/js/app.js"); after != before {
+		t.Errorf("SetAssetVersion(\"dev\") changed the URL: %q -> %q", before, after)
+	}
+}

--- a/internal/view/layouts/base.templ
+++ b/internal/view/layouts/base.templ
@@ -84,16 +84,16 @@ templ Base(props view.BaseProps) {
 			<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 			<meta name="description" content="Go Performance Starter"/>
 			<title>{ props.Title }</title>
-			<!-- CSS -->
-			<link rel="stylesheet" href="/static/css/app.css"/>
-			<link rel="stylesheet" href="/static/css/semantic-colors.css"/>
+			<!-- CSS: AssetURL stamps ?v= so the 1-year cache busts per release (ADR-016) -->
+			<link rel="stylesheet" href={ view.AssetURL("/static/css/app.css") }/>
+			<link rel="stylesheet" href={ view.AssetURL("/static/css/semantic-colors.css") }/>
 			<!-- Favicon: the mark glyph (bolt on teal); SVG first, PNG fallback -->
-			<link rel="icon" type="image/svg+xml" href="/static/img/mark.svg"/>
-			<link rel="icon" type="image/png" href="/static/img/favicon.png"/>
+			<link rel="icon" type="image/svg+xml" href={ view.AssetURL("/static/img/mark.svg") }/>
+			<link rel="icon" type="image/png" href={ view.AssetURL("/static/img/favicon.png") }/>
 			<!-- HTMX -->
-			<script src="/static/js/htmx.min.js" defer></script>
+			<script src={ view.AssetURL("/static/js/htmx.min.js") } defer></script>
 			<!-- Alpine.js -->
-			<script src="/static/js/alpine.min.js" defer></script>
+			<script src={ view.AssetURL("/static/js/alpine.min.js") } defer></script>
 		</head>
 		<body
 			x-data={ darkModeData() }
@@ -115,7 +115,7 @@ templ Base(props view.BaseProps) {
 			@footer(props)
 			<!-- App scripts: all behavior lives in external files or Alpine
 			     attributes; inline script blocks are CSP-forbidden (ADR-028) -->
-			<script src="/static/js/app.js" defer></script>
+			<script src={ view.AssetURL("/static/js/app.js") } defer></script>
 			@htmxLoadingIndicator()
 			@toastNotifications()
 		</body>

--- a/internal/view/layouts/base_templ.go
+++ b/internal/view/layouts/base_templ.go
@@ -118,46 +118,124 @@ func Base(props view.BaseProps) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</title><!-- CSS --><link rel=\"stylesheet\" href=\"/static/css/app.css\"><link rel=\"stylesheet\" href=\"/static/css/semantic-colors.css\"><!-- Favicon: the mark glyph (bolt on teal); SVG first, PNG fallback --><link rel=\"icon\" type=\"image/svg+xml\" href=\"/static/img/mark.svg\"><link rel=\"icon\" type=\"image/png\" href=\"/static/img/favicon.png\"><!-- HTMX --><script src=\"/static/js/htmx.min.js\" defer></script><!-- Alpine.js --><script src=\"/static/js/alpine.min.js\" defer></script></head><body x-data=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</title><!-- CSS: AssetURL stamps ?v= so the 1-year cache busts per release (ADR-016) --><link rel=\"stylesheet\" href=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var3 string
-		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(darkModeData())
+		var templ_7745c5c3_Var3 templ.SafeURL
+		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinURLErrs(view.AssetURL("/static/css/app.css"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/layouts/base.templ`, Line: 99, Col: 26}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/layouts/base.templ`, Line: 88, Col: 69}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "\" x-init=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "\"><link rel=\"stylesheet\" href=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var4 string
-		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(darkModeInit())
+		var templ_7745c5c3_Var4 templ.SafeURL
+		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinURLErrs(view.AssetURL("/static/css/semantic-colors.css"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/layouts/base.templ`, Line: 100, Col: 26}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/layouts/base.templ`, Line: 89, Col: 81}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "\" hx-headers=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "\"><!-- Favicon: the mark glyph (bolt on teal); SVG first, PNG fallback --><link rel=\"icon\" type=\"image/svg+xml\" href=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var5 string
-		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(csrfHxHeaders(webutil.CSRFTokenFromContext(ctx)))
+		var templ_7745c5c3_Var5 templ.SafeURL
+		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinURLErrs(view.AssetURL("/static/img/mark.svg"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/layouts/base.templ`, Line: 101, Col: 64}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/layouts/base.templ`, Line: 91, Col: 85}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "\" class=\"min-h-screen flex flex-col bg-background dark:bg-background-dark text-text dark:text-text-dark\"><!-- Skip to content link for accessibility --><a href=\"#main-content\" class=\"sr-only focus:not-sr-only focus:absolute focus:p-4 focus:bg-white focus:z-50\">Skip to content</a>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "\"><link rel=\"icon\" type=\"image/png\" href=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var6 templ.SafeURL
+		templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinURLErrs(view.AssetURL("/static/img/favicon.png"))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/layouts/base.templ`, Line: 92, Col: 84}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "\"><!-- HTMX --><script src=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var7 string
+		templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(view.AssetURL("/static/js/htmx.min.js"))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/layouts/base.templ`, Line: 94, Col: 56}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "\" defer></script><!-- Alpine.js --><script src=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var8 string
+		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(view.AssetURL("/static/js/alpine.min.js"))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/layouts/base.templ`, Line: 96, Col: 58}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "\" defer></script></head><body x-data=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var9 string
+		templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(darkModeData())
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/layouts/base.templ`, Line: 99, Col: 26}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "\" x-init=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var10 string
+		templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(darkModeInit())
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/layouts/base.templ`, Line: 100, Col: 26}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "\" hx-headers=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var11 string
+		templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(csrfHxHeaders(webutil.CSRFTokenFromContext(ctx)))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/layouts/base.templ`, Line: 101, Col: 64}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "\" class=\"min-h-screen flex flex-col bg-background dark:bg-background-dark text-text dark:text-text-dark\"><!-- Skip to content link for accessibility --><a href=\"#main-content\" class=\"sr-only focus:not-sr-only focus:absolute focus:p-4 focus:bg-white focus:z-50\">Skip to content</a>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -165,7 +243,7 @@ func Base(props view.BaseProps) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<!-- Main content --><main id=\"main-content\" class=\"flex-grow\"><div class=\"max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<!-- Main content --><main id=\"main-content\" class=\"flex-grow\"><div class=\"max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -173,7 +251,7 @@ func Base(props view.BaseProps) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</div></main>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "</div></main>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -181,7 +259,20 @@ func Base(props view.BaseProps) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<!-- App scripts: all behavior lives in external files or Alpine\n\t\t\t     attributes; inline script blocks are CSP-forbidden (ADR-028) --><script src=\"/static/js/app.js\" defer></script>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "<!-- App scripts: all behavior lives in external files or Alpine\n\t\t\t     attributes; inline script blocks are CSP-forbidden (ADR-028) --><script src=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var12 string
+		templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(view.AssetURL("/static/js/app.js"))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/layouts/base.templ`, Line: 118, Col: 51}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "\" defer></script>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -193,7 +284,7 @@ func Base(props view.BaseProps) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</body></html>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</body></html>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -217,12 +308,12 @@ func header(props view.BaseProps) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var6 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var6 == nil {
-			templ_7745c5c3_Var6 = templ.NopComponent
+		templ_7745c5c3_Var13 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var13 == nil {
+			templ_7745c5c3_Var13 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<header class=\"bg-surface text-text dark:bg-surface-dark dark:text-text-dark shadow\" x-data=\"{ navOpen: false }\"><div class=\"max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4\"><div class=\"flex justify-between items-center\"><div class=\"flex items-center space-x-6\"><!-- Brand lockup: mark always, wordmark from sm up (mark-only on\n\t\t\t\t\t     phones). The mark appears here and nowhere else in the chrome —\n\t\t\t\t\t     controls use functional icons, the footer uses the wordmark. --><a href=\"/\" class=\"flex items-center gap-2\" aria-label=\"Go Performance Starter — home\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<header class=\"bg-surface text-text dark:bg-surface-dark dark:text-text-dark shadow\" x-data=\"{ navOpen: false }\"><div class=\"max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4\"><div class=\"flex justify-between items-center\"><div class=\"flex items-center space-x-6\"><!-- Brand lockup: mark always, wordmark from sm up (mark-only on\n\t\t\t\t\t     phones). The mark appears here and nowhere else in the chrome —\n\t\t\t\t\t     controls use functional icons, the footer uses the wordmark. --><a href=\"/\" class=\"flex items-center gap-2\" aria-label=\"Go Performance Starter — home\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -230,7 +321,7 @@ func header(props view.BaseProps) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<span class=\"text-xl font-bold text-primary-600 whitespace-nowrap hidden sm:inline\">Go Performance Starter</span></a><nav class=\"hidden md:flex space-x-4\" role=\"navigation\" aria-label=\"Primary\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "<span class=\"text-xl font-bold text-primary-600 whitespace-nowrap hidden sm:inline\">Go Performance Starter</span></a><nav class=\"hidden md:flex space-x-4\" role=\"navigation\" aria-label=\"Primary\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -238,7 +329,7 @@ func header(props view.BaseProps) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</nav></div><div class=\"flex items-center space-x-4\"><div class=\"flex items-center gap-6\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "</nav></div><div class=\"flex items-center space-x-4\"><div class=\"flex items-center gap-6\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -252,12 +343,12 @@ func header(props view.BaseProps) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<a href=\"/auth/page\" class=\"px-3 py-2 rounded-md text-sm font-medium whitespace-nowrap text-text hover:bg-gray-100 dark:text-text-dark dark:hover:bg-gray-800\">Sign In</a> ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "<a href=\"/auth/page\" class=\"px-3 py-2 rounded-md text-sm font-medium whitespace-nowrap text-text hover:bg-gray-100 dark:text-text-dark dark:hover:bg-gray-800\">Sign In</a> ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "<button type=\"button\" class=\"md:hidden rounded-md p-2 text-text dark:text-text-dark hover:bg-gray-100 dark:hover:bg-gray-800 focus:outline-hidden focus:ring-2 focus:ring-primary\" @click=\"navOpen = !navOpen\" :aria-expanded=\"navOpen.toString()\" aria-controls=\"mobile-nav\" aria-label=\"Toggle navigation\"><svg x-show=\"!navOpen\" class=\"h-6 w-6\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" aria-hidden=\"true\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M4 6h16M4 12h16M4 18h16\"></path></svg> <svg x-show=\"navOpen\" x-cloak class=\"h-6 w-6\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" aria-hidden=\"true\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M6 18L18 6M6 6l12 12\"></path></svg></button></div></div></div><nav id=\"mobile-nav\" x-show=\"navOpen\" x-cloak @click.away=\"navOpen = false\" class=\"md:hidden mt-3 flex flex-col gap-1 pb-2\" role=\"navigation\" aria-label=\"Primary\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "<button type=\"button\" class=\"md:hidden rounded-md p-2 text-text dark:text-text-dark hover:bg-gray-100 dark:hover:bg-gray-800 focus:outline-hidden focus:ring-2 focus:ring-primary\" @click=\"navOpen = !navOpen\" :aria-expanded=\"navOpen.toString()\" aria-controls=\"mobile-nav\" aria-label=\"Toggle navigation\"><svg x-show=\"!navOpen\" class=\"h-6 w-6\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" aria-hidden=\"true\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M4 6h16M4 12h16M4 18h16\"></path></svg> <svg x-show=\"navOpen\" x-cloak class=\"h-6 w-6\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" aria-hidden=\"true\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M6 18L18 6M6 6l12 12\"></path></svg></button></div></div></div><nav id=\"mobile-nav\" x-show=\"navOpen\" x-cloak @click.away=\"navOpen = false\" class=\"md:hidden mt-3 flex flex-col gap-1 pb-2\" role=\"navigation\" aria-label=\"Primary\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -265,7 +356,7 @@ func header(props view.BaseProps) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "</nav></div></header>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "</nav></div></header>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -292,12 +383,12 @@ func navLinks() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var7 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var7 == nil {
-			templ_7745c5c3_Var7 = templ.NopComponent
+		templ_7745c5c3_Var14 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var14 == nil {
+			templ_7745c5c3_Var14 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "<a href=\"/patterns\" class=\"px-3 py-2 rounded-md text-sm font-medium text-text hover:bg-gray-100 dark:text-text-dark dark:hover:bg-gray-800\">Patterns</a> <a href=\"/learn/quiz\" class=\"px-3 py-2 rounded-md text-sm font-medium text-text hover:bg-gray-100 dark:text-text-dark dark:hover:bg-gray-800\">Quiz</a> <a href=\"/learn/flashcards\" class=\"px-3 py-2 rounded-md text-sm font-medium text-text hover:bg-gray-100 dark:text-text-dark dark:hover:bg-gray-800\">Flashcards</a> <a href=\"/dashboard\" class=\"px-3 py-2 rounded-md text-sm font-medium text-text hover:bg-gray-100 dark:text-text-dark dark:hover:bg-gray-800\">Dashboard</a>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "<a href=\"/patterns\" class=\"px-3 py-2 rounded-md text-sm font-medium text-text hover:bg-gray-100 dark:text-text-dark dark:hover:bg-gray-800\">Patterns</a> <a href=\"/learn/quiz\" class=\"px-3 py-2 rounded-md text-sm font-medium text-text hover:bg-gray-100 dark:text-text-dark dark:hover:bg-gray-800\">Quiz</a> <a href=\"/learn/flashcards\" class=\"px-3 py-2 rounded-md text-sm font-medium text-text hover:bg-gray-100 dark:text-text-dark dark:hover:bg-gray-800\">Flashcards</a> <a href=\"/dashboard\" class=\"px-3 py-2 rounded-md text-sm font-medium text-text hover:bg-gray-100 dark:text-text-dark dark:hover:bg-gray-800\">Dashboard</a>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -323,12 +414,12 @@ func darkModeToggle() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var8 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var8 == nil {
-			templ_7745c5c3_Var8 = templ.NopComponent
+		templ_7745c5c3_Var15 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var15 == nil {
+			templ_7745c5c3_Var15 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<button @click=\"dark = !dark\" :aria-pressed=\"dark\" class=\"rounded-md p-2 text-text dark:text-text-dark hover:bg-gray-100 dark:hover:bg-gray-800 focus:outline-hidden focus:ring-2 focus:ring-primary transition-colors\" title=\"Toggle dark mode\" aria-label=\"Toggle dark mode\"><!-- Sun: shown in light mode --><svg x-show=\"!dark\" class=\"h-5 w-5\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" stroke-width=\"2\" aria-hidden=\"true\"><circle cx=\"12\" cy=\"12\" r=\"4\"></circle> <path stroke-linecap=\"round\" d=\"M12 2v2m0 16v2M4.93 4.93l1.41 1.41m11.32 11.32 1.41 1.41M2 12h2m16 0h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41\"></path></svg><!-- Moon: shown in dark mode --><svg x-show=\"dark\" x-cloak class=\"h-5 w-5\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" stroke-width=\"2\" aria-hidden=\"true\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79Z\"></path></svg></button>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "<button @click=\"dark = !dark\" :aria-pressed=\"dark\" class=\"rounded-md p-2 text-text dark:text-text-dark hover:bg-gray-100 dark:hover:bg-gray-800 focus:outline-hidden focus:ring-2 focus:ring-primary transition-colors\" title=\"Toggle dark mode\" aria-label=\"Toggle dark mode\"><!-- Sun: shown in light mode --><svg x-show=\"!dark\" class=\"h-5 w-5\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" stroke-width=\"2\" aria-hidden=\"true\"><circle cx=\"12\" cy=\"12\" r=\"4\"></circle> <path stroke-linecap=\"round\" d=\"M12 2v2m0 16v2M4.93 4.93l1.41 1.41m11.32 11.32 1.41 1.41M2 12h2m16 0h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41\"></path></svg><!-- Moon: shown in dark mode --><svg x-show=\"dark\" x-cloak class=\"h-5 w-5\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" stroke-width=\"2\" aria-hidden=\"true\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79Z\"></path></svg></button>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -352,38 +443,38 @@ func userMenu(userName string) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var9 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var9 == nil {
-			templ_7745c5c3_Var9 = templ.NopComponent
+		templ_7745c5c3_Var16 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var16 == nil {
+			templ_7745c5c3_Var16 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "<div x-data=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "<div x-data=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var10 string
-		templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(userMenuData())
+		var templ_7745c5c3_Var17 string
+		templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(userMenuData())
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/layouts/base.templ`, Line: 209, Col: 29}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "\" class=\"relative\"><button @click=\"open = !open\" class=\"flex items-center focus:outline-hidden focus:ring-2 focus:ring-primary\" aria-haspopup=\"true\" :aria-expanded=\"open.toString()\" aria-controls=\"user-menu-dropdown\"><span class=\"mr-2 text-text dark:text-text-dark\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "\" class=\"relative\"><button @click=\"open = !open\" class=\"flex items-center focus:outline-hidden focus:ring-2 focus:ring-primary\" aria-haspopup=\"true\" :aria-expanded=\"open.toString()\" aria-controls=\"user-menu-dropdown\"><span class=\"mr-2 text-text dark:text-text-dark\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var11 string
-		templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(userName)
+		var templ_7745c5c3_Var18 string
+		templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(userName)
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/layouts/base.templ`, Line: 217, Col: 62}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "</span> <svg class=\"w-4 h-4 transform transition-transform\" :class=\"{ 'rotate-180': open }\" xmlns=\"http://www.w3.org/2000/svg\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M19 9l-7 7-7-7\"></path></svg></button><div x-show=\"open\" @keydown.escape.window=\"open = false\" @click.away=\"open = false\" class=\"absolute right-0 mt-2 w-48 bg-surface text-text dark:bg-surface-dark dark:text-text-dark shadow-lg rounded-md py-2 z-50\" role=\"menu\" id=\"user-menu-dropdown\" tabindex=\"-1\"><a href=\"/profile\" class=\"block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-800\" role=\"menuitem\" tabindex=\"-1\">Profile</a> <a href=\"/auth/logout\" class=\"block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-800\" role=\"menuitem\" tabindex=\"-1\">Logout</a></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "</span> <svg class=\"w-4 h-4 transform transition-transform\" :class=\"{ 'rotate-180': open }\" xmlns=\"http://www.w3.org/2000/svg\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M19 9l-7 7-7-7\"></path></svg></button><div x-show=\"open\" @keydown.escape.window=\"open = false\" @click.away=\"open = false\" class=\"absolute right-0 mt-2 w-48 bg-surface text-text dark:bg-surface-dark dark:text-text-dark shadow-lg rounded-md py-2 z-50\" role=\"menu\" id=\"user-menu-dropdown\" tabindex=\"-1\"><a href=\"/profile\" class=\"block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-800\" role=\"menuitem\" tabindex=\"-1\">Profile</a> <a href=\"/auth/logout\" class=\"block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-800\" role=\"menuitem\" tabindex=\"-1\">Logout</a></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -407,25 +498,25 @@ func footer(props view.BaseProps) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var12 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var12 == nil {
-			templ_7745c5c3_Var12 = templ.NopComponent
+		templ_7745c5c3_Var19 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var19 == nil {
+			templ_7745c5c3_Var19 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "<footer class=\"bg-surface text-text dark:bg-surface-dark dark:text-text-dark border-t border-gray-200 dark:border-gray-800\"><div class=\"max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6\"><div class=\"flex flex-col md:flex-row justify-between items-center\"><p class=\"text-gray-500 dark:text-gray-400 text-sm\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "<footer class=\"bg-surface text-text dark:bg-surface-dark dark:text-text-dark border-t border-gray-200 dark:border-gray-800\"><div class=\"max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6\"><div class=\"flex flex-col md:flex-row justify-between items-center\"><p class=\"text-gray-500 dark:text-gray-400 text-sm\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var13 string
-		templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(footerCopyright(props.CurrentYear))
+		var templ_7745c5c3_Var20 string
+		templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(footerCopyright(props.CurrentYear))
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/layouts/base.templ`, Line: 242, Col: 41}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "</p><div class=\"flex space-x-4 mt-4 md:mt-0\"><a href=\"/terms\" class=\"text-sm text-gray-500 hover:text-text dark:text-gray-400 dark:hover:text-text-dark\">Terms</a> <a href=\"/privacy\" class=\"text-sm text-gray-500 hover:text-text dark:text-gray-400 dark:hover:text-text-dark\">Privacy</a></div></div></div></footer>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "</p><div class=\"flex space-x-4 mt-4 md:mt-0\"><a href=\"/terms\" class=\"text-sm text-gray-500 hover:text-text dark:text-gray-400 dark:hover:text-text-dark\">Terms</a> <a href=\"/privacy\" class=\"text-sm text-gray-500 hover:text-text dark:text-gray-400 dark:hover:text-text-dark\">Privacy</a></div></div></div></footer>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -452,12 +543,12 @@ func htmxLoadingIndicator() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var14 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var14 == nil {
-			templ_7745c5c3_Var14 = templ.NopComponent
+		templ_7745c5c3_Var21 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var21 == nil {
+			templ_7745c5c3_Var21 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "<div id=\"global-loading\" class=\"hidden fixed inset-0 bg-gray-800/50 flex items-center justify-center z-50\"><div class=\"text-white font-semibold\">Loading...</div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "<div id=\"global-loading\" class=\"hidden fixed inset-0 bg-gray-800/50 flex items-center justify-center z-50\"><div class=\"text-white font-semibold\">Loading...</div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -481,38 +572,38 @@ func toastNotifications() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var15 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var15 == nil {
-			templ_7745c5c3_Var15 = templ.NopComponent
+		templ_7745c5c3_Var22 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var22 == nil {
+			templ_7745c5c3_Var22 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "<div x-data=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "<div x-data=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var16 string
-		templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(toastData())
+		var templ_7745c5c3_Var23 string
+		templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(toastData())
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/layouts/base.templ`, Line: 264, Col: 22}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "\" x-init=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "\" x-init=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var17 string
-		templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(toastInit())
+		var templ_7745c5c3_Var24 string
+		templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(toastInit())
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/layouts/base.templ`, Line: 265, Col: 22}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "\" class=\"fixed bottom-4 right-4 z-50 flex flex-col space-y-3 items-end\" aria-live=\"polite\" aria-atomic=\"true\"><template x-for=\"toast in toasts\" :key=\"toast.id\"><div x-show=\"true\" x-transition:enter=\"transition ease-out duration-300\" x-transition:enter-start=\"opacity-0 translate-y-4\" x-transition:enter-end=\"opacity-100 translate-y-0\" x-transition:leave=\"transition ease-in duration-200\" x-transition:leave-start=\"opacity-100\" x-transition:leave-end=\"opacity-0\" :class=\"{\n\t\t\t\t\t'bg-green-600 text-white': toast.type === 'success',\n\t\t\t\t\t'bg-red-600 text-white': toast.type === 'error',\n\t\t\t\t\t'bg-yellow-500 text-black': toast.type === 'warning'\n\t\t\t\t}\" class=\"shadow-lg rounded px-4 py-2 min-w-[200px] flex items-center gap-2 animate-fade\" role=\"status\"><template x-if=\"toast.type === 'success'\"><span aria-hidden=\"true\">&#10003;</span></template><template x-if=\"toast.type === 'error'\"><span aria-hidden=\"true\">!</span></template><template x-if=\"toast.type === 'warning'\"><span aria-hidden=\"true\">&#9888;</span></template><span x-text=\"toast.msg\"></span></div></template></div><style>\n\t\t@keyframes fade {\n\t\t\tfrom { opacity: 0; }\n\t\t\tto { opacity: 1; }\n\t\t}\n\t\t.animate-fade {\n\t\t\tanimation: fade 0.5s;\n\t\t}\n\t</style>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "\" class=\"fixed bottom-4 right-4 z-50 flex flex-col space-y-3 items-end\" aria-live=\"polite\" aria-atomic=\"true\"><template x-for=\"toast in toasts\" :key=\"toast.id\"><div x-show=\"true\" x-transition:enter=\"transition ease-out duration-300\" x-transition:enter-start=\"opacity-0 translate-y-4\" x-transition:enter-end=\"opacity-100 translate-y-0\" x-transition:leave=\"transition ease-in duration-200\" x-transition:leave-start=\"opacity-100\" x-transition:leave-end=\"opacity-0\" :class=\"{\n\t\t\t\t\t'bg-green-600 text-white': toast.type === 'success',\n\t\t\t\t\t'bg-red-600 text-white': toast.type === 'error',\n\t\t\t\t\t'bg-yellow-500 text-black': toast.type === 'warning'\n\t\t\t\t}\" class=\"shadow-lg rounded px-4 py-2 min-w-[200px] flex items-center gap-2 animate-fade\" role=\"status\"><template x-if=\"toast.type === 'success'\"><span aria-hidden=\"true\">&#10003;</span></template><template x-if=\"toast.type === 'error'\"><span aria-hidden=\"true\">!</span></template><template x-if=\"toast.type === 'warning'\"><span aria-hidden=\"true\">&#9888;</span></template><span x-text=\"toast.msg\"></span></div></template></div><style>\n\t\t@keyframes fade {\n\t\t\tfrom { opacity: 0; }\n\t\t\tto { opacity: 1; }\n\t\t}\n\t\t.animate-fade {\n\t\t\tanimation: fade 0.5s;\n\t\t}\n\t</style>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
## What

Cache-busting for static assets, plus the 0.5.2 changelog.

## Why

`/static` ships `Cache-Control: public, max-age=31536000`, but pages referenced bare asset URLs — so every deploy left returning browsers on stale CSS/JS until a hard refresh. This bit three separate times during the 0.5.x design work (invisible wordmark, giant unswapped brand mark, missing 4xx-swap listener). ADR-016's aggressive caching explicitly assumes "versioned/hashed assets"; the versioned half was never implemented.

## How

- `view.AssetURL(path)` appends `?v=<stamp>`; `view.SetAssetVersion` is wired in `main` from the existing `-X main.version` ldflag, so each release mints new asset URLs. Dev builds default to a process-start stamp — `task dev` restarts bust caches too. Query-escaped for dirty build strings.
- `base.templ` routes all CSS/JS/favicon references through it.
- Tests first: unit contract on `AssetURL`/`SetAssetVersion`, and a server test asserting every asset reference on a rendered page carries `?v=`.

Query-string stamping over content-hashing: no build-pipeline changes, works with the existing file server, and per-release granularity is exactly the staleness boundary that matters here.

## Testing

- [x] Tests first; `task ci` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)