### PR TITLE
refactor(health): ping the DB through a consumer-side Pinger seam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `/health` readiness probe pings its dependency through a consumer-side
+  `handler.Pinger` seam instead of importing `pgxpool` directly — the one
+  standing `adr003-no-sql-in-handlers` warning from the ADR-033 launch is
+  resolved by refactor, not allowlist (#92, #99)
+
 ### Fixed
 - WCAG AA contrast across both modes (2026-07-17 audit; every Lighthouse
   a11y deduction was this): `--color-teal` darkened `#468189` → `#427a82`

--- a/docs/adr/ADR-003-SQL-Code-Generation-and-Data-Access.md
+++ b/docs/adr/ADR-003-SQL-Code-Generation-and-Data-Access.md
@@ -61,4 +61,5 @@ Key considerations include:
 - **Checks:**
   - TC-1, TC-2 → `adr003-no-sql-in-handlers` in `scripts/adrcheck` (status: **warn**)
 - **Not machine-checkable:** Repository-interface granularity and naming judgment. sqlc-regeneration drift (`task db:generate` output vs committed code) has no wired check — recorded as a TODO in ADR-033.
-- **Graduation log:** _(empty)_
+- **Graduation log:**
+  - 2026-08-19 — the one standing `adr003-no-sql-in-handlers` finding (health handler imported `pgxpool` to ping the pool, ADR-033 launch note) was resolved by refactoring the ping behind a consumer-side `handler.Pinger` seam (#92, #99); the check has reported clean since. Status stays **warn** — promotion per the 7-clean-days rule.

--- a/internal/handler/health_handler.go
+++ b/internal/handler/health_handler.go
@@ -8,19 +8,27 @@ import (
 	"runtime/debug"
 	"sync"
 	"time"
-
-	"github.com/jackc/pgx/v5/pgxpool"
 )
+
+// Pinger is the readiness dependency the detail probe checks. It is the
+// consumer-side seam that keeps this package driver-free (ADR-003): the
+// server passes its *pgxpool.Pool, which satisfies it; tests pass a fake.
+type Pinger interface {
+	Ping(ctx context.Context) error
+}
 
 var (
 	startTime  time.Time
 	startOnce  sync.Once
-	healthDB   *pgxpool.Pool
+	healthDB   Pinger
 	healthDBMu sync.RWMutex
 )
 
-// InitHealth records the server start time and stores the DB pool for health checks.
-func InitHealth(db *pgxpool.Pool) {
+// InitHealth records the server start time and stores the dependency the
+// detail probe pings. Pass nil when no database is configured — callers
+// holding a typed nil pointer must convert it to a nil interface themselves,
+// or the probe will ping a nil pool.
+func InitHealth(db Pinger) {
 	startOnce.Do(func() {
 		startTime = time.Now()
 	})

--- a/internal/handler/health_handler_test.go
+++ b/internal/handler/health_handler_test.go
@@ -1,6 +1,9 @@
 package handler
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -41,5 +44,94 @@ func TestHealthHandler(t *testing.T) {
 				t.Errorf("HealthHandler() body = %q, want %q", w.Body.String(), tt.wantBody)
 			}
 		})
+	}
+}
+
+// pingerFunc adapts a function to the Pinger seam so tests can script the
+// dependency's answer without a database driver.
+type pingerFunc func(ctx context.Context) error
+
+func (f pingerFunc) Ping(ctx context.Context) error { return f(ctx) }
+
+// TestHealthDetailHandler_Pinger proves the readiness probe reads dependency
+// health through the Pinger seam (ADR-003: handlers stay driver-free) and
+// maps each outcome to the ADR-013 status contract.
+func TestHealthDetailHandler_Pinger(t *testing.T) {
+	tests := []struct {
+		name       string
+		pinger     Pinger
+		wantStatus int
+		wantState  string
+		wantDB     string
+	}{
+		{
+			name:       "reachable dependency is ok",
+			pinger:     pingerFunc(func(context.Context) error { return nil }),
+			wantStatus: http.StatusOK,
+			wantState:  "ok",
+			wantDB:     "ok",
+		},
+		{
+			name:       "failing ping degrades to 503",
+			pinger:     pingerFunc(func(context.Context) error { return errors.New("connection refused") }),
+			wantStatus: http.StatusServiceUnavailable,
+			wantState:  "degraded",
+			wantDB:     "unreachable",
+		},
+		{
+			name:       "no dependency configured is healthy",
+			pinger:     nil,
+			wantStatus: http.StatusOK,
+			wantState:  "ok",
+			wantDB:     "not configured",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			InitHealth(tt.pinger)
+			t.Cleanup(func() { InitHealth(nil) })
+
+			rec := httptest.NewRecorder()
+			HealthDetailHandler(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
+
+			if rec.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d", rec.Code, tt.wantStatus)
+			}
+			if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+				t.Errorf("Content-Type = %q, want application/json", ct)
+			}
+			var resp struct {
+				Status string            `json:"status"`
+				Checks map[string]string `json:"checks"`
+			}
+			if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if resp.Status != tt.wantState {
+				t.Errorf("status = %q, want %q", resp.Status, tt.wantState)
+			}
+			if resp.Checks["database"] != tt.wantDB {
+				t.Errorf("checks.database = %q, want %q", resp.Checks["database"], tt.wantDB)
+			}
+		})
+	}
+}
+
+// TestHealthDetailHandler_PingTimeout proves the probe bounds the dependency
+// call: a ping that honours ctx must be cut off, not hang the readiness check.
+func TestHealthDetailHandler_PingTimeout(t *testing.T) {
+	var sawDeadline bool
+	InitHealth(pingerFunc(func(ctx context.Context) error {
+		_, sawDeadline = ctx.Deadline()
+		return nil
+	}))
+	t.Cleanup(func() { InitHealth(nil) })
+
+	rec := httptest.NewRecorder()
+	HealthDetailHandler(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
+
+	if !sawDeadline {
+		t.Error("ping context carried no deadline — a slow dependency could hang the probe")
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -59,8 +59,14 @@ func New(cfg *config.Config, db *pgxpool.Pool) (*Server, error) {
 		authClient: authClient,
 	}
 
-	// Initialize health check with DB pool for connectivity checks
-	handler.InitHealth(db)
+	// Initialize health check with DB pool for connectivity checks. The pool
+	// is handed over as a handler.Pinger (ADR-003 keeps the handler
+	// driver-free); a nil pool must become a nil interface, not a typed nil.
+	var pinger handler.Pinger
+	if db != nil {
+		pinger = db
+	}
+	handler.InitHealth(pinger)
 
 	s.setupMiddleware()
 	s.setupRoutes()


### PR DESCRIPTION
## Summary
- `internal/handler/health_handler.go` no longer imports `pgxpool`. The readiness ping goes through a consumer-side `handler.Pinger { Ping(ctx) error }` seam (engineering.md: "define it at the consumer"), which `*pgxpool.Pool` already satisfies — so `server.New` hands the pool over unchanged (with the typed-nil → nil-interface guard).
- Resolves the one standing `adr003-no-sql-in-handlers` WARNING from the ADR-033 launch by **refactor, not allowlist** — the check now reports PASS.
- `HealthDetailHandler` is now testable without a database: table-driven cases for ok / degraded (503) / not-configured, plus a ping-deadline assertion.
- ADR-003 Enforcement → Graduation log gets a dated note recording the resolution (append-only legal move per ADR-033 §3; status stays **warn** pending the 7-clean-days rule). CHANGELOG `Unreleased › Changed` entry.

Closes #92
Closes #99

## Verification
- `task ci` green; `go run ./scripts/adrcheck` → `PASS adr003-no-sql-in-handlers`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)