### PR TITLE
feat(patterns): wave 2 — 7 more showcases; kill the full-screen loading flash

### DIFF
--- a/internal/handler/patterns_handlers.go
+++ b/internal/handler/patterns_handlers.go
@@ -1,10 +1,13 @@
 package handler
 
 import (
+	"fmt"
 	"log/slog"
 	"net/http"
+	"runtime"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/a-h/templ"
 	"github.com/go-chi/chi/v5"
@@ -35,6 +38,11 @@ func PatternsRoutes(r chi.Router) {
 		api.Get("/skeleton", PatternSkeleton)
 		api.Get("/tab/{name}", PatternTab)
 		api.Post("/bulk", PatternBulk)
+		api.Get("/time", PatternTime)             // polling tick
+		api.Post("/counter", PatternCounter)      // out-of-band swap
+		api.Post("/confirm", PatternConfirm)      // hx-confirm + hx-disabled-elt
+		api.Get("/transition", PatternTransition) // View Transitions swap
+		api.Get("/slow", PatternSlow)             // hx-indicator + hx-disabled-elt
 	})
 }
 
@@ -235,6 +243,110 @@ count := len(r.Form["selected"])
 view.Render(w, r, http.StatusOK,
   partials.PatternBulkResult(count))`,
 	},
+	{
+		Slug:         "polling",
+		Title:        "Polling",
+		Summary:      "A live server value without WebSockets: the element re-fetches itself on a fixed interval — the whole real-time stack is one attribute.",
+		HTMXFeatures: []string{`hx-trigger="load, every 5s"`, "hx-get"},
+		TemplSource: `<div hx-get="/patterns/api/time"
+  hx-trigger="load, every 5s"
+  hx-swap="innerHTML">...</div>`,
+		HandlerSource: `now := time.Now().Format("15:04:05")
+view.Render(w, r, http.StatusOK,
+  partials.PatternTimeTick(now, load))`,
+	},
+	{
+		Slug:         "oob-swap",
+		Title:        "Out-of-band swap",
+		Summary:      "One response updates two regions: the button replaces itself, and a badge elsewhere updates via hx-swap-oob riding the same payload.",
+		HTMXFeatures: []string{"hx-swap-oob", "hx-vals", `hx-swap="outerHTML"`},
+		TemplSource: `<!-- response contains BOTH: -->
+<button id="oob-counter-btn" ...>Add item</button>
+<span id="oob-total" hx-swap-oob="true">
+  3 added
+</span>`,
+		HandlerSource: `count, _ := strconv.Atoi(r.FormValue("count"))
+view.Render(w, r, http.StatusOK,
+  partials.PatternCounterResponse(
+    partials.PatternCounterProps{Count: count + 1}))`,
+	},
+	{
+		Slug:         "confirm-delete",
+		Title:        "Confirm + disabled button",
+		Summary:      "hx-confirm gates the request behind a native confirm dialog; hx-disabled-elt holds the button while the request runs.",
+		HTMXFeatures: []string{"hx-confirm", `hx-disabled-elt="this"`, "hx-post"},
+		TemplSource: `<button hx-post="/patterns/api/confirm"
+  hx-confirm="Delete this demo item?"
+  hx-disabled-elt="this"
+  hx-target="closest div">Delete item</button>`,
+		HandlerSource: `// The interesting part happens client-side
+// before this runs.
+view.Render(w, r, http.StatusOK,
+  partials.PatternConfirmResult())`,
+	},
+	{
+		Slug:         "view-transitions",
+		Title:        "View Transitions",
+		Summary:      "transition:true on the swap animates it through the browser's View Transitions API — cross-fade with zero animation code, instant fallback elsewhere.",
+		HTMXFeatures: []string{`hx-swap="innerHTML transition:true"`},
+		TemplSource: `<button hx-get="/patterns/api/transition?step=1"
+  hx-target="#vt-card"
+  hx-swap="innerHTML transition:true">
+  Next card
+</button>`,
+		HandlerSource: `step, _ := strconv.Atoi(r.URL.Query().Get("step"))
+view.Render(w, r, http.StatusOK,
+  partials.PatternTransitionCard(step))`,
+	},
+	{
+		Slug:         "loading-states",
+		Title:        "Loading states",
+		Summary:      "The right way to show in-flight work: a per-element spinner (hx-indicator) and a disabled trigger (hx-disabled-elt) — never a full-screen overlay.",
+		HTMXFeatures: []string{"hx-indicator", `hx-disabled-elt="this"`},
+		TemplSource: `<button hx-get="/patterns/api/slow"
+  hx-indicator="#slow-spin"
+  hx-disabled-elt="this"
+  hx-target="#slow-out">Load slowly</button>
+<span id="slow-spin" class="htmx-indicator">
+  Working...
+</span>`,
+		HandlerSource: `// Deliberate delay so there is something
+// to indicate (capped at 1.5s).
+time.Sleep(delay)
+view.Render(w, r, http.StatusOK,
+  partials.PatternSlowContent())`,
+	},
+	{
+		Slug:           "modal",
+		Title:          "Modal (teleport)",
+		Summary:        "An accessible Alpine modal: x-teleport lifts it to <body> so no ancestor clips it, Escape and backdrop close it, focus lands inside.",
+		AlpineFeatures: []string{"x-teleport", "x-show", "@keydown.escape.window", "x-transition"},
+		TemplSource: `<button @click="open = true">Open modal</button>
+<template x-teleport="body">
+  <div x-show="open" @keydown.escape.window="open = false">
+    <div @click="open = false" class="backdrop"></div>
+    <div role="dialog" aria-modal="true">...</div>
+  </div>
+</template>`,
+		HandlerSource: `// No handler — entirely client-side.
+// Server-rendered pages still work without
+// it: the modal content is enhancement.`,
+	},
+	{
+		Slug:           "global-store",
+		Title:          "Global store",
+		Summary:        "Alpine.store shares state across unrelated components: two separate x-data islands read and write one store registered in app.js.",
+		AlpineFeatures: []string{"Alpine.store", "$store", "x-text"},
+		TemplSource: `<!-- two unrelated components: -->
+<button @click="$store.demo.inc()">+1</button>
+...
+<span x-text="$store.demo.count"></span>`,
+		HandlerSource: `// app.js, at alpine:init:
+Alpine.store("demo", {
+  count: 0,
+  inc() { this.count++ },
+})`,
+	},
 }
 
 // patternTabs is the content served by the server-loaded tabs demo.
