### PR TITLE
fix(security): trusted-proxy client IP on Fly — right-most XFF + CIDRs (#72)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,8 +36,11 @@ SUPABASE_ANON_KEY=
 # Trusted proxy networks (ADR-027): comma-separated CIDRs whose
 # X-Forwarded-For / X-Real-IP are honored for client-IP resolution. Empty
 # (default) trusts NO forwarded headers — fails closed against IP spoofing.
-# Set to your edge proxy's egress ranges in production.
-# TRUSTED_PROXY_CIDRS=173.245.48.0/20,103.21.244.0/22
+# Set to your edge proxy's ranges in production: on Fly the direct peer is
+# fly-proxy (172.16.0.0/12); behind Cloudflare use its published ranges.
+# XFF resolves right-to-left skipping trusted entries, so appending proxies
+# and multi-hop chains (Cloudflare -> Fly) are handled correctly.
+# TRUSTED_PROXY_CIDRS=172.16.0.0/12
 
 # Max request body size in bytes accepted before a handler reads it.
 # MAX_REQUEST_BODY_BYTES=1048576

--- a/docs/adr/ADR-027-Trusted-Proxy-Client-IP.md
+++ b/docs/adr/ADR-027-Trusted-Proxy-Client-IP.md
@@ -4,7 +4,7 @@
 
 ## Status
 
-Accepted (amends ADR-014 §4; refines ADR-025 §2)
+Accepted (amends ADR-014 §4; refines ADR-025 §2). **Amended 2026-07-12:** X-Forwarded-For resolution changed from left-most to right-most-untrusted — see the dated note in the Decision section.
 
 ## Context
 
@@ -21,7 +21,9 @@ Replace the unconditional `RealIP` with a **trusted-proxy-gated** resolver:
 - A new middleware `RealIP(trustedProxyCIDRs []string)` normalizes `r.RemoteAddr` to a bare IP (stripping the port so the rate-limiter key is per-IP, not per-connection), and honors the forwarded client-IP headers **only when the direct peer's address falls inside one of the configured trusted-proxy CIDRs.**
 - Configuration is `TRUSTED_PROXY_CIDRS` (ADR-015): a comma-separated CIDR list, **default empty**. Empty means *trust no forwarded headers* — the direct peer IP is used verbatim. This is the safe default: a misconfigured deployment under-counts distinct clients (fails closed toward more limiting), never over-trusts a spoofed header.
 - Deployments that terminate at a trusted proxy set `TRUSTED_PROXY_CIDRS` to that proxy's egress ranges (Cloudflare's published ranges, or the Fly private `fdaa::/16` / edge range when fronted by Fly). Documented in `.env.example` and the deployment guide.
