### PR TITLE
feat(patterns): group 19 patterns into 5 categories with docs-style discovery

### DIFF
--- a/internal/handler/patterns_handlers.go
+++ b/internal/handler/patterns_handlers.go
@@ -57,12 +57,38 @@ var patternStubData = []string{
 
 const patternScrollPerPage = 5
 
+// patternCategories are the teaching groups the showcase is organized by,
+// in display order. Every catalogue entry names one (enforced by test).
+var patternCategories = []view.PatternCategory{
+	{Slug: "fetch-swap", Title: "Fetch & swap", Blurb: "The core loop: an attribute fires a request, the server renders HTML, HTMX places it."},
+	{Slug: "search-lists", Title: "Search & lists", Blurb: "Server-filtered results with debounce, indicators, and pagination that loads itself."},
+	{Slug: "forms-actions", Title: "Forms & actions", Blurb: "Validation, editing, confirmation, and honest in-flight feedback — all server-round-trip."},
+	{Slug: "server-driven", Title: "Server-driven UX", Blurb: "Responses that steer the page: toasts from headers, multi-region swaps, animated transitions."},
+	{Slug: "alpine-islands", Title: "Alpine islands", Blurb: "The client-only slice: state, teleported modals, and stores shared across components."},
+}
+
+// patternGroups orders the catalogue by category for the grouped page.
+func patternGroups() []view.PatternGroup {
+	groups := make([]view.PatternGroup, 0, len(patternCategories))
+	for _, cat := range patternCategories {
+		g := view.PatternGroup{Category: cat}
+		for _, s := range patternsCatalog {
+			if s.Category == cat.Slug {
+				g.Sections = append(g.Sections, s)
+			}
+		}
+		groups = append(groups, g)
+	}
+	return groups
+}
+
 // patternsCatalog drives the showcase sections. Source snippets are abridged
 // from the real handlers and templates below (kept in sync by hand — see
 // ux-overhaul-spec.md for the generated-source future iteration).
 var patternsCatalog = []view.PatternSection{
 	{
 		Slug:         "partial-swap",
+		Category:     "fetch-swap",
 		Title:        "Partial swap",
 		Summary:      "Click a button, replace a fragment. The simplest HTMX pattern — a GET returns rendered HTML and hx-target places it.",
 		HTMXFeatures: []string{"hx-get", "hx-target", "hx-swap"},
@@ -78,6 +104,7 @@ var patternsCatalog = []view.PatternSection{
 	},
 	{
 		Slug:         "live-search",
+		Category:     "search-lists",
 		Title:        "Live search",
 		Summary:      "Type in a search box; results filter server-side with a debounce, so the server stays the single source of truth.",
 		HTMXFeatures: []string{"hx-get", `hx-trigger="keyup changed delay:300ms"`, "hx-target"},
@@ -92,6 +119,7 @@ view.Render(w, r, http.StatusOK,
 	},
 	{
 		Slug:         "click-to-edit",
+		Category:     "forms-actions",
 		Title:        "Click to edit",
 		Summary:      "Click text to turn it into an edit form; saving swaps the display view back in. Two endpoints, zero client state.",
 		HTMXFeatures: []string{"hx-get", "hx-put", "hx-swap"},
@@ -107,6 +135,7 @@ view.Render(w, r, http.StatusOK,
 	},
 	{
 		Slug:           "inline-validation",
+		Category:       "forms-actions",
 		Title:          "Inline validation",
 		Summary:        "Alpine validates as you type; the server re-checks on submit and returns field errors into the same markup.",
 		HTMXFeatures:   []string{"hx-post", "hx-target"},
@@ -123,6 +152,7 @@ view.Render(w, r, http.StatusOK,
 	},
 	{
 		Slug:           "optimistic-ui",
+		Category:       "forms-actions",
 		Title:          "Optimistic UI",
 		Summary:        "A favorite toggle that swaps instantly — current state rides along in hx-vals, so the endpoint stays stateless.",
 		HTMXFeatures:   []string{"hx-post", `hx-swap="outerHTML"`, "hx-vals"},
@@ -140,6 +170,7 @@ view.Render(w, r, http.StatusOK,
 	},
 	{
 		Slug:         "infinite-scroll",
+		Category:     "search-lists",
 		Title:        "Infinite scroll",
 		Summary:      "Scroll to the bottom and the next page loads automatically; the sentinel row replaces itself with each new page.",
 		HTMXFeatures: []string{"hx-get", `hx-trigger="revealed"`, `hx-swap="outerHTML"`},
@@ -154,6 +185,7 @@ view.Render(w, r, http.StatusOK,
 	},
 	{
 		Slug:         "typeahead",
+		Category:     "search-lists",
 		Title:        "Active search (typeahead)",
 		Summary:      "Like live search, plus a loading indicator that HTMX toggles for you while the request is in flight.",
 		HTMXFeatures: []string{"hx-get", `hx-trigger="keyup changed delay:200ms"`, "hx-indicator"},
@@ -167,6 +199,7 @@ view.Render(w, r, http.StatusOK,
 	},
 	{
 		Slug:           "toasts",
+		Category:       "server-driven",
 		Title:          "Toast notifications",
 		Summary:        "The response body swaps a tiny status line; the toast itself fires from the HX-Trigger header into an Alpine listener.",
 		HTMXFeatures:   []string{"HX-Trigger", "HX-Toast-Type"},
@@ -182,6 +215,7 @@ view.Render(w, r, http.StatusOK,
 	},
 	{
 		Slug:           "dark-mode",
+		Category:       "alpine-islands",
 		Title:          "Dark mode",
 		Summary:        "Alpine state seeded from the system preference, persisted to localStorage, applied as a class on the root element.",
 		AlpineFeatures: []string{"x-data", "$watch", "localStorage"},
@@ -194,6 +228,7 @@ view.Render(w, r, http.StatusOK,
 	},
 	{
 		Slug:           "skeleton-loading",
+		Category:       "fetch-swap",
 		Title:          "Skeleton loading",
 		Summary:        "A CSS skeleton renders instantly; HTMX replaces it with real content on a delayed load trigger.",
 		HTMXFeatures:   []string{"hx-get", `hx-trigger="load delay:1.5s"`},
@@ -210,6 +245,7 @@ view.Render(w, r, http.StatusOK,
 	},
 	{
 		Slug:           "tabs",
+		Category:       "fetch-swap",
 		Title:          "Tabs",
 		Summary:        "Tab buttons fetch server-rendered panels; Alpine handles the client-only variant (see the source panel you're using).",
 		HTMXFeatures:   []string{"hx-get", "hx-target"},
@@ -225,6 +261,7 @@ view.Render(w, r, http.StatusOK,
 	},
 	{
 		Slug:           "bulk-operations",
+		Category:       "forms-actions",
 		Title:          "Bulk operations",
 		Summary:        "Alpine tracks the checkbox selection client-side; one HTMX POST submits the whole batch as form values.",
 		HTMXFeatures:   []string{"hx-post", "hx-target"},
@@ -245,6 +282,7 @@ view.Render(w, r, http.StatusOK,
 	},
 	{
 		Slug:         "polling",
+		Category:     "fetch-swap",
 		Title:        "Polling",
 		Summary:      "A live server value without WebSockets: the element re-fetches itself on a fixed interval — the whole real-time stack is one attribute.",
 		HTMXFeatures: []string{`hx-trigger="load, every 5s"`, "hx-get"},
@@ -257,6 +295,7 @@ view.Render(w, r, http.StatusOK,
 	},
 	{
 		Slug:         "oob-swap",
+		Category:     "server-driven",
 		Title:        "Out-of-band swap",
 		Summary:      "One response updates two regions: the button replaces itself, and a badge elsewhere updates via hx-swap-oob riding the same payload.",
 		HTMXFeatures: []string{"hx-swap-oob", "hx-vals", `hx-swap="outerHTML"`},
@@ -272,6 +311,7 @@ view.Render(w, r, http.StatusOK,
 	},
 	{
 		Slug:         "confirm-delete",
+		Category:     "forms-actions",
 		Title:        "Confirm + disabled button",
 		Summary:      "hx-confirm gates the request behind a native confirm dialog; hx-disabled-elt holds the button while the request runs.",
 		HTMXFeatures: []string{"hx-confirm", `hx-disabled-elt="this"`, "hx-post"},
@@ -286,6 +326,7 @@ view.Render(w, r, http.StatusOK,
 	},
 	{
 		Slug:         "view-transitions",
+		Category:     "server-driven",
 		Title:        "View Transitions",
 		Summary:      "transition:true on the swap animates it through the browser's View Transitions API — cross-fade with zero animation code, instant fallback elsewhere.",
 		HTMXFeatures: []string{`hx-swap="innerHTML transition:true"`},
@@ -300,6 +341,7 @@ view.Render(w, r, http.StatusOK,
 	},
 	{
 		Slug:         "loading-states",
+		Category:     "forms-actions",
 		Title:        "Loading states",
 		Summary:      "The right way to show in-flight work: a per-element spinner (hx-indicator) and a disabled trigger (hx-disabled-elt) — never a full-screen overlay.",
 		HTMXFeatures: []string{"hx-indicator", `hx-disabled-elt="this"`},
@@ -318,6 +360,7 @@ view.Render(w, r, http.StatusOK,
 	},
 	{
 		Slug:           "modal",
+		Category:       "alpine-islands",
 		Title:          "Modal (teleport)",
 		Summary:        "An accessible Alpine modal: x-teleport lifts it to <body> so no ancestor clips it, Escape and backdrop close it, focus lands inside.",
 		AlpineFeatures: []string{"x-teleport", "x-show", "@keydown.escape.window", "x-transition"},
@@ -334,6 +377,7 @@ view.Render(w, r, http.StatusOK,
 	},
 	{
 		Slug:           "global-store",
+		Category:       "alpine-islands",
 		Title:          "Global store",
 		Summary:        "Alpine.store shares state across unrelated components: two separate x-data islands read and write one store registered in app.js.",
 		AlpineFeatures: []string{"Alpine.store", "$store", "x-text"},
@@ -360,7 +404,7 @@ var patternTabs = map[string]string{
 func PatternsPage(w http.ResponseWriter, r *http.Request) {
 	props := pages.PatternsPageProps{
 		BaseProps: view.NewBaseProps("Pattern Showcase"),
-		Sections:  patternsCatalog,
+		Groups:    patternGroups(),
 	}
 	if err := view.Render(w, r, http.StatusOK, pages.PatternsPage(props)); err != nil {
 		slog.Error("Failed to render patterns page", "error", err)

--- a/internal/handler/patterns_handlers_test.go
+++ b/internal/handler/patterns_handlers_test.go
@@ -213,3 +213,57 @@ func TestPatternsAPI(t *testing.T) {
 		})
 	}
 }
+
+// TestPatternsCatalogCategorized pins the discovery model: every pattern
+// belongs to one of the five teaching categories, and every category has at
+// least one pattern — an uncategorized entry would silently fall out of the
+// grouped page.
+func TestPatternsCatalogCategorized(t *testing.T) {
+	valid := make(map[string]bool)
+	for _, c := range patternCategories {
+		valid[c.Slug] = true
+	}
+	if len(valid) != 5 {
+		t.Fatalf("expected 5 pattern categories, got %d", len(valid))
+	}
+
+	seen := make(map[string]int)
+	for _, s := range patternsCatalog {
+		if !valid[s.Category] {
+			t.Errorf("pattern %q has unknown category %q", s.Slug, s.Category)
+		}
+		seen[s.Category]++
+	}
+	for slug := range valid {
+		if seen[slug] == 0 {
+			t.Errorf("category %q has no patterns", slug)
+		}
+	}
+}
+
+// TestPatternsPageDiscovery pins the navigation/discovery layer: a sidebar
+// TOC for the scroll-spy to drive, and one grouped section per category.
+func TestPatternsPageDiscovery(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/patterns", nil)
+	w := httptest.NewRecorder()
+
+	newPatternsRouter().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /patterns status = %d, want 200", w.Code)
+	}
+	body := w.Body.String()
+
+	if !strings.Contains(body, `data-testid="patterns-nav"`) {
+		t.Error("patterns page missing the sidebar TOC nav")
+	}
+	if got := strings.Count(body, `data-testid="pattern-category"`); got != 5 {
+		t.Errorf("patterns page renders %d category sections, want 5", got)
+	}
+	// Every pattern must keep its anchor so deep links and the TOC work.
+	for _, slug := range patternSlugs {
+		if !strings.Contains(body, `id="`+slug+`"`) {
+			t.Errorf("pattern %q lost its section anchor in the grouped layout", slug)
+		}
+	}
+}

--- a/internal/view/models.go
+++ b/internal/view/models.go
@@ -6,10 +6,24 @@ type PatternSection struct {
 	Slug           string
 	Title          string
 	Summary        string
+	Category       string // slug of the PatternCategory this belongs to
 	HTMXFeatures   []string
 	AlpineFeatures []string
 	TemplSource    string
 	HandlerSource  string
+}
+
+// PatternCategory is one teaching group on the showcase.
+type PatternCategory struct {
+	Slug  string
+	Title string
+	Blurb string
+}
+
+// PatternGroup pairs a category with its patterns, in display order.
+type PatternGroup struct {
+	Category PatternCategory
+	Sections []PatternSection
 }
 
 // QuizScore is the running quiz progress shown on the quiz surfaces (ADR-024).

--- a/internal/view/pages/patterns.templ
+++ b/internal/view/pages/patterns.templ
@@ -6,35 +6,77 @@ import (
 	"github.com/clownware/go-performance-starter/internal/view/partials"
 )
 
-// PatternsPageProps holds data for the /patterns showcase (ADR-024 surface 2).
+// PatternsPageProps holds data for the /patterns showcase (ADR-024 surface 2),
+// grouped by teaching category for discovery.
 type PatternsPageProps struct {
 	view.BaseProps
-	Sections []view.PatternSection
+	Groups []view.PatternGroup
 }
 
 templ PatternsPage(props PatternsPageProps) {
 	@layouts.Base(props.BaseProps) {
 		<h1 class="text-2xl font-semibold mb-2">Pattern Showcase</h1>
 		<p class="text-muted-foreground mb-6 max-w-2xl">
-			Every HTMX and Alpine.js pattern this starter supports, live. Each demo is
-			the real thing — the source shown next to it is what serves it.
+			Every HTMX and Alpine.js pattern this starter supports, live and grouped
+			by what it teaches. Each demo is the real thing — the source shown next
+			to it is what serves it.
 		</p>
-		<nav aria-label="Patterns" class="mb-10 flex flex-wrap gap-2">
-			for _, s := range props.Sections {
-				<a href={ templ.SafeURL("#" + s.Slug) } class="px-3 py-1 rounded-full text-sm bg-surface border border-border hover:border-primary focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary">
-					{ s.Title }
-				</a>
-			}
-		</nav>
-		for _, s := range props.Sections {
+		<div class="lg:grid lg:grid-cols-[230px_minmax(0,1fr)] lg:gap-10">
+			<!-- Desktop: sticky TOC; app.js scroll-spy marks the section in view -->
+			<aside class="hidden lg:block">
+				<nav data-testid="patterns-nav" aria-label="Patterns" class="sticky top-8 max-h-[calc(100vh-4rem)] overflow-y-auto pr-2 text-sm">
+					for _, g := range props.Groups {
+						<p class="uppercase tracking-wide text-xs text-muted-foreground mt-5 mb-1 first:mt-0">{ g.Category.Title }</p>
+						<ul>
+							for _, s := range g.Sections {
+								<li>
+									<a
+										href={ templ.SafeURL("#" + s.Slug) }
+										class="block py-1 text-muted-foreground hover:text-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary rounded"
+									>
+										{ s.Title }
+									</a>
+								</li>
+							}
+						</ul>
+					}
+				</nav>
+			</aside>
+			<div>
+				<!-- Mobile: grouped pills replace the sidebar -->
+				<nav aria-label="Patterns" class="mb-10 lg:hidden">
+					for _, g := range props.Groups {
+						<p class="uppercase tracking-wide text-xs text-muted-foreground mt-4 mb-2 first:mt-0">{ g.Category.Title }</p>
+						<div class="flex flex-wrap gap-2">
+							for _, s := range g.Sections {
+								<a href={ templ.SafeURL("#" + s.Slug) } class="px-3 py-1 rounded-full text-sm bg-surface border border-border hover:border-primary focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary">
+									{ s.Title }
+								</a>
+							}
+						</div>
+					}
+				</nav>
+				for _, g := range props.Groups {
+					@patternCategorySection(g)
+				}
+			</div>
+		</div>
+	}
+}
+
+templ patternCategorySection(g view.PatternGroup) {
+	<section data-testid="pattern-category" aria-labelledby={ "cat-" + g.Category.Slug } class="mb-20">
+		<h2 id={ "cat-" + g.Category.Slug } class="text-2xl font-bold mb-1 pb-2 border-b border-border">{ g.Category.Title }</h2>
+		<p class="text-muted-foreground mt-2 mb-10 max-w-2xl">{ g.Category.Blurb }</p>
+		for _, s := range g.Sections {
 			@patternSection(s)
 		}
-	}
+	</section>
 }
 
 templ patternSection(s view.PatternSection) {
 	<section id={ s.Slug } class="mb-14 scroll-mt-24" aria-labelledby={ s.Slug + "-title" }>
-		<h2 id={ s.Slug + "-title" } class="text-xl font-semibold mb-1">{ s.Title }</h2>
+		<h3 id={ s.Slug + "-title" } class="text-xl font-semibold mb-1">{ s.Title }</h3>
 		<p class="text-muted-foreground mb-3 max-w-2xl">{ s.Summary }</p>
 		<div class="flex flex-wrap gap-2 mb-4">
 			for _, f := range s.HTMXFeatures {

--- a/internal/view/pages/patterns_templ.go
+++ b/internal/view/pages/patterns_templ.go
@@ -14,10 +14,11 @@ import (
 	"github.com/clownware/go-performance-starter/internal/view/partials"
 )
 
-// PatternsPageProps holds data for the /patterns showcase (ADR-024 surface 2).
+// PatternsPageProps holds data for the /patterns showcase (ADR-024 surface 2),
+// grouped by teaching category for discovery.
 type PatternsPageProps struct {
 	view.BaseProps
-	Sections []view.PatternSection
+	Groups []view.PatternGroup
 }
 
 func PatternsPage(props PatternsPageProps) templ.Component {
@@ -53,55 +54,232 @@ func PatternsPage(props PatternsPageProps) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<h1 class=\"text-2xl font-semibold mb-2\">Pattern Showcase</h1><p class=\"text-muted-foreground mb-6 max-w-2xl\">Every HTMX and Alpine.js pattern this starter supports, live. Each demo is the real thing — the source shown next to it is what serves it.</p><nav aria-label=\"Patterns\" class=\"mb-10 flex flex-wrap gap-2\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<h1 class=\"text-2xl font-semibold mb-2\">Pattern Showcase</h1><p class=\"text-muted-foreground mb-6 max-w-2xl\">Every HTMX and Alpine.js pattern this starter supports, live and grouped by what it teaches. Each demo is the real thing — the source shown next to it is what serves it.</p><div class=\"lg:grid lg:grid-cols-[230px_minmax(0,1fr)] lg:gap-10\"><!-- Desktop: sticky TOC; app.js scroll-spy marks the section in view --><aside class=\"hidden lg:block\"><nav data-testid=\"patterns-nav\" aria-label=\"Patterns\" class=\"sticky top-8 max-h-[calc(100vh-4rem)] overflow-y-auto pr-2 text-sm\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			for _, s := range props.Sections {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<a href=\"")
+			for _, g := range props.Groups {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<p class=\"uppercase tracking-wide text-xs text-muted-foreground mt-5 mb-1 first:mt-0\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var3 templ.SafeURL
-				templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL("#" + s.Slug))
+				var templ_7745c5c3_Var3 string
+				templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(g.Category.Title)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/patterns.templ`, Line: 24, Col: 41}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/patterns.templ`, Line: 29, Col: 110}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "\" class=\"px-3 py-1 rounded-full text-sm bg-surface border border-border hover:border-primary focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</p><ul>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var4 string
-				templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(s.Title)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/patterns.templ`, Line: 25, Col: 14}
+				for _, s := range g.Sections {
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "<li><a href=\"")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var4 templ.SafeURL
+					templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL("#" + s.Slug))
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/patterns.templ`, Line: 34, Col: 44}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "\" class=\"block py-1 text-muted-foreground hover:text-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary rounded\">")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var5 string
+					templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(s.Title)
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/patterns.templ`, Line: 37, Col: 19}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</a></li>")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</a>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</ul>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</nav>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</nav></aside><div><!-- Mobile: grouped pills replace the sidebar --><nav aria-label=\"Patterns\" class=\"mb-10 lg:hidden\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			for _, s := range props.Sections {
-				templ_7745c5c3_Err = patternSection(s).Render(ctx, templ_7745c5c3_Buffer)
+			for _, g := range props.Groups {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<p class=\"uppercase tracking-wide text-xs text-muted-foreground mt-4 mb-2 first:mt-0\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
+				var templ_7745c5c3_Var6 string
+				templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(g.Category.Title)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/patterns.templ`, Line: 49, Col: 110}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</p><div class=\"flex flex-wrap gap-2\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				for _, s := range g.Sections {
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<a href=\"")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var7 templ.SafeURL
+					templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL("#" + s.Slug))
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/patterns.templ`, Line: 52, Col: 45}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "\" class=\"px-3 py-1 rounded-full text-sm bg-surface border border-border hover:border-primary focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary\">")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var8 string
+					templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(s.Title)
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/patterns.templ`, Line: 53, Col: 18}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "</a>")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</div>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "</nav>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			for _, g := range props.Groups {
+				templ_7745c5c3_Err = patternCategorySection(g).Render(ctx, templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</div></div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
 			}
 			return nil
 		})
 		templ_7745c5c3_Err = layouts.Base(props.BaseProps).Render(templ.WithChildren(ctx, templ_7745c5c3_Var2), templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+func patternCategorySection(g view.PatternGroup) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var9 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var9 == nil {
+			templ_7745c5c3_Var9 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<section data-testid=\"pattern-category\" aria-labelledby=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var10 string
+		templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs("cat-" + g.Category.Slug)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/patterns.templ`, Line: 68, Col: 83}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "\" class=\"mb-20\"><h2 id=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var11 string
+		templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs("cat-" + g.Category.Slug)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/patterns.templ`, Line: 69, Col: 35}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "\" class=\"text-2xl font-bold mb-1 pb-2 border-b border-border\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var12 string
+		templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(g.Category.Title)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/patterns.templ`, Line: 69, Col: 116}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "</h2><p class=\"text-muted-foreground mt-2 mb-10 max-w-2xl\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var13 string
+		templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(g.Category.Blurb)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/patterns.templ`, Line: 70, Col: 74}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "</p>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		for _, s := range g.Sections {
+			templ_7745c5c3_Err = patternSection(s).Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "</section>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -125,119 +303,119 @@ func patternSection(s view.PatternSection) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var5 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var5 == nil {
-			templ_7745c5c3_Var5 = templ.NopComponent
+		templ_7745c5c3_Var14 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var14 == nil {
+			templ_7745c5c3_Var14 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<section id=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "<section id=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var6 string
-		templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(s.Slug)
+		var templ_7745c5c3_Var15 string
+		templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(s.Slug)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/patterns.templ`, Line: 36, Col: 21}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/patterns.templ`, Line: 78, Col: 21}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "\" class=\"mb-14 scroll-mt-24\" aria-labelledby=\"")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var7 string
-		templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(s.Slug + "-title")
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/patterns.templ`, Line: 36, Col: 86}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "\" class=\"mb-14 scroll-mt-24\" aria-labelledby=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "\"><h2 id=\"")
+		var templ_7745c5c3_Var16 string
+		templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(s.Slug + "-title")
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/patterns.templ`, Line: 78, Col: 86}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var8 string
-		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(s.Slug + "-title")
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/patterns.templ`, Line: 37, Col: 28}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "\"><h3 id=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "\" class=\"text-xl font-semibold mb-1\">")
+		var templ_7745c5c3_Var17 string
+		templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(s.Slug + "-title")
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/patterns.templ`, Line: 79, Col: 28}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var9 string
-		templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(s.Title)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/patterns.templ`, Line: 37, Col: 75}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "\" class=\"text-xl font-semibold mb-1\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</h2><p class=\"text-muted-foreground mb-3 max-w-2xl\">")
+		var templ_7745c5c3_Var18 string
+		templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(s.Title)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/patterns.templ`, Line: 79, Col: 75}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var10 string
-		templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(s.Summary)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/patterns.templ`, Line: 38, Col: 61}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "</h3><p class=\"text-muted-foreground mb-3 max-w-2xl\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "</p><div class=\"flex flex-wrap gap-2 mb-4\">")
+		var templ_7745c5c3_Var19 string
+		templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(s.Summary)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/patterns.templ`, Line: 80, Col: 61}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "</p><div class=\"flex flex-wrap gap-2 mb-4\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		for _, f := range s.HTMXFeatures {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<code class=\"text-xs px-2 py-1 rounded bg-primary/10 text-primary\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "<code class=\"text-xs px-2 py-1 rounded bg-primary/10 text-primary\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var11 string
-			templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(f)
+			var templ_7745c5c3_Var20 string
+			templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(f)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/patterns.templ`, Line: 41, Col: 74}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/patterns.templ`, Line: 83, Col: 74}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "</code> ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "</code> ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
 		for _, f := range s.AlpineFeatures {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "<code class=\"text-xs px-2 py-1 rounded bg-accent/30 text-foreground\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "<code class=\"text-xs px-2 py-1 rounded bg-accent/30 text-foreground\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var12 string
-			templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(f)
+			var templ_7745c5c3_Var21 string
+			templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(f)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/patterns.templ`, Line: 44, Col: 76}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/patterns.templ`, Line: 86, Col: 76}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "</code>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "</code>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</div><div class=\"grid lg:grid-cols-2 gap-4 items-start\"><div class=\"bg-surface rounded-lg shadow-md p-6\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "</div><div class=\"grid lg:grid-cols-2 gap-4 items-start\"><div class=\"bg-surface rounded-lg shadow-md p-6\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -245,7 +423,7 @@ func patternSection(s view.PatternSection) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -253,7 +431,7 @@ func patternSection(s view.PatternSection) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "</div></section>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "</div></section>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -277,38 +455,38 @@ func patternSource(s view.PatternSection) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var13 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var13 == nil {
-			templ_7745c5c3_Var13 = templ.NopComponent
+		templ_7745c5c3_Var22 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var22 == nil {
+			templ_7745c5c3_Var22 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "<div x-data=\"{ tab: 'templ' }\" class=\"rounded-lg overflow-hidden border border-border\"><div role=\"tablist\" class=\"flex border-b border-border text-sm\"><button role=\"tab\" @click=\"tab = 'templ'\" :aria-selected=\"(tab === 'templ').toString()\" :class=\"tab === 'templ' ? 'bg-surface font-medium' : 'text-muted-foreground'\" class=\"px-4 py-2\">Template</button> <button role=\"tab\" @click=\"tab = 'handler'\" :aria-selected=\"(tab === 'handler').toString()\" :class=\"tab === 'handler' ? 'bg-surface font-medium' : 'text-muted-foreground'\" class=\"px-4 py-2\">Handler</button></div><pre x-show=\"tab === 'templ'\" class=\"p-4 text-xs overflow-x-auto\"><code>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "<div x-data=\"{ tab: 'templ' }\" class=\"rounded-lg overflow-hidden border border-border\"><div role=\"tablist\" class=\"flex border-b border-border text-sm\"><button role=\"tab\" @click=\"tab = 'templ'\" :aria-selected=\"(tab === 'templ').toString()\" :class=\"tab === 'templ' ? 'bg-surface font-medium' : 'text-muted-foreground'\" class=\"px-4 py-2\">Template</button> <button role=\"tab\" @click=\"tab = 'handler'\" :aria-selected=\"(tab === 'handler').toString()\" :class=\"tab === 'handler' ? 'bg-surface font-medium' : 'text-muted-foreground'\" class=\"px-4 py-2\">Handler</button></div><pre x-show=\"tab === 'templ'\" class=\"p-4 text-xs overflow-x-auto\"><code>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var14 string
-		templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(s.TemplSource)
+		var templ_7745c5c3_Var23 string
+		templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(s.TemplSource)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/patterns.templ`, Line: 78, Col: 89}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/patterns.templ`, Line: 120, Col: 89}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "</code></pre><pre x-show=\"tab === 'handler'\" x-cloak class=\"p-4 text-xs overflow-x-auto\"><code>")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var15 string
-		templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(s.HandlerSource)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/patterns.templ`, Line: 79, Col: 101}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "</code></pre><pre x-show=\"tab === 'handler'\" x-cloak class=\"p-4 text-xs overflow-x-auto\"><code>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "</code></pre></div>")
+		var templ_7745c5c3_Var24 string
+		templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(s.HandlerSource)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/patterns.templ`, Line: 121, Col: 101}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "</code></pre></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -333,24 +511,24 @@ func patternDemo(slug string) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var16 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var16 == nil {
-			templ_7745c5c3_Var16 = templ.NopComponent
+		templ_7745c5c3_Var25 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var25 == nil {
+			templ_7745c5c3_Var25 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		switch slug {
 		case "partial-swap":
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "<button hx-get=\"/patterns/api/swap\" hx-target=\"#swap-demo\" hx-swap=\"innerHTML\" class=\"btn btn-primary mb-3\">Swap this fragment</button><div id=\"swap-demo\" class=\"text-sm text-muted-foreground\">Click the button — the server replaces this text.</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "<button hx-get=\"/patterns/api/swap\" hx-target=\"#swap-demo\" hx-swap=\"innerHTML\" class=\"btn btn-primary mb-3\">Swap this fragment</button><div id=\"swap-demo\" class=\"text-sm text-muted-foreground\">Click the button — the server replaces this text.</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		case "live-search":
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "<label for=\"live-search-input\" class=\"sr-only\">Search the stack</label> <input id=\"live-search-input\" type=\"search\" name=\"q\" placeholder=\"Search the stack (try 'go')...\" hx-get=\"/patterns/api/search\" hx-trigger=\"keyup changed delay:300ms\" hx-target=\"#search-results\" class=\"input w-full mb-3\"><div id=\"search-results\"></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "<label for=\"live-search-input\" class=\"sr-only\">Search the stack</label> <input id=\"live-search-input\" type=\"search\" name=\"q\" placeholder=\"Search the stack (try 'go')...\" hx-get=\"/patterns/api/search\" hx-trigger=\"keyup changed delay:300ms\" hx-target=\"#search-results\" class=\"input w-full mb-3\"><div id=\"search-results\"></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		case "click-to-edit":
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "<div id=\"edit-demo\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "<div id=\"edit-demo\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -358,12 +536,12 @@ func patternDemo(slug string) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		case "inline-validation":
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "<form x-data=\"{ email: '' }\" class=\"space-y-2\" @submit.prevent=\"\"><label for=\"inline-validation-email\" class=\"block text-sm\">Email</label> <input id=\"inline-validation-email\" type=\"email\" x-model=\"email\" class=\"input w-full\" placeholder=\"you@example.com\"><p x-show=\"email.length > 0 && !email.includes('@')\" class=\"text-danger text-sm\" role=\"alert\">That doesn't look like an email address.</p><p class=\"text-xs text-muted-foreground\">Alpine checks as you type; the same rules run server-side on submit (the profile form is the full round trip).</p></form>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "<form x-data=\"{ email: '' }\" class=\"space-y-2\" @submit.prevent=\"\"><label for=\"inline-validation-email\" class=\"block text-sm\">Email</label> <input id=\"inline-validation-email\" type=\"email\" x-model=\"email\" class=\"input w-full\" placeholder=\"you@example.com\"><p x-show=\"email.length > 0 && !email.includes('@')\" class=\"text-danger text-sm\" role=\"alert\">That doesn't look like an email address.</p><p class=\"text-xs text-muted-foreground\">Alpine checks as you type; the same rules run server-side on submit (the profile form is the full round trip).</p></form>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -373,122 +551,122 @@ func patternDemo(slug string) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		case "infinite-scroll":
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "<ul class=\"divide-y divide-border max-h-48 overflow-y-auto\" aria-label=\"Infinite scroll demo\"><li hx-get=\"/patterns/api/scroll?page=1\" hx-trigger=\"revealed\" hx-swap=\"outerHTML\" class=\"py-2 text-center text-muted-foreground\">Scroll me into view...</li></ul>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "<ul class=\"divide-y divide-border max-h-48 overflow-y-auto\" aria-label=\"Infinite scroll demo\"><li hx-get=\"/patterns/api/scroll?page=1\" hx-trigger=\"revealed\" hx-swap=\"outerHTML\" class=\"py-2 text-center text-muted-foreground\">Scroll me into view...</li></ul>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		case "typeahead":
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "<label for=\"typeahead-input\" class=\"sr-only\">Typeahead search</label> <input id=\"typeahead-input\" type=\"search\" name=\"q\" placeholder=\"Type to look ahead...\" hx-get=\"/patterns/api/typeahead\" hx-trigger=\"keyup changed delay:200ms\" hx-target=\"#typeahead-results\" hx-indicator=\"#typeahead-indicator\" class=\"input w-full mb-1\"> <span id=\"typeahead-indicator\" class=\"htmx-indicator text-xs text-muted-foreground\">Searching...</span><div id=\"typeahead-results\"></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "<label for=\"typeahead-input\" class=\"sr-only\">Typeahead search</label> <input id=\"typeahead-input\" type=\"search\" name=\"q\" placeholder=\"Type to look ahead...\" hx-get=\"/patterns/api/typeahead\" hx-trigger=\"keyup changed delay:200ms\" hx-target=\"#typeahead-results\" hx-indicator=\"#typeahead-indicator\" class=\"input w-full mb-1\"> <span id=\"typeahead-indicator\" class=\"htmx-indicator text-xs text-muted-foreground\">Searching...</span><div id=\"typeahead-results\"></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		case "toasts":
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "<div class=\"flex flex-wrap gap-2\" id=\"toast-demo-result\"><button hx-post=\"/patterns/api/toast\" hx-vals=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "<div class=\"flex flex-wrap gap-2\" id=\"toast-demo-result\"><button hx-post=\"/patterns/api/toast\" hx-vals=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var17 string
-			templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(`{"type": "success"}`)
+			var templ_7745c5c3_Var26 string
+			templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs(`{"type": "success"}`)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/patterns.templ`, Line: 149, Col: 73}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/patterns.templ`, Line: 191, Col: 73}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "\" hx-target=\"#toast-demo-status\" class=\"btn btn-primary\">Success toast</button> <button hx-post=\"/patterns/api/toast\" hx-vals=\"")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var18 string
-			templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(`{"type": "warning"}`)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/patterns.templ`, Line: 150, Col: 73}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "\" hx-target=\"#toast-demo-status\" class=\"btn btn-primary\">Success toast</button> <button hx-post=\"/patterns/api/toast\" hx-vals=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "\" hx-target=\"#toast-demo-status\" class=\"btn btn-secondary\">Warning toast</button> <button hx-post=\"/patterns/api/toast\" hx-vals=\"")
+			var templ_7745c5c3_Var27 string
+			templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(`{"type": "warning"}`)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/patterns.templ`, Line: 192, Col: 73}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var19 string
-			templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(`{"type": "error"}`)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/patterns.templ`, Line: 151, Col: 71}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "\" hx-target=\"#toast-demo-status\" class=\"btn btn-secondary\">Warning toast</button> <button hx-post=\"/patterns/api/toast\" hx-vals=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "\" hx-target=\"#toast-demo-status\" class=\"btn btn-danger\">Error toast</button></div><div id=\"toast-demo-status\" class=\"mt-2\"></div>")
+			var templ_7745c5c3_Var28 string
+			templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs(`{"type": "error"}`)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/patterns.templ`, Line: 193, Col: 71}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "\" hx-target=\"#toast-demo-status\" class=\"btn btn-danger\">Error toast</button></div><div id=\"toast-demo-status\" class=\"mt-2\"></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		case "dark-mode":
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "<p class=\"text-sm text-muted-foreground\">The toggle in the header is this pattern: Alpine state persisted to localStorage, seeded from the system preference, applied as a class on the root element. This panel restyles with it — try it.</p>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, "<p class=\"text-sm text-muted-foreground\">The toggle in the header is this pattern: Alpine state persisted to localStorage, seeded from the system preference, applied as a class on the root element. This panel restyles with it — try it.</p>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		case "skeleton-loading":
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "<div hx-get=\"/patterns/api/skeleton\" hx-trigger=\"load delay:1.5s\" hx-swap=\"innerHTML\"><div class=\"animate-pulse space-y-2\" aria-hidden=\"true\"><div class=\"h-4 rounded bg-border w-1/3\"></div><div class=\"h-3 rounded bg-border w-full\"></div><div class=\"h-3 rounded bg-border w-2/3\"></div></div></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "<div hx-get=\"/patterns/api/skeleton\" hx-trigger=\"load delay:1.5s\" hx-swap=\"innerHTML\"><div class=\"animate-pulse space-y-2\" aria-hidden=\"true\"><div class=\"h-4 rounded bg-border w-1/3\"></div><div class=\"h-3 rounded bg-border w-full\"></div><div class=\"h-3 rounded bg-border w-2/3\"></div></div></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		case "tabs":
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "<div x-data=\"{}\" role=\"tablist\" class=\"flex gap-2 mb-2\"><button role=\"tab\" hx-get=\"/patterns/api/tab/templ\" hx-target=\"#tab-demo-panel\" class=\"btn btn-secondary\">templ</button> <button role=\"tab\" hx-get=\"/patterns/api/tab/htmx\" hx-target=\"#tab-demo-panel\" class=\"btn btn-secondary\">HTMX</button> <button role=\"tab\" hx-get=\"/patterns/api/tab/alpine\" hx-target=\"#tab-demo-panel\" class=\"btn btn-secondary\">Alpine</button></div><div id=\"tab-demo-panel\" class=\"border border-border rounded-md min-h-16\"><div class=\"p-4 text-sm text-muted-foreground\">Pick a tab — its panel is rendered server-side.</div></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, "<div x-data=\"{}\" role=\"tablist\" class=\"flex gap-2 mb-2\"><button role=\"tab\" hx-get=\"/patterns/api/tab/templ\" hx-target=\"#tab-demo-panel\" class=\"btn btn-secondary\">templ</button> <button role=\"tab\" hx-get=\"/patterns/api/tab/htmx\" hx-target=\"#tab-demo-panel\" class=\"btn btn-secondary\">HTMX</button> <button role=\"tab\" hx-get=\"/patterns/api/tab/alpine\" hx-target=\"#tab-demo-panel\" class=\"btn btn-secondary\">Alpine</button></div><div id=\"tab-demo-panel\" class=\"border border-border rounded-md min-h-16\"><div class=\"p-4 text-sm text-muted-foreground\">Pick a tab — its panel is rendered server-side.</div></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		case "bulk-operations":
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "<form x-data=\"{ selected: [] }\" hx-post=\"/patterns/api/bulk\" hx-target=\"#bulk-demo-result\" class=\"space-y-2\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 53, "<form x-data=\"{ selected: [] }\" hx-post=\"/patterns/api/bulk\" hx-target=\"#bulk-demo-result\" class=\"space-y-2\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			for _, name := range []string{"Request logging", "Rate limiting", "Metrics"} {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "<label class=\"flex items-center gap-2\"><input type=\"checkbox\" name=\"selected\" value=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 54, "<label class=\"flex items-center gap-2\"><input type=\"checkbox\" name=\"selected\" value=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var20 string
-				templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(name)
+				var templ_7745c5c3_Var29 string
+				templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.JoinStringErrs(name)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/patterns.templ`, Line: 186, Col: 57}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/patterns.templ`, Line: 228, Col: 57}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "\" x-model=\"selected\" class=\"text-primary focus:ring-primary\"> <span>")
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var29))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var21 string
-				templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(name)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/patterns.templ`, Line: 187, Col: 18}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 55, "\" x-model=\"selected\" class=\"text-primary focus:ring-primary\"> <span>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "</span></label> ")
+				var templ_7745c5c3_Var30 string
+				templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinStringErrs(name)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/patterns.templ`, Line: 229, Col: 18}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var30))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 56, "</span></label> ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "<button type=\"submit\" class=\"btn btn-primary\" :disabled=\"selected.length === 0\">Archive (<span x-text=\"selected.length\"></span>)</button><div id=\"bulk-demo-result\" aria-live=\"polite\"></div></form>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 57, "<button type=\"submit\" class=\"btn btn-primary\" :disabled=\"selected.length === 0\">Archive (<span x-text=\"selected.length\"></span>)</button><div id=\"bulk-demo-result\" aria-live=\"polite\"></div></form>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		case "polling":
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "<div hx-get=\"/patterns/api/time\" hx-trigger=\"load, every 5s\" hx-swap=\"innerHTML\" aria-live=\"off\"><span class=\"text-sm text-muted-foreground\">Fetching server time...</span></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 58, "<div hx-get=\"/patterns/api/time\" hx-trigger=\"load, every 5s\" hx-swap=\"innerHTML\" aria-live=\"off\"><span class=\"text-sm text-muted-foreground\">Fetching server time...</span></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		case "oob-swap":
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "<div class=\"flex items-center justify-between gap-4\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 59, "<div class=\"flex items-center justify-between gap-4\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -500,17 +678,17 @@ func patternDemo(slug string) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "</div><p class=\"mt-3 text-xs text-muted-foreground\">The badge is a separate region — it updates via hx-swap-oob in the button's response.</p>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 60, "</div><p class=\"mt-3 text-xs text-muted-foreground\">The badge is a separate region — it updates via hx-swap-oob in the button's response.</p>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		case "confirm-delete":
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "<div><button hx-post=\"/patterns/api/confirm\" hx-confirm=\"Delete this demo item?\" hx-disabled-elt=\"this\" hx-target=\"closest div\" hx-swap=\"innerHTML\" class=\"btn btn-danger\">Delete item</button></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 61, "<div><button hx-post=\"/patterns/api/confirm\" hx-confirm=\"Delete this demo item?\" hx-disabled-elt=\"this\" hx-target=\"closest div\" hx-swap=\"innerHTML\" class=\"btn btn-danger\">Delete item</button></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		case "view-transitions":
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "<div id=\"vt-card\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 62, "<div id=\"vt-card\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -518,22 +696,22 @@ func patternDemo(slug string) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 63, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		case "loading-states":
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "<div class=\"flex items-center gap-3\"><button hx-get=\"/patterns/api/slow\" hx-indicator=\"#slow-spin\" hx-disabled-elt=\"this\" hx-target=\"#slow-out\" class=\"btn btn-primary\">Load slowly</button> <span id=\"slow-spin\" class=\"htmx-indicator text-sm text-muted-foreground\">Working...</span></div><div id=\"slow-out\" class=\"mt-3\" aria-live=\"polite\"></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 64, "<div class=\"flex items-center gap-3\"><button hx-get=\"/patterns/api/slow\" hx-indicator=\"#slow-spin\" hx-disabled-elt=\"this\" hx-target=\"#slow-out\" class=\"btn btn-primary\">Load slowly</button> <span id=\"slow-spin\" class=\"htmx-indicator text-sm text-muted-foreground\">Working...</span></div><div id=\"slow-out\" class=\"mt-3\" aria-live=\"polite\"></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		case "modal":
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "<div x-data=\"{ open: false }\"><button @click=\"open = true\" class=\"btn btn-primary\">Open modal</button><template x-teleport=\"body\"><div x-show=\"open\" x-cloak @keydown.escape.window=\"open = false\" class=\"fixed inset-0 z-50 flex items-center justify-center p-4\"><div @click=\"open = false\" class=\"absolute inset-0 bg-night/60\" aria-hidden=\"true\"></div><div role=\"dialog\" aria-modal=\"true\" aria-labelledby=\"demo-modal-title\" x-show=\"open\" x-transition class=\"relative bg-surface text-foreground rounded-lg shadow-lg p-6 max-w-sm w-full\"><h3 id=\"demo-modal-title\" class=\"text-lg font-semibold mb-2\">Teleported modal</h3><p class=\"text-sm text-muted-foreground mb-4\">This dialog lives at the end of <code>&lt;body&gt;</code> via x-teleport, so no ancestor stacking context can clip it. Escape or the backdrop closes it.</p><button @click=\"open = false\" class=\"btn btn-secondary\">Close</button></div></div></template></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 65, "<div x-data=\"{ open: false }\"><button @click=\"open = true\" class=\"btn btn-primary\">Open modal</button><template x-teleport=\"body\"><div x-show=\"open\" x-cloak @keydown.escape.window=\"open = false\" class=\"fixed inset-0 z-50 flex items-center justify-center p-4\"><div @click=\"open = false\" class=\"absolute inset-0 bg-night/60\" aria-hidden=\"true\"></div><div role=\"dialog\" aria-modal=\"true\" aria-labelledby=\"demo-modal-title\" x-show=\"open\" x-transition class=\"relative bg-surface text-foreground rounded-lg shadow-lg p-6 max-w-sm w-full\"><h3 id=\"demo-modal-title\" class=\"text-lg font-semibold mb-2\">Teleported modal</h3><p class=\"text-sm text-muted-foreground mb-4\">This dialog lives at the end of <code>&lt;body&gt;</code> via x-teleport, so no ancestor stacking context can clip it. Escape or the backdrop closes it.</p><button @click=\"open = false\" class=\"btn btn-secondary\">Close</button></div></div></template></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		case "global-store":
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "<div class=\"flex items-center justify-between gap-4\"><div x-data=\"{}\"><button @click=\"$store.demo.inc()\" class=\"btn btn-primary\">+1 from component A</button></div><div x-data=\"{}\" class=\"px-3 py-1 rounded-full text-sm bg-primary/10 text-primary tabular-nums\">Component B sees: <span x-text=\"$store.demo.count\"></span></div></div><p class=\"mt-3 text-xs text-muted-foreground\">Two unrelated x-data islands sharing one Alpine.store registered in app.js.</p>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 66, "<div class=\"flex items-center justify-between gap-4\"><div x-data=\"{}\"><button @click=\"$store.demo.inc()\" class=\"btn btn-primary\">+1 from component A</button></div><div x-data=\"{}\" class=\"px-3 py-1 rounded-full text-sm bg-primary/10 text-primary tabular-nums\">Component B sees: <span x-text=\"$store.demo.count\"></span></div></div><p class=\"mt-3 text-xs text-muted-foreground\">Two unrelated x-data islands sharing one Alpine.store registered in app.js.</p>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -53,3 +53,44 @@ document.addEventListener('DOMContentLoaded', () => {
 // swap. In-flight feedback is per-element — htmx puts .htmx-request on the
 // triggering element (styled in input.css); hx-indicator and hx-disabled-elt
 // handle explicit spinners and disabled submit buttons.