@@ -363,6 +475,57 @@ func PatternBulk(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	renderPattern(w, r, "bulk", partials.PatternBulkResult(len(r.Form["selected"])))
+}
+
+// PatternTime serves one polling tick (client re-requests every 5s).
+func PatternTime(w http.ResponseWriter, r *http.Request) {
+	now := time.Now().Format("15:04:05")
+	load := fmt.Sprintf("goroutines: %d", runtime.NumGoroutine())
+	renderPattern(w, r, "time", partials.PatternTimeTick(now, load))
+}
+
+// PatternCounter answers with the incremented button AND an out-of-band
+// badge update — one response, two swapped regions. State rides in hx-vals
+// so the endpoint stays stateless like the favorite toggle.
+func PatternCounter(w http.ResponseWriter, r *http.Request) {
+	count, _ := strconv.Atoi(r.FormValue("count"))
+	if count < 0 || count > 1_000_000 {
+		count = 0
+	}
+	renderPattern(w, r, "counter", partials.PatternCounterResponse(partials.PatternCounterProps{Count: count + 1}))
+}
+
+// PatternConfirm serves the post-confirmation state; the interesting part
+// (hx-confirm, hx-disabled-elt) happens client-side before this runs.
+func PatternConfirm(w http.ResponseWriter, r *http.Request) {
+	renderPattern(w, r, "confirm", partials.PatternConfirmResult())
+}
+
+// PatternTransition serves the next card for the View Transitions demo.
+func PatternTransition(w http.ResponseWriter, r *http.Request) {
+	step, _ := strconv.Atoi(r.URL.Query().Get("step"))
+	if step < 0 {
+		step = 0
+	}
+	renderPattern(w, r, "transition", partials.PatternTransitionCard(step))
+}
+
+// PatternSlow delays server-side so hx-indicator/hx-disabled-elt have
+// something to indicate. The delay is capped and overridable (tests pass 0).
+func PatternSlow(w http.ResponseWriter, r *http.Request) {
+	delay := 800
+	if d, err := strconv.Atoi(r.URL.Query().Get("delay")); err == nil && d >= 0 {
+		delay = d
+	}
+	if delay > 1500 {
+		delay = 1500
+	}
+	select {
+	case <-time.After(time.Duration(delay) * time.Millisecond):
+	case <-r.Context().Done():
+		return
+	}
+	renderPattern(w, r, "slow", partials.PatternSlowContent())
 }
 
 // renderPattern renders a demo fragment, logging render failures like every

