### PR TITLE
chore(ci): cap every job with timeout-minutes; cancel superseded PR runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,17 @@ on:
   pull_request:
     branches: [ main, master ]
 
+# Cancel superseded runs on the same PR; never cancel default-branch pushes.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ci:
     name: Quality Gate (task ci)
     runs-on: ubuntu-latest
+    # Without a cap a hung step runs to GitHub's 360-minute default; this job averages ~3 min.
+    timeout-minutes: 15
     permissions:
       contents: read
       pull-requests: write
@@ -112,6 +119,7 @@ jobs:
   docker:
     name: Docker Image
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
     - uses: actions/checkout@v7
 

--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -15,6 +15,8 @@ jobs:
   validate:
     name: Validate migrations against fresh Postgres
     runs-on: ubuntu-latest
+    # Without a cap a hung step runs to GitHub's 360-minute default.
+    timeout-minutes: 15
     services:
       postgres:
         # Tracks production (Supabase runs Postgres 16 on Alpine) and
@@ -50,6 +52,7 @@ jobs:
   migrate:
     name: Apply to production
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: validate
     env:
       DATABASE_URL: ${{ secrets.SUPABASE_DATABASE_URL }}

--- a/.github/workflows/demo-reset.yml
+++ b/.github/workflows/demo-reset.yml
@@ -18,6 +18,8 @@ jobs:
   gate:
     name: Check demo secrets
     runs-on: ubuntu-latest
+    # Without a cap a hung step runs to GitHub's 360-minute default.
+    timeout-minutes: 5
     outputs:
       has-db-url: ${{ steps.check.outputs.has-db-url }}
     steps:
@@ -36,6 +38,7 @@ jobs:
   reset:
     name: Reset demo data
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     needs: gate
     if: needs.gate.outputs.has-db-url == 'true' && vars.DEMO_MODE == '1'
     env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,8 @@ jobs:
   gate:
     name: Check deploy secrets
     runs-on: ubuntu-latest
+    # Without a cap a hung step runs to GitHub's 360-minute default.
+    timeout-minutes: 5
     outputs:
       has-fly-token: ${{ steps.check.outputs.has-fly-token }}
     steps:
@@ -39,6 +41,7 @@ jobs:
   deploy:
     name: Deploy (Fly.io example)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: gate
     if: needs.gate.outputs.has-fly-token == 'true'
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
   image:
     name: Build & Push Image
     runs-on: ubuntu-latest
+    # Without a cap a hung step runs to GitHub's 360-minute default.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
 
@@ -72,6 +74,7 @@ jobs:
   stamp:
     name: Stamp versions.json
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: image
     steps:
       # Stamp the manifest's "template" field on the default branch — the ref
@@ -101,6 +104,7 @@ jobs:
   migrate:
     name: Apply Migrations
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: image
     env:
       DATABASE_URL: ${{ secrets.SUPABASE_DATABASE_URL }}
@@ -124,6 +128,7 @@ jobs:
   deploy:
     name: Deploy (Fly.io example)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: migrate
     env:
       FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.github/workflows/vuln-scan.yml
+++ b/.github/workflows/vuln-scan.yml
@@ -17,6 +17,8 @@ jobs:
   govulncheck:
     name: govulncheck
     runs-on: ubuntu-latest
+    # Without a cap a hung step runs to GitHub's 360-minute default.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
 


### PR DESCRIPTION
## What

`timeout-minutes` on every job in all six workflows, plus workflow-level `concurrency` on `ci.yml` only.

| Workflow | Job | Cap |
|---|---|---|
| ci.yml | ci (Quality Gate) | 15 (measured ~3 min) |
| ci.yml | docker | 30 |
| db-migrate.yml | validate / migrate | 15 / 30 |
| demo-reset.yml | gate / reset | 5 / 20 |
| deploy.yml | gate / deploy | 5 / 30 |
| release.yml | image / stamp / migrate / deploy | 30 / 15 / 30 / 30 |
| vuln-scan.yml | govulncheck | 20 |

`ci.yml` concurrency: `ci-${{ github.ref }}`, `cancel-in-progress` only for `pull_request` events. Deploy/release/migrate/reset workflows are deliberately **not** given cancel-in-progress (deploy.yml keeps its existing `cancel-in-progress: false`).

## Why

The clownware org Actions pool is being exhausted. Without a cap a hung step runs to GitHub's 360-minute default; superseded PR pushes currently run to completion.

## Testing

- All six workflows + dependabot.yml parse-validated with PyYAML; a script asserts every job has `timeout-minutes`.
- Declarative workflow config only; `task ci` is unaffected (no Go/asset changes). Org checks are refused by the billing lock, so this merges on parse validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)