-- We assume a **single** trusted hop and read the left-most forwarded entry. Multi-hop proxy chains are out of scope; revisit if a second trusted layer is introduced.
+- ~~We assume a **single** trusted hop and read the left-most forwarded entry. Multi-hop proxy chains are out of scope; revisit if a second trusted layer is introduced.~~
+  **Amendment (2026-07-12, issue #72):** live verification on Fly falsified the left-most assumption. Edge proxies (Fly, Cloudflare) **append** the peer they saw to any client-supplied `X-Forwarded-For` rather than stripping it, so the left-most entry is attacker-controlled the moment a trusted CIDR is configured — a client sending `X-Forwarded-For: 6.6.6.6` would land every request in a fresh rate-limit bucket, recreating the exact spoofing vector this ADR exists to close. The resolver now walks XFF **right-to-left, skipping trusted-proxy addresses and invalid entries, and takes the first remaining IP** (the nearest hop that is not our own infrastructure). An XFF consisting only of trusted entries falls back to the direct peer (fails closed). This also handles multi-hop chains (e.g. Cloudflare → Fly with both ranges trusted). The trusted-peer gate is unchanged: with `TRUSTED_PROXY_CIDRS` empty, no forwarded header is ever honored.
+  Verified values for Fly: the app's direct peer is fly-proxy at a private `172.16.0.0/12` address (observed `172.19.9.185`), so the demo sets `TRUSTED_PROXY_CIDRS=172.16.0.0/12` in `fly.toml`.
 
 ## Consequences
 

--- a/fly.toml
+++ b/fly.toml
@@ -19,6 +19,10 @@ primary_region = "ewr"
   # Non-secret tuning lives here, versioned — not in `fly secrets` where it
   # becomes invisible and gets lost on app migrations.
   DB_MAX_CONNS = "10"
+  # fly-proxy is the direct peer (observed 172.19.x.x, issue #72); trusting
+  # its private range makes per-client rate limiting see real visitor IPs
+  # instead of one shared bucket (ADR-027).
+  TRUSTED_PROXY_CIDRS = "172.16.0.0/12"
   # Anonymous guest identities (ADR-024): requires "anonymous sign-ins"
   # enabled in the Supabase project (done 2026-07). Visitors to /learn get a
   # real Supabase identity server-side; the TTL reaper expires stale ones.

--- a/internal/middleware/realip.go
+++ b/internal/middleware/realip.go
@@ -14,14 +14,20 @@ import (
 //
 // With no trusted CIDRs it never trusts a forwarded header — a request hitting
 // the app directly cannot spoof its client IP to evade the rate limiter or
-// poison logs. A single trusted hop is assumed; the left-most XFF entry wins.
+// poison logs. X-Forwarded-For is resolved right-to-left, skipping trusted
+// proxy addresses: edge proxies (Fly, Cloudflare) APPEND the peer they saw to
+// any client-supplied value, so the left-most entry is attacker-controlled
+// and the right-most untrusted entry is the real client (ADR-027, amended
+// 2026-07-12).
 func RealIP(trustedProxyCIDRs []string) func(http.Handler) http.Handler {
 	trusted := parseCIDRs(trustedProxyCIDRs)
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ip := hostOnly(r.RemoteAddr)
-			if forwarded := forwardedClientIP(r); forwarded != "" && peerIsTrusted(ip, trusted) {
-				ip = forwarded
+			if peerIsTrusted(ip, trusted) {
+				if forwarded := forwardedClientIP(r, trusted); forwarded != "" {
+					ip = forwarded
+				}
 			}
 			r.RemoteAddr = ip
 			next.ServeHTTP(w, r)
@@ -68,13 +74,24 @@ func peerIsTrusted(peer string, trusted []*net.IPNet) bool {
 	return false
 }
 
-// forwardedClientIP returns the left-most X-Forwarded-For entry, falling back
-// to X-Real-IP then True-Client-IP. Callers must only trust the result when the
-// direct peer is a trusted proxy (ADR-027).
-func forwardedClientIP(r *http.Request) string {
+// forwardedClientIP resolves X-Forwarded-For right-to-left — skipping trusted
+// proxy addresses and invalid entries — and returns the first remaining IP:
+// the nearest hop that is not our own infrastructure. An XFF consisting only
+// of trusted/invalid entries yields "" (callers fall back to the direct peer,
+// failing closed). Falls back to X-Real-IP then True-Client-IP, which are
+// single-valued headers set by the trusted peer. Callers must only trust the
+// result when the direct peer is a trusted proxy (ADR-027).
+func forwardedClientIP(r *http.Request, trusted []*net.IPNet) string {
 	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-		if first := strings.TrimSpace(strings.Split(xff, ",")[0]); first != "" {
-			return first
+		entries := strings.Split(xff, ",")
+		for i := len(entries) - 1; i >= 0; i-- {
+			entry := strings.TrimSpace(entries[i])
+			if net.ParseIP(entry) == nil {
+				continue
+			}
+			if !peerIsTrusted(entry, trusted) {
+				return entry
+			}
 		}
 	}
 	if xr := strings.TrimSpace(r.Header.Get("X-Real-IP")); xr != "" {

--- a/internal/middleware/realip_test.go
+++ b/internal/middleware/realip_test.go
@@ -23,11 +23,42 @@ func TestRealIP(t *testing.T) {
 			want:       "203.0.113.7",
 		},
 		{
-			name:       "trusted peer honors left-most XFF",
+			name:       "trusted peer resolves the right-most untrusted XFF entry",
 			trusted:    []string{"10.0.0.0/8"},
 			remoteAddr: "10.0.0.9:443",
 			xff:        "1.2.3.4, 10.0.0.9",
 			want:       "1.2.3.4",
+		},
+		{
+			name: "client-spoofed XFF prefix is ignored behind an appending proxy",
+			// Fly/Cloudflare APPEND the real client to any inbound XFF, so
+			// the left-most entry is attacker-controlled: the client sent
+			// "6.6.6.6" and the proxy appended the true 203.0.113.9.
+			trusted:    []string{"172.16.0.0/12"},
+			remoteAddr: "172.19.9.185:39154",
+			xff:        "6.6.6.6, 203.0.113.9",
+			want:       "203.0.113.9",
+		},
+		{
+			name:       "multi-hop chain skips trusted proxies right-to-left",
+			trusted:    []string{"172.16.0.0/12", "10.0.0.0/8"},
+			remoteAddr: "172.19.9.185:39154",
+			xff:        "203.0.113.9, 10.0.0.4",
+			want:       "203.0.113.9",
+		},
+		{
+			name:       "XFF of only trusted addresses falls back to the peer",
+			trusted:    []string{"172.16.0.0/12"},
+			remoteAddr: "172.19.9.185:39154",
+			xff:        "172.19.0.1, 172.20.0.2",
+			want:       "172.19.9.185",
+		},
+		{
+			name:       "garbage XFF entries are skipped",
+			trusted:    []string{"172.16.0.0/12"},
+			remoteAddr: "172.19.9.185:39154",
+			xff:        "203.0.113.9, not-an-ip",
+			want:       "203.0.113.9",
 		},
 		{
 			name:       "untrusted peer ignores XFF",


### PR DESCRIPTION
## What

Fixes #72: verifies and configures `TRUSTED_PROXY_CIDRS` for the Fly demo, and fixes the X-Forwarded-For algorithm the verification proved unsafe.

## Why

Live logs show every request arriving from fly-proxy at `172.19.9.185` — all visitors share one rate-limit bucket (the 5/min auth tier and /learn tier collapse across users). But simply trusting that CIDR with the existing **left-most** XFF rule would open the exact spoofing vector ADR-027 exists to close: Fly (and Cloudflare) **append** the real client to any client-supplied XFF, so the left-most entry is attacker-controlled.

## How

- `RealIP` now resolves XFF **right-to-left, skipping trusted-proxy and invalid entries**, taking the first remaining IP — the nearest hop that isn't our infrastructure. An all-trusted XFF falls back to the direct peer (fails closed). Multi-hop chains (Cloudflare → Fly) work when both ranges are trusted. The trusted-peer gate is unchanged: empty config never honors any forwarded header.
- `fly.toml` sets `TRUSTED_PROXY_CIDRS=172.16.0.0/12` (versioned, non-secret).
- ADR-027 amended with the verified evidence; `.env.example` documents the Fly value.

## Testing

- [x] Failing-first table-driven cases: spoofed XFF prefix ignored, multi-hop skip, all-trusted fallback to peer, garbage entries skipped (ADR-023)
- [x] `task ci` passes end-to-end
- [ ] Post-merge: verify live logs show real visitor IPs (will confirm after deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)