--- a/internal/handler/patterns_handlers_test.go
+++ b/internal/handler/patterns_handlers_test.go
@@ -33,6 +33,14 @@ var patternSlugs = []string{
 	"skeleton-loading",
 	"tabs",
 	"bulk-operations",
+	// wave 2: the rest of the bells and whistles
+	"polling",
+	"oob-swap",
+	"confirm-delete",
+	"view-transitions",
+	"loading-states",
+	"modal",
+	"global-store",
 }
 
 func TestPatternsPage(t *testing.T) {
@@ -138,6 +146,37 @@ func TestPatternsAPI(t *testing.T) {
 			name:       "bulk operation result",
 			method:     http.MethodPost,
 			target:     "/patterns/api/bulk",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "polling tick",
+			method:     http.MethodGet,
+			target:     "/patterns/api/time",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:         "counter response carries an out-of-band swap",
+			method:       http.MethodPost,
+			target:       "/patterns/api/counter",
+			wantStatus:   http.StatusOK,
+			wantContains: []string{`hx-swap-oob`},
+		},
+		{
+			name:       "confirmed delete returns the emptied state",
+			method:     http.MethodPost,
+			target:     "/patterns/api/confirm",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "view-transition card",
+			method:     http.MethodGet,
+			target:     "/patterns/api/transition?step=1",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "loading-states content (delay capped server-side)",
+			method:     http.MethodGet,
+			target:     "/patterns/api/slow?delay=0",
 			wantStatus: http.StatusOK,
 		},
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -237,4 +237,10 @@ func TestServer_AssetCacheBusting(t *testing.T) {
 	if strings.Contains(body, "semantic-colors.css") {
 		t.Error("page still references the retired semantic-colors.css")
 	}
+	// No global loading overlay: it flashed the full screen on every HTMX
+	// fragment swap. In-flight feedback is per-element (.htmx-request,
+	// hx-indicator, hx-disabled-elt).
+	if strings.Contains(body, "global-loading") {
+		t.Error("page still renders the retired full-screen loading overlay")
+	}
 }

--- a/internal/view/layouts/base.templ
+++ b/internal/view/layouts/base.templ
@@ -96,6 +96,11 @@ templ Base(props view.BaseProps) {
 			<link rel="icon" type="image/png" href={ view.AssetURL("/static/img/favicon.png") }/>
 			<!-- HTMX -->
 			<script src={ view.AssetURL("/static/js/htmx.min.js") } defer></script>
+			<!-- App scripts BEFORE Alpine: with defer, Alpine starts the moment
+			     it executes and fires alpine:init immediately — app.js must have
+			     its listener (Alpine.data/store registrations) in place first.
+			     Inline scripts stay CSP-forbidden (ADR-028). -->
+			<script src={ view.AssetURL("/static/js/app.js") } defer></script>
 			<!-- Alpine.js -->
 			<script src={ view.AssetURL("/static/js/alpine.min.js") } defer></script>
 		</head>
@@ -117,10 +122,10 @@ templ Base(props view.BaseProps) {
 				</div>
 			</main>
 			@footer(props)
-			<!-- App scripts: all behavior lives in external files or Alpine
-			     attributes; inline script blocks are CSP-forbidden (ADR-028) -->
-			<script src={ view.AssetURL("/static/js/app.js") } defer></script>
-			@htmxLoadingIndicator()
+			<!-- app.js loads in <head> before Alpine (registration ordering).
+			     No global loading overlay here either: a full-screen flash on
+			     every fragment swap is an HTMX anti-pattern — in-flight feedback
+			     is per-element (.htmx-request, hx-indicator, hx-disabled-elt). -->
 			@toastNotifications()
 		</body>
 	</html>
@@ -252,15 +257,6 @@ templ footer(props view.BaseProps) {
 			</div>
 		</div>
 	</footer>
-}
-
-// htmxLoadingIndicator is the overlay app.js toggles on htmx:beforeRequest /
-// htmx:afterRequest (the listeners live there — inline scripts are
-// CSP-forbidden per ADR-028).
-templ htmxLoadingIndicator() {
-	<div id="global-loading" class="hidden fixed inset-0 bg-night/50 flex items-center justify-center z-50">
-		<div class="text-white font-semibold">Loading...</div>
-	</div>
 }
 
 templ toastNotifications() {

--- a/internal/view/layouts/base_templ.go
+++ b/internal/view/layouts/base_templ.go
@@ -173,59 +173,72 @@ func Base(props view.BaseProps) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "\" defer></script><!-- Alpine.js --><script src=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "\" defer></script><!-- App scripts BEFORE Alpine: with defer, Alpine starts the moment\n\t\t\t     it executes and fires alpine:init immediately — app.js must have\n\t\t\t     its listener (Alpine.data/store registrations) in place first.\n\t\t\t     Inline scripts stay CSP-forbidden (ADR-028). --><script src=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var7 string
-		templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(view.AssetURL("/static/js/alpine.min.js"))
+		templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(view.AssetURL("/static/js/app.js"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/layouts/base.templ`, Line: 100, Col: 58}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/layouts/base.templ`, Line: 103, Col: 51}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "\" defer></script></head><body x-data=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "\" defer></script><!-- Alpine.js --><script src=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var8 string
-		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(darkModeData())
+		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(view.AssetURL("/static/js/alpine.min.js"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/layouts/base.templ`, Line: 103, Col: 26}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/layouts/base.templ`, Line: 105, Col: 58}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "\" x-init=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "\" defer></script></head><body x-data=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var9 string
-		templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(darkModeInit())
+		templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(darkModeData())
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/layouts/base.templ`, Line: 104, Col: 26}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/layouts/base.templ`, Line: 108, Col: 26}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "\" hx-headers=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "\" x-init=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var10 string
-		templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(csrfHxHeaders(webutil.CSRFTokenFromContext(ctx)))
+		templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(darkModeInit())
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/layouts/base.templ`, Line: 105, Col: 64}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/layouts/base.templ`, Line: 109, Col: 26}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "\" class=\"min-h-screen flex flex-col bg-background text-foreground\"><!-- Skip to content link for accessibility --><a href=\"#main-content\" class=\"sr-only focus:not-sr-only focus:absolute focus:p-4 focus:bg-surface focus:z-50\">Skip to content</a>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "\" hx-headers=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var11 string
+		templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(csrfHxHeaders(webutil.CSRFTokenFromContext(ctx)))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/layouts/base.templ`, Line: 110, Col: 64}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "\" class=\"min-h-screen flex flex-col bg-background text-foreground\"><!-- Skip to content link for accessibility --><a href=\"#main-content\" class=\"sr-only focus:not-sr-only focus:absolute focus:p-4 focus:bg-surface focus:z-50\">Skip to content</a>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -233,7 +246,7 @@ func Base(props view.BaseProps) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<!-- Main content --><main id=\"main-content\" class=\"flex-grow\"><div class=\"max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<!-- Main content --><main id=\"main-content\" class=\"flex-grow\"><div class=\"max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -241,7 +254,7 @@ func Base(props view.BaseProps) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</div></main>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "</div></main>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -249,24 +262,7 @@ func Base(props view.BaseProps) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<!-- App scripts: all behavior lives in external files or Alpine\n\t\t\t     attributes; inline script blocks are CSP-forbidden (ADR-028) --><script src=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var11 string
-		templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(view.AssetURL("/static/js/app.js"))
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/layouts/base.templ`, Line: 122, Col: 51}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "\" defer></script>")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = htmxLoadingIndicator().Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "<!-- app.js loads in <head> before Alpine (registration ordering).\n\t\t\t     No global loading overlay here either: a full-screen flash on\n\t\t\t     every fragment swap is an HTMX anti-pattern — in-flight feedback\n\t\t\t     is per-element (.htmx-request, hx-indicator, hx-disabled-elt). -->")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -445,7 +441,7 @@ func userMenu(userName string) templ.Component {
 		var templ_7745c5c3_Var16 string
 		templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(userMenuData())
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/layouts/base.templ`, Line: 213, Col: 29}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/layouts/base.templ`, Line: 218, Col: 29}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
 		if templ_7745c5c3_Err != nil {
@@ -458,7 +454,7 @@ func userMenu(userName string) templ.Component {
 		var templ_7745c5c3_Var17 string
 		templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(userName)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/layouts/base.templ`, Line: 221, Col: 48}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/layouts/base.templ`, Line: 226, Col: 48}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 		if templ_7745c5c3_Err != nil {
@@ -500,45 +496,13 @@ func footer(props view.BaseProps) templ.Component {
 		var templ_7745c5c3_Var19 string
 		templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(footerCopyright(props.CurrentYear))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/layouts/base.templ`, Line: 246, Col: 41}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/layouts/base.templ`, Line: 251, Col: 41}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "</p><div class=\"flex space-x-4 mt-4 md:mt-0\"><a href=\"/terms\" class=\"text-sm text-muted-foreground hover:text-foreground\">Terms</a> <a href=\"/privacy\" class=\"text-sm text-muted-foreground hover:text-foreground\">Privacy</a></div></div></div></footer>")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		return nil
-	})
-}
-
-// htmxLoadingIndicator is the overlay app.js toggles on htmx:beforeRequest /
-// htmx:afterRequest (the listeners live there — inline scripts are
-// CSP-forbidden per ADR-028).
-func htmxLoadingIndicator() templ.Component {
-	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
-		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
-		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
-			return templ_7745c5c3_CtxErr
-		}
-		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
-		if !templ_7745c5c3_IsBuffer {
-			defer func() {
-				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
-				if templ_7745c5c3_Err == nil {
-					templ_7745c5c3_Err = templ_7745c5c3_BufErr
-				}
-			}()
-		}
-		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var20 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var20 == nil {
-			templ_7745c5c3_Var20 = templ.NopComponent
-		}
-		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "<div id=\"global-loading\" class=\"hidden fixed inset-0 bg-night/50 flex items-center justify-center z-50\"><div class=\"text-white font-semibold\">Loading...</div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -562,38 +526,38 @@ func toastNotifications() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var21 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var21 == nil {
-			templ_7745c5c3_Var21 = templ.NopComponent
+		templ_7745c5c3_Var20 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var20 == nil {
+			templ_7745c5c3_Var20 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "<div x-data=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "<div x-data=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var21 string
+		templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(toastData())
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/layouts/base.templ`, Line: 264, Col: 22}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "\" x-init=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var22 string
-		templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs(toastData())
+		templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs(toastInit())
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/layouts/base.templ`, Line: 268, Col: 22}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/layouts/base.templ`, Line: 265, Col: 22}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "\" x-init=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var23 string
-		templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(toastInit())
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/layouts/base.templ`, Line: 269, Col: 22}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "\" class=\"fixed bottom-4 right-4 z-50 flex flex-col space-y-3 items-end\" aria-live=\"polite\" aria-atomic=\"true\"><template x-for=\"toast in toasts\" :key=\"toast.id\"><div x-show=\"true\" x-transition:enter=\"transition ease-out duration-300\" x-transition:enter-start=\"opacity-0 translate-y-4\" x-transition:enter-end=\"opacity-100 translate-y-0\" x-transition:leave=\"transition ease-in duration-200\" x-transition:leave-start=\"opacity-100\" x-transition:leave-end=\"opacity-0\" :class=\"{\n\t\t\t\t\t'border-success': toast.type === 'success',\n\t\t\t\t\t'border-danger': toast.type === 'error',\n\t\t\t\t\t'border-warning': toast.type === 'warning'\n\t\t\t\t}\" class=\"shadow-lg rounded-md px-4 py-3 min-w-[220px] max-w-sm flex items-center gap-2 animate-fade bg-surface text-foreground border-l-4\" role=\"status\"><template x-if=\"toast.type === 'success'\"><span aria-hidden=\"true\" class=\"text-success font-bold\">&#10003;</span></template><template x-if=\"toast.type === 'error'\"><span aria-hidden=\"true\" class=\"text-danger font-bold\">!</span></template><template x-if=\"toast.type === 'warning'\"><span aria-hidden=\"true\" class=\"text-warning font-bold\">&#9888;</span></template><span x-text=\"toast.msg\" class=\"text-sm\"></span></div></template></div><style>\n\t\t@keyframes fade {\n\t\t\tfrom { opacity: 0; }\n\t\t\tto { opacity: 1; }\n\t\t}\n\t\t.animate-fade {\n\t\t\tanimation: fade 0.5s;\n\t\t}\n\t</style>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "\" class=\"fixed bottom-4 right-4 z-50 flex flex-col space-y-3 items-end\" aria-live=\"polite\" aria-atomic=\"true\"><template x-for=\"toast in toasts\" :key=\"toast.id\"><div x-show=\"true\" x-transition:enter=\"transition ease-out duration-300\" x-transition:enter-start=\"opacity-0 translate-y-4\" x-transition:enter-end=\"opacity-100 translate-y-0\" x-transition:leave=\"transition ease-in duration-200\" x-transition:leave-start=\"opacity-100\" x-transition:leave-end=\"opacity-0\" :class=\"{\n\t\t\t\t\t'border-success': toast.type === 'success',\n\t\t\t\t\t'border-danger': toast.type === 'error',\n\t\t\t\t\t'border-warning': toast.type === 'warning'\n\t\t\t\t}\" class=\"shadow-lg rounded-md px-4 py-3 min-w-[220px] max-w-sm flex items-center gap-2 animate-fade bg-surface text-foreground border-l-4\" role=\"status\"><template x-if=\"toast.type === 'success'\"><span aria-hidden=\"true\" class=\"text-success font-bold\">&#10003;</span></template><template x-if=\"toast.type === 'error'\"><span aria-hidden=\"true\" class=\"text-danger font-bold\">!</span></template><template x-if=\"toast.type === 'warning'\"><span aria-hidden=\"true\" class=\"text-warning font-bold\">&#9888;</span></template><span x-text=\"toast.msg\" class=\"text-sm\"></span></div></template></div><style>\n\t\t@keyframes fade {\n\t\t\tfrom { opacity: 0; }\n\t\t\tto { opacity: 1; }\n\t\t}\n\t\t.animate-fade {\n\t\t\tanimation: fade 0.5s;\n\t\t}\n\t</style>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/view/pages/patterns.templ
+++ b/internal/view/pages/patterns.templ
@@ -192,5 +192,84 @@ templ patternDemo(slug string) {
 				</button>
 				<div id="bulk-demo-result" aria-live="polite"></div>
 			</form>
+		case "polling":
+			<div hx-get="/patterns/api/time" hx-trigger="load, every 5s" hx-swap="innerHTML" aria-live="off">
+				<span class="text-sm text-muted-foreground">Fetching server time...</span>
+			</div>
+		case "oob-swap":
+			<div class="flex items-center justify-between gap-4">
+				@partials.PatternCounterButton(partials.PatternCounterProps{Count: 0})
+				@partials.PatternCounterBadge(0, false)
+			</div>
+			<p class="mt-3 text-xs text-muted-foreground">
+				The badge is a separate region — it updates via hx-swap-oob in the button's response.
+			</p>
+		case "confirm-delete":
+			<div>
+				<button
+					hx-post="/patterns/api/confirm"
+					hx-confirm="Delete this demo item?"
+					hx-disabled-elt="this"
+					hx-target="closest div"
+					hx-swap="innerHTML"
+					class="btn btn-danger"
+				>
+					Delete item
+				</button>
+			</div>
+		case "view-transitions":
+			<div id="vt-card">
+				@partials.PatternTransitionCard(0)
+			</div>
+		case "loading-states":
+			<div class="flex items-center gap-3">
+				<button
+					hx-get="/patterns/api/slow"
+					hx-indicator="#slow-spin"
+					hx-disabled-elt="this"
+					hx-target="#slow-out"
+					class="btn btn-primary"
+				>
+					Load slowly
+				</button>
+				<span id="slow-spin" class="htmx-indicator text-sm text-muted-foreground">Working...</span>
+			</div>
+			<div id="slow-out" class="mt-3" aria-live="polite"></div>
+		case "modal":
+			<div x-data="{ open: false }">
+				<button @click="open = true" class="btn btn-primary">Open modal</button>
+				<template x-teleport="body">
+					<div x-show="open" x-cloak @keydown.escape.window="open = false" class="fixed inset-0 z-50 flex items-center justify-center p-4">
+						<div @click="open = false" class="absolute inset-0 bg-night/60" aria-hidden="true"></div>
+						<div
+							role="dialog"
+							aria-modal="true"
+							aria-labelledby="demo-modal-title"
+							x-show="open"
+							x-transition
+							class="relative bg-surface text-foreground rounded-lg shadow-lg p-6 max-w-sm w-full"
+						>
+							<h3 id="demo-modal-title" class="text-lg font-semibold mb-2">Teleported modal</h3>
+							<p class="text-sm text-muted-foreground mb-4">
+								This dialog lives at the end of <code>&lt;body&gt;</code> via x-teleport,
+								so no ancestor stacking context can clip it. Escape or the backdrop closes it.
+							</p>
+							<button @click="open = false" class="btn btn-secondary">Close</button>
+						</div>
+					</div>
+				</template>
+			</div>
+		case "global-store":
+			<div class="flex items-center justify-between gap-4">
+				<div x-data="{}">
+					<button @click="$store.demo.inc()" class="btn btn-primary">+1 from component A</button>
+				</div>
+				<div x-data="{}" class="px-3 py-1 rounded-full text-sm bg-primary/10 text-primary tabular-nums">
+					Component B sees: <span x-text="$store.demo.count"></span>
+				</div>
+			</div>
+			<p class="mt-3 text-xs text-muted-foreground">
+				Two unrelated x-data islands sharing one Alpine.store registered in app.js.
+			</p>
 	}
 }