+
+// Scroll-spy for the /patterns sidebar TOC: highlight the pattern section
+// currently in view. Progressive enhancement — without JS the TOC is still
+// a working anchor list.
+document.addEventListener('DOMContentLoaded', () => {
+  const nav = document.querySelector('[data-testid="patterns-nav"]');
+  if (!nav || !('IntersectionObserver' in window)) return;
+
+  const links = new Map();
+  nav.querySelectorAll('a[href^="#"]').forEach((a) => {
+    links.set(a.getAttribute('href').slice(1), a);
+  });
+
+  const activate = (id) => {
+    links.forEach((a, key) => {
+      if (key === id) {
+        a.setAttribute('aria-current', 'location');
+        a.classList.add('text-link', 'font-medium');
+        a.classList.remove('text-muted-foreground');
+      } else {
+        a.removeAttribute('aria-current');
+        a.classList.remove('text-link', 'font-medium');
+        a.classList.add('text-muted-foreground');
+      }
+    });
+  };
+
+  const observer = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((e) => {
+        if (e.isIntersecting) activate(e.target.id);
+      });
+    },
+    // Fire when a section crosses the upper-middle band of the viewport.
+    { rootMargin: '-15% 0px -70% 0px' }
+  );
+  links.forEach((_, id) => {
+    const section = document.getElementById(id);
+    if (section) observer.observe(section);
+  });
+});


