### PR TITLE
feat(auth): enable guest mode — anonymous sign-ins are on in Supabase

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -19,6 +19,10 @@ primary_region = "ewr"
   # Non-secret tuning lives here, versioned — not in `fly secrets` where it
   # becomes invisible and gets lost on app migrations.
   DB_MAX_CONNS = "10"
+  # Anonymous guest identities (ADR-024): requires "anonymous sign-ins"
+  # enabled in the Supabase project (done 2026-07). Visitors to /learn get a
+  # real Supabase identity server-side; the TTL reaper expires stale ones.
+  GUEST_MODE_ENABLED = "true"
 
 [http_service]
   internal_port = 4000


### PR DESCRIPTION
Flips `GUEST_MODE_ENABLED` on in fly.toml `[env]` now that anonymous sign-ins are enabled in the Supabase project (prerequisite from the Phase 2 handoff, confirmed done). Visitors to /learn get a real anonymous identity server-side per ADR-024 — quiz + flashcards with zero signup friction, RLS-scoped, TTL-reaped. Takes effect with the next release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)