--- a/internal/view/pages/patterns_templ.go
+++ b/internal/view/pages/patterns_templ.go
@@ -482,6 +482,61 @@ func patternDemo(slug string) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
+		case "polling":
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "<div hx-get=\"/patterns/api/time\" hx-trigger=\"load, every 5s\" hx-swap=\"innerHTML\" aria-live=\"off\"><span class=\"text-sm text-muted-foreground\">Fetching server time...</span></div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		case "oob-swap":
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "<div class=\"flex items-center justify-between gap-4\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = partials.PatternCounterButton(partials.PatternCounterProps{Count: 0}).Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = partials.PatternCounterBadge(0, false).Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "</div><p class=\"mt-3 text-xs text-muted-foreground\">The badge is a separate region — it updates via hx-swap-oob in the button's response.</p>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		case "confirm-delete":
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "<div><button hx-post=\"/patterns/api/confirm\" hx-confirm=\"Delete this demo item?\" hx-disabled-elt=\"this\" hx-target=\"closest div\" hx-swap=\"innerHTML\" class=\"btn btn-danger\">Delete item</button></div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		case "view-transitions":
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "<div id=\"vt-card\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = partials.PatternTransitionCard(0).Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "</div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		case "loading-states":
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "<div class=\"flex items-center gap-3\"><button hx-get=\"/patterns/api/slow\" hx-indicator=\"#slow-spin\" hx-disabled-elt=\"this\" hx-target=\"#slow-out\" class=\"btn btn-primary\">Load slowly</button> <span id=\"slow-spin\" class=\"htmx-indicator text-sm text-muted-foreground\">Working...</span></div><div id=\"slow-out\" class=\"mt-3\" aria-live=\"polite\"></div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		case "modal":
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "<div x-data=\"{ open: false }\"><button @click=\"open = true\" class=\"btn btn-primary\">Open modal</button><template x-teleport=\"body\"><div x-show=\"open\" x-cloak @keydown.escape.window=\"open = false\" class=\"fixed inset-0 z-50 flex items-center justify-center p-4\"><div @click=\"open = false\" class=\"absolute inset-0 bg-night/60\" aria-hidden=\"true\"></div><div role=\"dialog\" aria-modal=\"true\" aria-labelledby=\"demo-modal-title\" x-show=\"open\" x-transition class=\"relative bg-surface text-foreground rounded-lg shadow-lg p-6 max-w-sm w-full\"><h3 id=\"demo-modal-title\" class=\"text-lg font-semibold mb-2\">Teleported modal</h3><p class=\"text-sm text-muted-foreground mb-4\">This dialog lives at the end of <code>&lt;body&gt;</code> via x-teleport, so no ancestor stacking context can clip it. Escape or the backdrop closes it.</p><button @click=\"open = false\" class=\"btn btn-secondary\">Close</button></div></div></template></div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		case "global-store":
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "<div class=\"flex items-center justify-between gap-4\"><div x-data=\"{}\"><button @click=\"$store.demo.inc()\" class=\"btn btn-primary\">+1 from component A</button></div><div x-data=\"{}\" class=\"px-3 py-1 rounded-full text-sm bg-primary/10 text-primary tabular-nums\">Component B sees: <span x-text=\"$store.demo.count\"></span></div></div><p class=\"mt-3 text-xs text-muted-foreground\">Two unrelated x-data islands sharing one Alpine.store registered in app.js.</p>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
 		}
 		return nil
 	})

