### PR TITLE
ci(demo-reset): add least-privilege permissions block

### DIFF
--- a/.github/workflows/demo-reset.yml
+++ b/.github/workflows/demo-reset.yml
@@ -14,6 +14,9 @@ on:
     - cron: '0 7 * * *' # nightly, 07:00 UTC
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   gate:
     name: Check demo secrets


### PR DESCRIPTION
## Summary
- Adds a top-level `permissions: contents: read` block to `.github/workflows/demo-reset.yml`, matching `vuln-scan.yml`.
- The workflow only checks out code and talks to the demo DB via `SUPABASE_DATABASE_URL`; nothing needs write scope. No behavior change.

Closes #101

## Verification
- `task ci` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)