### PR DESCRIPTION
## What

Answers "should the patterns be categorized / discovery enhanced?" — yes: the showcase is now grouped into five teaching categories with a docs-style navigation layer.

## Why

At 19 patterns, the flat pill cloud wrapped into an unscannable blob and the single scroll gave no sense of place or progression.

## How

- **Five categories by what each pattern teaches**: Fetch & swap (4), Search & lists (3), Forms & actions (6), Server-driven UX (3), Alpine islands (3). Membership is data on `view.PatternSection`; a test pins that every pattern names a known category and none is empty.
- **Desktop**: sticky sidebar TOC (`230px` docs layout) with category-grouped links; an IntersectionObserver scroll-spy in `app.js` sets `aria-current` + highlight on the section in view. Pure progressive enhancement — without JS it's a plain anchor list.
- **Mobile**: grouped pills under category labels replace the sidebar.
- Heading hierarchy corrected: category `h2` → pattern `h3`; every pattern keeps its `id` anchor (test-pinned) so existing deep links survive.

## Testing

- [x] Tests first (category integrity + discovery markup + anchor preservation), red → green
- [x] `task ci` green
- [x] Browser-verified: sidebar tracks scroll (View Transitions link went active on scroll), mobile single-column with grouped pills, all demos still interactive

🤖 Generated with [Claude Code](https://claude.com/claude-code)