--- a/internal/view/partials/patterns.templ
+++ b/internal/view/partials/patterns.templ
@@ -157,3 +157,100 @@ templ PatternBulkResult(count int) {
 		{ fmt.Sprintf("Archived %d item(s) in one request.", count) }
 	</p>
 }
+
+// --- Wave 2 fragments ---
+
+// PatternTimeTick is the polling demo payload: one server-rendered tick.
+templ PatternTimeTick(now string, load string) {
+	<div class="flex items-baseline gap-3">
+		<span class="text-2xl font-semibold tabular-nums">{ now }</span>
+		<span class="text-sm text-muted-foreground">server time - refreshed every 5s ({ load })</span>
+	</div>
+}
+
+// PatternCounterProps carries the stateless counter demo state in hx-vals.
+type PatternCounterProps struct {
+	Count int
+}
+
+// PatternCounterButton replaces itself on each click and updates the badge
+// elsewhere in the panel via an out-of-band swap in the same response.
+templ PatternCounterButton(props PatternCounterProps) {
+	<button
+		id="oob-counter-btn"
+		hx-post="/patterns/api/counter"
+		hx-vals={ fmt.Sprintf(`{"count": "%d"}`, props.Count) }
+		hx-swap="outerHTML"
+		class="btn btn-primary"
+	>
+		Add item
+	</button>
+}
+
+// PatternCounterBadge is the second region the counter response updates
+// out-of-band — one request, two swaps.
+templ PatternCounterBadge(count int, oob bool) {
+	<span
+		id="oob-total"
+		if oob {
+			hx-swap-oob="true"
+		}
+		class="px-3 py-1 rounded-full text-sm bg-primary/10 text-primary tabular-nums"
+	>
+		{ fmt.Sprintf("%d added", count) }
+	</span>
+}
+
+// PatternCounterResponse is the full counter payload: the replacement button
+// plus the OOB badge.
+templ PatternCounterResponse(props PatternCounterProps) {
+	@PatternCounterButton(props)
+	@PatternCounterBadge(props.Count, true)
+}
+
+// PatternConfirmResult replaces the confirm-delete demo row once confirmed.
+templ PatternConfirmResult() {
+	<div class="p-3 rounded-md bg-success/10 text-success text-sm" role="status">
+		Deleted - hx-confirm gated the request and hx-disabled-elt held the
+		button while it ran.
+	</div>
+}
+
+// PatternTransitionCard cycles three token-tinted cards; the swap animates
+// via the View Transitions API (hx-swap "transition:true").
+templ PatternTransitionCard(step int) {
+	switch step % 3 {
+		case 0:
+			<div class="p-6 rounded-lg bg-primary/15 border border-primary">
+				<h4 class="font-semibold mb-1">Teal</h4>
+				<p class="text-sm text-muted-foreground">Swapped with a cross-fade via the View Transitions API - no animation library.</p>
+			</div>
+		case 1:
+			<div class="p-6 rounded-lg bg-accent/30 border border-accent">
+				<h4 class="font-semibold mb-1">Sage</h4>
+				<p class="text-sm text-muted-foreground">Each swap is a plain HTMX innerHTML swap with transition:true.</p>
+			</div>
+		default:
+			<div class="p-6 rounded-lg bg-danger/10 border border-danger">
+				<h4 class="font-semibold mb-1">Bittersweet</h4>
+				<p class="text-sm text-muted-foreground">Browsers without the API just swap instantly - progressive enhancement.</p>
+			</div>
+	}
+	<button
+		hx-get={ fmt.Sprintf("/patterns/api/transition?step=%d", step+1) }
+		hx-target="#vt-card"
+		hx-swap="innerHTML transition:true"
+		class="btn btn-secondary mt-3"
+	>
+		Next card
+	</button>
+}
+
+// PatternSlowContent lands after the server-side delay in the
+// loading-states demo.
+templ PatternSlowContent() {
+	<div class="p-3 rounded-md bg-success/10 text-success text-sm" role="status">
+		Loaded. While this request ran, the button was disabled
+		(hx-disabled-elt) and the spinner showed (hx-indicator).
+	</div>
+}

