### PR TITLE
fix(profile): persist name updates to the users row (#70)

### DIFF
--- a/internal/database/querier.go
+++ b/internal/database/querier.go
@@ -60,6 +60,10 @@ type Querier interface {
 	UpdateOrganization(ctx context.Context, arg UpdateOrganizationParams) (Organization, error)
 	UpdateOrganizationMember(ctx context.Context, arg UpdateOrganizationMemberParams) (OrganizationMember, error)
 	UpdateUser(ctx context.Context, arg UpdateUserParams) (User, error)
+	// Profile self-service rename (#70). Deliberately narrow — the generic
+	// UpdateUser's COALESCE params make a name-only change thread every other
+	// column through untouched.
+	UpdateUserName(ctx context.Context, arg UpdateUserNameParams) (User, error)
 }
 
 var _ Querier = (*Queries)(nil)

--- a/internal/database/users.sql.go
+++ b/internal/database/users.sql.go
@@ -302,3 +302,37 @@ func (q *Queries) UpdateUser(ctx context.Context, arg UpdateUserParams) (User, e
 	)
 	return i, err
 }
+
+const updateUserName = `-- name: UpdateUserName :one
+UPDATE users
+SET name = $2, updated_at = NOW()
+WHERE id = $1
+RETURNING id, email, name, avatar_url, auth_id, is_active, last_login_at, created_at, updated_at, first_run_complete, is_anonymous
+`
+
+type UpdateUserNameParams struct {
+	ID   uuid.UUID   `json:"id"`
+	Name pgtype.Text `json:"name"`
+}
+
+// Profile self-service rename (#70). Deliberately narrow — the generic
+// UpdateUser's COALESCE params make a name-only change thread every other
+// column through untouched.
+func (q *Queries) UpdateUserName(ctx context.Context, arg UpdateUserNameParams) (User, error) {
+	row := q.db.QueryRow(ctx, updateUserName, arg.ID, arg.Name)
+	var i User
+	err := row.Scan(
+		&i.ID,
+		&i.Email,
+		&i.Name,
+		&i.AvatarUrl,
+		&i.AuthID,
+		&i.IsActive,
+		&i.LastLoginAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.FirstRunComplete,
+		&i.IsAnonymous,
+	)
+	return i, err
+}

