### PR TITLE
fix(ci): pass the release tag into the Docker build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,8 @@ jobs:
           context: .
           load: true
           tags: local/app:budget-check
+          build-args: |
+            VERSION=${{ github.ref_name }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -58,6 +60,8 @@ jobs:
             ghcr.io/${{ github.repository }}:${{ github.ref_name }}
             ghcr.io/${{ github.repository }}:latest
             ghcr.io/${{ github.repository }}:sha-${{ github.sha }}
+          build-args: |
+            VERSION=${{ github.ref_name }}
           cache-from: type=gha
 
       - name: Create GitHub release

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,8 +47,12 @@ RUN templ generate
 # -s: strip symbol table
 # -w: strip DWARF debug info
 # -trimpath: remove file system paths from executable
+# VERSION comes from the build arg (.git is dockerignored, so git describe
+# can't run in this context); the release workflow passes the tag, local
+# builds keep the fallback and the app stamps assets from process start.
+ARG VERSION=dev
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
-    -ldflags="-s -w -X main.version=$(git describe --tags --always --dirty 2>/dev/null || echo 'dev')" \
+    -ldflags="-s -w -X main.version=${VERSION}" \
     -trimpath \
     -o app \
     ./cmd/api


### PR DESCRIPTION
## What

Passes the release tag into the Docker build as a `VERSION` build arg.

## Why

Follow-up to #54: the deployed v0.5.2 stamps assets with `?v=<unix-time>` instead of `?v=v0.5.2`. The Dockerfile ran `git describe` for `-X main.version`, but `.git` is dockerignored so it always fell back to `dev` — released binaries never knew their version. Harmless for cache-busting correctness (each deploy still mints a fresh stamp) but the two Fly machines carry different stamps, causing needless cache churn, and the boot log reports `version=dev` in production.

## How

`ARG VERSION=dev` in the build stage, ldflags use it; the release workflow passes `VERSION=${{ github.ref_name }}` to both the budget-check and push builds. Local/fork builds keep the `dev` fallback (process-start stamping).

No release cut for this — it takes effect on the next tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)