--- a/internal/view/partials/patterns_templ.go
+++ b/internal/view/partials/patterns_templ.go
@@ -590,4 +590,322 @@ func PatternBulkResult(count int) templ.Component {
 	})
 }
 
+// --- Wave 2 fragments ---
+
+// PatternTimeTick is the polling demo payload: one server-rendered tick.
+func PatternTimeTick(now string, load string) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var26 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var26 == nil {
+			templ_7745c5c3_Var26 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "<div class=\"flex items-baseline gap-3\"><span class=\"text-2xl font-semibold tabular-nums\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var27 string
+		templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(now)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/patterns.templ`, Line: 166, Col: 57}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "</span> <span class=\"text-sm text-muted-foreground\">server time - refreshed every 5s (")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var28 string
+		templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs(load)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/patterns.templ`, Line: 167, Col: 86}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, ")</span></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// PatternCounterProps carries the stateless counter demo state in hx-vals.
+type PatternCounterProps struct {
+	Count int
+}
+
+// PatternCounterButton replaces itself on each click and updates the badge
+// elsewhere in the panel via an out-of-band swap in the same response.
+func PatternCounterButton(props PatternCounterProps) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var29 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var29 == nil {
+			templ_7745c5c3_Var29 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "<button id=\"oob-counter-btn\" hx-post=\"/patterns/api/counter\" hx-vals=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var30 string
+		templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf(`{"count": "%d"}`, props.Count))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/patterns.templ`, Line: 182, Col: 55}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var30))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "\" hx-swap=\"outerHTML\" class=\"btn btn-primary\">Add item</button>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// PatternCounterBadge is the second region the counter response updates
+// out-of-band — one request, two swaps.
+func PatternCounterBadge(count int, oob bool) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var31 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var31 == nil {
+			templ_7745c5c3_Var31 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "<span id=\"oob-total\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if oob {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, " hx-swap-oob=\"true\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, " class=\"px-3 py-1 rounded-full text-sm bg-primary/10 text-primary tabular-nums\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var32 string
+		templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d added", count))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/patterns.templ`, Line: 200, Col: 34}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var32))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "</span>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// PatternCounterResponse is the full counter payload: the replacement button
+// plus the OOB badge.
+func PatternCounterResponse(props PatternCounterProps) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var33 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var33 == nil {
+			templ_7745c5c3_Var33 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = PatternCounterButton(props).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = PatternCounterBadge(props.Count, true).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// PatternConfirmResult replaces the confirm-delete demo row once confirmed.
+func PatternConfirmResult() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var34 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var34 == nil {
+			templ_7745c5c3_Var34 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "<div class=\"p-3 rounded-md bg-success/10 text-success text-sm\" role=\"status\">Deleted - hx-confirm gated the request and hx-disabled-elt held the button while it ran.</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// PatternTransitionCard cycles three token-tinted cards; the swap animates
+// via the View Transitions API (hx-swap "transition:true").
+func PatternTransitionCard(step int) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var35 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var35 == nil {
+			templ_7745c5c3_Var35 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		switch step % 3 {
+		case 0:
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "<div class=\"p-6 rounded-lg bg-primary/15 border border-primary\"><h4 class=\"font-semibold mb-1\">Teal</h4><p class=\"text-sm text-muted-foreground\">Swapped with a cross-fade via the View Transitions API - no animation library.</p></div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		case 1:
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "<div class=\"p-6 rounded-lg bg-accent/30 border border-accent\"><h4 class=\"font-semibold mb-1\">Sage</h4><p class=\"text-sm text-muted-foreground\">Each swap is a plain HTMX innerHTML swap with transition:true.</p></div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		default:
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "<div class=\"p-6 rounded-lg bg-danger/10 border border-danger\"><h4 class=\"font-semibold mb-1\">Bittersweet</h4><p class=\"text-sm text-muted-foreground\">Browsers without the API just swap instantly - progressive enhancement.</p></div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "<button hx-get=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var36 string
+		templ_7745c5c3_Var36, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("/patterns/api/transition?step=%d", step+1))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/patterns.templ`, Line: 240, Col: 66}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var36))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, "\" hx-target=\"#vt-card\" hx-swap=\"innerHTML transition:true\" class=\"btn btn-secondary mt-3\">Next card</button>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// PatternSlowContent lands after the server-side delay in the
+// loading-states demo.
+func PatternSlowContent() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var37 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var37 == nil {
+			templ_7745c5c3_Var37 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "<div class=\"p-3 rounded-md bg-success/10 text-success text-sm\" role=\"status\">Loaded. While this request ran, the button was disabled (hx-disabled-elt) and the spinner showed (hx-indicator).</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
 var _ = templruntime.GeneratedTemplate

--- a/web/static/css/input.css
+++ b/web/static/css/input.css
@@ -108,6 +108,17 @@
   }
 }
 
+/* Per-element in-flight feedback: htmx adds .htmx-request to the triggering
+   element for the duration of the request. This replaces the removed global
+   overlay, which flashed the whole screen on every fragment swap. */
+@layer components {
+  button.htmx-request,
+  form.htmx-request button[type="submit"] {
+    opacity: 0.65;
+    cursor: progress;
+  }
+}
+
 /* Custom utilities */
 @utility text-shadow {
   text-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -9,6 +9,15 @@ document.addEventListener('alpine:init', () => {
       this.open = !this.open;
     }
   }));
+
+  // Cross-component state for the /patterns global-store demo: unrelated
+  // x-data islands read and write this via $store.demo.
+  Alpine.store('demo', {
+    count: 0,
+    inc() {
+      this.count++;
+    }
+  });
 });
 
 // HTMX event listeners
@@ -40,14 +49,7 @@ document.addEventListener('DOMContentLoaded', () => {
   console.log('Go Performance Starter loaded');
 });
 
-// Global HTMX loading indicator — the overlay markup lives in the base
-// layout; the listeners live here because inline <script> is CSP-forbidden
-// (ADR-028). Events bubble to document, so this covers swapped content too.
-document.addEventListener('htmx:beforeRequest', () => {
-  const el = document.getElementById('global-loading');
-  if (el) el.classList.remove('hidden');
-});
-document.addEventListener('htmx:afterRequest', () => {
-  const el = document.getElementById('global-loading');
-  if (el) el.classList.add('hidden');
-});
+// No global loading overlay: it flashed the whole screen on every fragment
+// swap. In-flight feedback is per-element — htmx puts .htmx-request on the
+// triggering element (styled in input.css); hx-indicator and hx-disabled-elt
+// handle explicit spinners and disabled submit buttons.


### PR DESCRIPTION
## What

Answers both halves of "why does the screen flash, and are we showcasing everything?": removes the flash at its root, and grows the showcase from 12 to 19 patterns.

## Why

**The flash**: the base layout shipped a full-screen `fixed inset-0` loading overlay toggled on `htmx:beforeRequest`/`afterRequest` — every fragment swap (even 50ms ones) strobed the entire screen. Global modal overlays for AJAX are an HTMX anti-pattern; in-flight feedback belongs on the element that triggered the request.

**Coverage**: the original 12 patterns covered the core but skipped several of HTMX's and Alpine's best tricks.

## How

- **Overlay removed** (+ its app.js listeners); replaced with `.htmx-request` button styling in `input.css`, and the existing `hx-indicator`/`hx-disabled-elt` tools — now also *taught* by a dedicated pattern. A server test pins the overlay's absence.
- **7 new patterns**, each with live demo + tabbed source: `polling` (live server time, `hx-trigger="load, every 5s"`), `oob-swap` (one response updates two regions via `hx-swap-oob`), `confirm-delete` (`hx-confirm` + `hx-disabled-elt`), `view-transitions` (`hx-swap="... transition:true"` — View Transitions API cross-fade, zero animation code), `loading-states` (the right way, against a deliberately slow endpoint, capped 1.5s), `modal` (Alpine `x-teleport`, Escape/backdrop close, `aria-modal`), `global-store` (`Alpine.store` shared across unrelated components).
- **Latent bug fixed**: `app.js` loaded at the end of `<body>`, but deferred Alpine starts and fires `alpine:init` the moment it executes — so `Alpine.data`/`Alpine.store` registrations never ran. `app.js` now loads in `<head>` before Alpine (the documented Alpine ordering).

Deliberately not included (documented choice): `hx-boost` (this starter favors real navigations), SSE/WebSocket extensions (extra JS weight vs. polling demo), `hx-delete`/`hx-patch` verbs (plain-form progressive enhancement uses POST), Alpine plugins (`$persist`, focus-trap — core-only budget).

## Testing

- [x] Tests first: 7 new slug anchors + 5 endpoint rows red → green
- [x] `task ci` green (JS 32.2KB/50KB, CSS 7.5KB/30KB gzipped)
- [x] Browser-verified each new pattern live: polling ticks, OOB badge counts, confirm gates + result, VT card cycles, slow-load disables button + spinner + re-enables, modal opens/Escape-closes, store shared across islands

🤖 Generated with [Claude Code](https://claude.com/claude-code)