--- a/internal/handler/first_run_handlers_test.go
+++ b/internal/handler/first_run_handlers_test.go
@@ -19,10 +19,13 @@ import (
 // repository calls.
 type fakeUserRepo struct {
 	repository.UserRepository
-	firstRunErr  error
-	gotUserID    uuid.UUID
-	gotComplete  bool
-	firstRunSeen bool
+	firstRunErr    error
+	gotUserID      uuid.UUID
+	gotComplete    bool
+	firstRunSeen   bool
+	updateNameErr  error
+	updateNameSeen bool
+	gotName        string
 }
 
 func (f *fakeUserRepo) UpdateFirstRunComplete(_ context.Context, id uuid.UUID, complete bool) error {

--- a/internal/handler/profile_handlers.go
+++ b/internal/handler/profile_handlers.go
@@ -9,6 +9,7 @@ import (
 	"github.com/clownware/go-performance-starter/internal/view"
 	"github.com/clownware/go-performance-starter/internal/view/pages"
 	"github.com/clownware/go-performance-starter/internal/view/partials"
+	"github.com/clownware/go-performance-starter/internal/webutil"
 )
 
 // userNameFromContext extracts the display name from the authenticated user context.
@@ -30,9 +31,19 @@ func userNameFromContext(r *http.Request) string {
 	return "User"
 }
 
+// profileDisplayName prefers the persisted users row (the write target of
+// ProfileUpdate, #70) and falls back to token metadata for identities whose
+// row has no name yet.
+func profileDisplayName(r *http.Request) string {
+	if u := webutil.GetUserFromContext(r.Context()); u != nil && u.Name.Valid && u.Name.String != "" {
+		return u.Name.String
+	}
+	return userNameFromContext(r)
+}
+
 // ProfileView renders the profile page (full page or fragment fallback).
 func ProfileView(w http.ResponseWriter, r *http.Request) {
-	userName := userNameFromContext(r)
+	userName := profileDisplayName(r)
 	baseProps := view.NewBaseProps("Profile")
 	baseProps.UserName = userName
 	props := pages.ProfilePageProps{
@@ -50,9 +61,9 @@ func ProfileUpdate(w http.ResponseWriter, r *http.Request) {
 		JSONError(w, http.StatusBadRequest, err)
 		return
 	}
-	name := r.FormValue("name")
+	name := strings.TrimSpace(r.FormValue("name"))
 	errors := make(map[string]string)
-	if strings.TrimSpace(name) == "" {
+	if name == "" {
 		errors["name"] = "Name cannot be empty"
 	}
 
@@ -81,7 +92,25 @@ func ProfileUpdate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Stub update successful
+	// Persist to the users row — UserLoader put it (and UserRepoMiddleware
+	// the repo) in context; without a row there is nothing to update.
+	user := webutil.GetUserFromContext(r.Context())
+	if user == nil {
+		http.Redirect(w, r, "/auth/page", http.StatusSeeOther)
+		return
+	}
+	repo := webutil.GetUserRepoFromContext(r.Context())
+	if repo == nil {
+		slog.Error("Profile update without a user repository in context")
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+	if _, err := repo.UpdateName(r.Context(), user.ID, name); err != nil {
+		slog.Error("Failed to persist profile name", "user_id", user.ID, "error", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
 	if view.IsHTMXRequest(r) {
 		view.SetHXTrigger(w, "Profile updated successfully!")
 		formProps := partials.ProfileFormProps{

--- a/internal/handler/profile_handlers_test.go
+++ b/internal/handler/profile_handlers_test.go
@@ -2,14 +2,41 @@ package handler
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/supabase-community/gotrue-go/types"
 
+	"github.com/clownware/go-performance-starter/internal/database"
 	"github.com/clownware/go-performance-starter/internal/middleware"
+	"github.com/clownware/go-performance-starter/internal/webutil"
 )
+
+// UpdateName extends the shared fakeUserRepo for the profile handlers.
+func (f *fakeUserRepo) UpdateName(_ context.Context, id uuid.UUID, name string) (*database.User, error) {
+	f.updateNameSeen = true
+	f.gotUserID = id
+	f.gotName = name
+	if f.updateNameErr != nil {
+		return nil, f.updateNameErr
+	}
+	return &database.User{ID: id, Name: pgtype.Text{String: name, Valid: true}}, nil
+}
+
+// withDBUser stores a users row (and the repo) in the context the way
+// UserLoader + UserRepoMiddleware do for the profile routes.
+func withDBUser(r *http.Request, user *database.User, repo *fakeUserRepo) *http.Request {
+	ctx := webutil.WithUser(r.Context(), user)
+	if repo != nil {
+		ctx = webutil.WithUserRepo(ctx, repo)
+	}
+	return r.WithContext(ctx)
+}
 
 // withAuthUser stores a gotrue user in the request context the way
 // middleware.AuthMiddleware does.
@@ -63,11 +90,27 @@ func TestUserNameFromContext(t *testing.T) {
 
 func TestProfileView(t *testing.T) {
 	tests := []struct {
-		name string
-		user *types.UserResponse
+		name     string
+		user     *types.UserResponse
+		dbUser   *database.User
+		wantName string
 	}{
 		{name: "anonymous context"},
 		{name: "authenticated user", user: &types.UserResponse{User: types.User{Email: "ada@example.com"}}},
+		{
+			// The persisted row is the source of truth (#70): a saved name
+			// must survive reloads instead of reverting to token metadata.
+			name:     "users row name wins over token metadata",
+			user:     &types.UserResponse{User: types.User{Email: "ada@example.com", UserMetadata: map[string]interface{}{"full_name": "Token Name"}}},
+			dbUser:   &database.User{ID: uuid.New(), Name: pgtype.Text{String: "Persisted Name", Valid: true}},
+			wantName: "Persisted Name",
+		},
+		{
+			name:     "empty users row name falls back to token metadata",
+			user:     &types.UserResponse{User: types.User{Email: "ada@example.com", UserMetadata: map[string]interface{}{"full_name": "Token Name"}}},
+			dbUser:   &database.User{ID: uuid.New()},
+			wantName: "Token Name",
+		},
 	}
 
 	for _, tt := range tests {
@@ -75,6 +118,9 @@ func TestProfileView(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, "/profile", nil)
 			if tt.user != nil {
 				req = withAuthUser(req, tt.user)
+			}
+			if tt.dbUser != nil {
+				req = withDBUser(req, tt.dbUser, nil)
 			}
 			w := httptest.NewRecorder()
 
@@ -86,29 +132,43 @@ func TestProfileView(t *testing.T) {
 			if w.Body.Len() == 0 {
 				t.Error("ProfileView() rendered an empty body")
 			}
+			if tt.wantName != "" && !strings.Contains(w.Body.String(), tt.wantName) {
+				t.Errorf("ProfileView() body missing %q", tt.wantName)
+			}
 		})
 	}
 }
 
 func TestProfileUpdate(t *testing.T) {
+	userID := uuid.New()
 	tests := []struct {
-		name         string
-		form         string
-		htmx         bool
-		wantStatus   int
-		wantLocation string
-		wantTrigger  bool
+		name          string
+		form          string
+		htmx          bool
+		noUser        bool // no users row in context (loader missing/failed)
+		repoErr       error
+		wantStatus    int
+		wantLocation  string
+		wantTrigger   bool
+		wantPersisted string // name the repository must receive
 	}{
 		{name: "malformed form body returns 400", form: "%zz", wantStatus: http.StatusBadRequest},
 		{name: "empty name via htmx re-renders form with 422", form: "name=+", htmx: true, wantStatus: http.StatusUnprocessableEntity},
 		{name: "empty name without htmx re-renders page with 422", form: "name=", wantStatus: http.StatusUnprocessableEntity},
-		{name: "valid name via htmx returns form with trigger", form: "name=Ada", htmx: true, wantStatus: http.StatusOK, wantTrigger: true},
-		{name: "valid name without htmx redirects", form: "name=Ada", wantStatus: http.StatusSeeOther, wantLocation: "/profile"},
+		{name: "valid name via htmx persists and triggers", form: "name=Ada", htmx: true, wantStatus: http.StatusOK, wantTrigger: true, wantPersisted: "Ada"},
+		{name: "valid name without htmx persists and redirects", form: "name=Ada", wantStatus: http.StatusSeeOther, wantLocation: "/profile", wantPersisted: "Ada"},
+		{name: "persisted name is trimmed", form: "name=+Ada+Lovelace+", htmx: true, wantStatus: http.StatusOK, wantTrigger: true, wantPersisted: "Ada Lovelace"},
+		{name: "no users row redirects to auth", form: "name=Ada", noUser: true, wantStatus: http.StatusSeeOther, wantLocation: "/auth/page"},
+		{name: "repository failure returns 500", form: "name=Ada", repoErr: errors.New("boom"), wantStatus: http.StatusInternalServerError},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			repo := &fakeUserRepo{updateNameErr: tt.repoErr}
 			req := formRequest("/profile", tt.form)
+			if !tt.noUser {
+				req = withDBUser(req, &database.User{ID: userID}, repo)
+			}
 			if tt.htmx {
 				req.Header.Set("HX-Request", "true")
 			}
@@ -129,6 +189,17 @@ func TestProfileUpdate(t *testing.T) {
 			}
 			if tt.wantStatus == http.StatusUnprocessableEntity && w.Body.Len() == 0 {
 				t.Error("validation failure rendered an empty body")
+			}
+			if tt.wantPersisted != "" {
+				if !repo.updateNameSeen {
+					t.Fatal("successful update never called UpdateName — the write does not persist (#70)")
+				}
+				if repo.gotName != tt.wantPersisted || repo.gotUserID != userID {
+					t.Errorf("UpdateName(%v, %q), want (%v, %q)", repo.gotUserID, repo.gotName, userID, tt.wantPersisted)
+				}
+			}
+			if tt.wantPersisted == "" && tt.repoErr == nil && repo.updateNameSeen {
+				t.Error("UpdateName called on a request that must not persist")
 			}
 		})
 	}

--- a/internal/middleware/user_loader_test.go
+++ b/internal/middleware/user_loader_test.go
@@ -45,6 +45,9 @@ func (f *fakeUserRepo) List(ctx context.Context, limit, offset int32) ([]databas
 func (f *fakeUserRepo) Update(ctx context.Context, params database.UpdateUserParams) (*database.User, error) {
 	return nil, repository.ErrNotFound
 }
+func (f *fakeUserRepo) UpdateName(ctx context.Context, id uuid.UUID, name string) (*database.User, error) {
+	return nil, repository.ErrNotFound
+}
 func (f *fakeUserRepo) Delete(ctx context.Context, id uuid.UUID) error { return nil }
 func (f *fakeUserRepo) SetLastLogin(ctx context.Context, id uuid.UUID, loginTime time.Time) error {
 	return nil

--- a/internal/repository/postgres/user.go
+++ b/internal/repository/postgres/user.go
@@ -109,6 +109,23 @@ func (r *UserRepo) Update(ctx context.Context, params database.UpdateUserParams)
 	return &user, nil
 }
 
+// UpdateName sets the user's display name (profile self-service, #70).
+func (r *UserRepo) UpdateName(ctx context.Context, id uuid.UUID, name string) (*database.User, error) {
+	user, err := inScope(ctx, r.db, r.querier, func(q database.Querier) (database.User, error) {
+		return q.UpdateUserName(ctx, database.UpdateUserNameParams{
+			ID:   id,
+			Name: pgtype.Text{String: name, Valid: true},
+		})
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, repository.ErrNotFound
+		}
+		return nil, err
+	}
+	return &user, nil
+}
+
 // Delete soft-deletes a user by setting is_active to false.
 func (r *UserRepo) Delete(ctx context.Context, id uuid.UUID) error {
 	_, err := inScope(ctx, r.db, r.querier, func(q database.Querier) (struct{}, error) {

--- a/internal/repository/postgres/user_repo_test.go
+++ b/internal/repository/postgres/user_repo_test.go
@@ -54,6 +54,20 @@ func TestUserRepoIntegration(t *testing.T) {
 	if _, err := repo.GetByEmail(ctx, "missing-"+uuid.NewString()+"@example.com"); err != repository.ErrNotFound {
 		t.Errorf("GetByEmail(missing) err = %v, want ErrNotFound", err)
 	}
+
+	renamed, err := repo.UpdateName(ctx, created.ID, "Ada Lovelace")
+	if err != nil {
+		t.Fatalf("UpdateName: %v", err)
+	}
+	if !renamed.Name.Valid || renamed.Name.String != "Ada Lovelace" {
+		t.Errorf("UpdateName name = %+v, want Ada Lovelace", renamed.Name)
+	}
+	if renamed.Email != email {
+		t.Errorf("UpdateName must not touch email: got %q, want %q", renamed.Email, email)
+	}
+	if _, err := repo.UpdateName(ctx, uuid.New(), "Nobody"); err != repository.ErrNotFound {
+		t.Errorf("UpdateName(missing) err = %v, want ErrNotFound", err)
+	}
 }
 
 // TestUserRLSIsolation proves the users_self_access policy: an authenticated

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -31,6 +31,9 @@ type UserRepository interface {
 	// Update modifies an existing user
 	Update(ctx context.Context, params database.UpdateUserParams) (*database.User, error)
 
+	// UpdateName sets the user's display name (profile self-service, #70)
+	UpdateName(ctx context.Context, id uuid.UUID, name string) (*database.User, error)
+
 	// Delete soft-deletes a user by setting is_active to false
 	Delete(ctx context.Context, id uuid.UUID) error
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -165,21 +165,16 @@ func (s *Server) setupRoutes() {
 	s.router.With(mw.MetricsGuard(s.cfg.MetricsToken, s.cfg.IsProduction())).
 		Handle("/metrics", promhttp.Handler())
 
-	// Profile page (HTMX-enabled, requires auth)
-	if s.authClient != nil {
+	// Profile page (HTMX-enabled, requires auth). Profile and first-run both
+	// need the DB users row loaded (and JIT-provisioned) from the
+	// authenticated identity — profile writes the name to that row (#70).
+	if s.authClient != nil && s.db != nil {
 		r.Group(func(protectedRouter chi.Router) {
 			protectedRouter.Use(mw.AuthMiddleware(s.authClient, s.cfg.IsProduction()))
+			protectedRouter.Use(mw.UserLoader(postgres.NewUserRepo(s.db, database.New(s.db))))
 			protectedRouter.Get("/profile", handler.ProfileView)
 			protectedRouter.Post("/profile", handler.ProfileUpdate)
-
-			// First-run onboarding needs the DB user row loaded (and
-			// JIT-provisioned) from the authenticated identity.
-			if s.db != nil {
-				protectedRouter.Group(func(firstRun chi.Router) {
-					firstRun.Use(mw.UserLoader(postgres.NewUserRepo(s.db, database.New(s.db))))
-					handler.FirstRunHandlers(firstRun)
-				})
-			}
+			handler.FirstRunHandlers(protectedRouter)
 		})
 	}
 

--- a/sql/queries/users.sql
+++ b/sql/queries/users.sql
@@ -54,6 +54,15 @@ WHERE id = $1;
 DELETE FROM users
 WHERE id = $1;
 
+-- name: UpdateUserName :one
+-- Profile self-service rename (#70). Deliberately narrow — the generic
+-- UpdateUser's COALESCE params make a name-only change thread every other
+-- column through untouched.
+UPDATE users
+SET name = $2, updated_at = NOW()
+WHERE id = $1
+RETURNING id, email, name, avatar_url, auth_id, is_active, last_login_at, created_at, updated_at, first_run_complete, is_anonymous;
+
 -- name: SetUserFirstRunComplete :exec
 UPDATE users
 SET first_run_complete = $2, updated_at = NOW()


### PR DESCRIPTION
## What

Fixes #70: the profile form's success toast now tells the truth — the name is written to the `users` row and survives reloads.

## How

- **`UpdateUserName` sqlc query**, deliberately narrow: the generic `UpdateUser`'s COALESCE params make a name-only change thread every other column through (its non-nullable `email` param would wipe the email if passed empty).
- **`UserRepository.UpdateName`** + RLS-scoped postgres implementation (`inScope`, ErrNotFound mapping like its siblings).
- **Profile routes now run under `UserLoader`** (merged with the first-run group), so the handler has the DB users row; it persists via the context repository and redirects to `/auth/page` when no row is present.
- **`ProfileView` prefers the persisted row's name** over gotrue token metadata, falling back for identities with no name yet. Names are trimmed before storage.

## Testing

- [x] Failing-first table-driven cases: persist on success (HTMX + plain form), trimming, no-row redirect, repository failure → 500, row-name-wins + token-fallback rendering (ADR-023)
- [x] Integration round-trip against real Postgres: rename persists, email untouched, missing ID → ErrNotFound
- [x] `task ci` passes end-to-end

**Live-verification caveat, reported honestly:** exercising the deployed flow needs an authenticated session; guest mode is still blocked by the Supabase toggle (#66) and I don't create accounts. The handler chain (AuthMiddleware → UserLoader → context repo) is identical to the proven first-run flow, and unit + integration tests cover both sides of the write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)