### PR TITLE
fix(auth): unique placeholder email for anonymous provisioning (hotfix)

### DIFF
--- a/internal/handler/first_run_handlers_test.go
+++ b/internal/handler/first_run_handlers_test.go
@@ -27,6 +27,7 @@ type fakeUserRepo struct {
 	updateNameSeen   bool
 	gotName          string
 	anonymousFlipIDs []uuid.UUID
+	updatedEmails    []string
 }
 
 func (f *fakeUserRepo) UpdateFirstRunComplete(_ context.Context, id uuid.UUID, complete bool) error {

--- a/internal/handler/upgrade_handlers.go
+++ b/internal/handler/upgrade_handlers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	"github.com/clownware/go-performance-starter/internal/auth"
+	"github.com/clownware/go-performance-starter/internal/database"
 	mw "github.com/clownware/go-performance-starter/internal/middleware"
 	"github.com/clownware/go-performance-starter/internal/validate"
 	"github.com/clownware/go-performance-starter/internal/view"
@@ -110,12 +111,16 @@ func UpgradeSubmit(upgrader anonUpgrader, secureCookie bool) http.HandlerFunc {
 			return
 		}
 
-		// Promote the row so the reaper can't touch it. Best-effort: the
-		// loader's claims-sync heals a miss on the next request, after the
-		// session below is refreshed to non-anonymous claims.
+		// Promote the row so the reaper can't touch it, and replace the
+		// guest placeholder email with the real one. Best-effort: the
+		// loader's claims-sync heals a missed promotion on the next request,
+		// after the session below is refreshed to non-anonymous claims.
 		if repo := webutil.GetUserRepoFromContext(r.Context()); repo != nil {
 			if err := repo.SetAnonymous(r.Context(), user.ID, false); err != nil {
 				slog.Error("Failed to promote upgraded users row (loader will heal)", "user_id", user.ID, "error", err)
+			}
+			if _, err := repo.Update(r.Context(), database.UpdateUserParams{ID: user.ID, Email: email}); err != nil {
+				slog.Error("Failed to sync upgraded email to users row", "user_id", user.ID, "error", err)
 			}
 		}
 

--- a/internal/handler/upgrade_handlers_test.go
+++ b/internal/handler/upgrade_handlers_test.go
@@ -56,6 +56,12 @@ func (f *fakeUserRepo) SetAnonymous(_ context.Context, id uuid.UUID, anonymous b
 	return nil
 }
 
+// Update records the email sync that replaces the guest placeholder (#68).
+func (f *fakeUserRepo) Update(_ context.Context, params database.UpdateUserParams) (*database.User, error) {
+	f.updatedEmails = append(f.updatedEmails, params.Email)
+	return &database.User{ID: params.ID, Email: params.Email}, nil
+}
+
 func upgradeRequest(t *testing.T, form string, user *database.User, repo *fakeUserRepo, withCookies bool) *http.Request {
 	t.Helper()
 	req := formRequest("/learn/upgrade", form)
@@ -248,6 +254,12 @@ func TestUpgradeSubmit(t *testing.T) {
 			gotFlip := len(repo.anonymousFlipIDs) == 1 && repo.anonymousFlipIDs[0] == userID
 			if gotFlip != tt.wantAnonFlip {
 				t.Errorf("row promotion = %v (%v), want %v", gotFlip, repo.anonymousFlipIDs, tt.wantAnonFlip)
+			}
+			if tt.wantAnonFlip {
+				// Promotion must also replace the guest placeholder email.
+				if len(repo.updatedEmails) != 1 || repo.updatedEmails[0] != tt.upgrader.gotEmail {
+					t.Errorf("email sync = %v, want [%q]", repo.updatedEmails, tt.upgrader.gotEmail)
+				}
 			}
 			var gotAccess string
 			for _, c := range w.Result().Cookies() {

--- a/internal/middleware/user_loader.go
+++ b/internal/middleware/user_loader.go
@@ -83,6 +83,13 @@ func provisionUser(r *http.Request, repo repository.UserRepository, claims webut
 			params.Name = pgtype.Text{String: name, Valid: true}
 		}
 	}
+	// Anonymous identities carry no email, and users.email is NOT NULL
+	// UNIQUE — a shared "" collides on the second guest ever (live 500s,
+	// 2026-07-12). Use a per-identity placeholder on the reserved .invalid
+	// TLD; the upgrade flow (#68) replaces it with the real address.
+	if params.Email == "" {
+		params.Email = sub + "@guest.invalid"
+	}
 	slog.Info("Provisioning users row for first authenticated request", "sub", sub)
 	return repo.Create(r.Context(), params)
 }

--- a/internal/middleware/user_loader_test.go
+++ b/internal/middleware/user_loader_test.go
@@ -72,6 +72,7 @@ func TestUserLoader(t *testing.T) {
 		wantUserEmail string
 		wantCreated   int
 		wantAnonFlip  bool
+		wantEmail     string // email the provisioned row must carry
 	}{
 		{
 			name:       "no claims: unauthorized",
@@ -92,6 +93,17 @@ func TestUserLoader(t *testing.T) {
 			repo:        &fakeUserRepo{byAuthID: map[string]*database.User{}},
 			wantStatus:  http.StatusOK,
 			wantCreated: 1,
+		},
+		{
+			// Anonymous identities have no email, and users.email is NOT
+			// NULL UNIQUE — a shared "" collides on the second guest ever
+			// (live 500s, 2026-07-12). Provision a per-identity placeholder.
+			name:        "anonymous provision gets a unique placeholder email",
+			claims:      &webutil.AuthClaims{Sub: "guest-sub-2", Role: webutil.RoleAuthenticated, IsAnonymous: true},
+			repo:        &fakeUserRepo{byAuthID: map[string]*database.User{}},
+			wantStatus:  http.StatusOK,
+			wantCreated: 1,
+			wantEmail:   "guest-sub-2@guest.invalid",
 		},
 		{
 			// Upgrade self-heal (#68): a non-anonymous token with a stale
@@ -148,6 +160,11 @@ func TestUserLoader(t *testing.T) {
 				}
 				if got := tt.repo.created[0].AuthID.String; got != tt.claims.Sub {
 					t.Errorf("provisioned auth_id = %q, want claims sub %q", got, tt.claims.Sub)
+				}
+				if tt.wantEmail != "" {
+					if got := tt.repo.created[0].Email; got != tt.wantEmail {
+						t.Errorf("provisioned email = %q, want %q", got, tt.wantEmail)
+					}
 				}
 			}
 			if tt.wantAnonFlip {


### PR DESCRIPTION
## What

Hotfix for a latent day-one guest-mode bug that surfaced minutes after anonymous sign-ins were enabled (#66): **every guest after the first ever gets a 500 on all /learn pages.**

## Why

JIT provisioning copies the gotrue email — `""` for every anonymous identity — into `users.email`, which is `NOT NULL UNIQUE`. The first guest claimed the `''` slot; every subsequent provision hits `users_email_key` and the loader 500s. Verified from live logs: `duplicate key value violates unique constraint "users_email_key"`.

## How

- Provision anonymous identities with `<sub>@guest.invalid` — unique per identity, on the RFC-reserved `.invalid` TLD so it can never route.
- The upgrade flow (#68) now also syncs the real email onto the row at promotion, replacing the placeholder.
- The one pre-existing `''` row is harmless (no future guest can collide with it again).

## Testing

- [x] Failing-first: provision test asserting the per-identity placeholder; upgrade test asserting the email sync at promotion (ADR-023)
- [x] `task ci` green
- [ ] Post-deploy: live re-verify a second fresh guest can load /learn/quiz (this is exactly the case that 500s today)

🤖 Generated with [Claude Code](https://claude.com/claude-code)