### PR TITLE
chore(versions): add -write sync mode so a pin bump is a one-file edit

### DIFF
--- a/.claude/stack.md
+++ b/.claude/stack.md
@@ -32,6 +32,7 @@ task scan:vuln         # govulncheck
 task agents:build      # regenerate AGENTS.md from CLAUDE.md + .claude/*.md
 task agents:check      # CI gate: fail if AGENTS.md drifts from sources
 task versions:check    # CI gate: fail if versions.json drifts from repo pins (ADR-030)
+task versions:sync     # rewrite versions.json from the repo pins after a dependency/toolchain bump (ADR-030)
 task demo:seed         # load demo fixtures (refuses without DEMO_MODE=1, ADR-031)
 task demo:reset        # purge guests' demo content + re-seed (refuses without DEMO_MODE=1)
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,6 +171,7 @@ task scan:vuln         # govulncheck
 task agents:build      # regenerate AGENTS.md from CLAUDE.md + .claude/*.md
 task agents:check      # CI gate: fail if AGENTS.md drifts from sources
 task versions:check    # CI gate: fail if versions.json drifts from repo pins (ADR-030)
+task versions:sync     # rewrite versions.json from the repo pins after a dependency/toolchain bump (ADR-030)
 task demo:seed         # load demo fixtures (refuses without DEMO_MODE=1, ADR-031)
 task demo:reset        # purge guests' demo content + re-seed (refuses without DEMO_MODE=1)
 ```

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Two hooks are the only blocking layer: a **Stop-gate** (agents can't finish a tu
 
 [`versions.json`](versions.json) at the repo root is a machine-readable manifest of what this template ships — its own release version (`template`) plus one key per meaningful stack pin (Go, templ, HTMX, Alpine, Tailwind, sqlc, …). External consumers fetch it raw from the default branch at build time, so treat it as a consumption contract: **adding keys is fine; renaming or removing keys is a breaking change.**
 
-It cannot drift: `task versions:check` (part of `task ci`) fails when any key disagrees with its in-repo source of truth (`go.mod`, `package-lock.json`, vendored JS bundles, sqlc headers, workflow pins), and the release workflow stamps the `template` field from the git tag ([ADR-030](docs/adr/ADR-030-Versions-Manifest-Contract.md)).
+It cannot drift: `task versions:check` (part of `task ci`) fails when any key disagrees with its in-repo source of truth (`go.mod`, `package-lock.json`, vendored JS bundles, sqlc headers, workflow pins), and the release workflow stamps the `template` field from the git tag ([ADR-030](docs/adr/ADR-030-Versions-Manifest-Contract.md)). After bumping a pin, `task versions:sync` rewrites the manifest from those same sources so the bump stays a one-file edit — the check remains the gate.
 
 ## Architecture Decisions
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -77,6 +77,11 @@ tasks:
     cmds:
       - go run ./scripts/checkversions
 
+  versions:sync:
+    desc: Rewrite versions.json from the repo's actual pins — run after a dependency/toolchain bump (ADR-030)
+    cmds:
+      - go run ./scripts/checkversions -write
+
   check:adr:
     desc: Run the ADR enforcement suite — warn-status checks report, block-status checks fail (ADR-033)
     cmds:

--- a/scripts/checkversions/main.go
+++ b/scripts/checkversions/main.go
@@ -3,10 +3,21 @@
 // of truth (go.mod, package-lock.json, vendored JS, sqlc headers, workflow
 // pins), so the manifest external consumers read can never drift from what
 // the template actually ships. Run from the repo root.
+//
+// Usage:
+//
+//	go run ./scripts/checkversions          # check (task versions:check, part of task ci)
+//	go run ./scripts/checkversions -write   # rewrite versions.json from the pins (task versions:sync)
+//
+// -write makes a pin bump a one-file edit: change go.mod (or whichever
+// source), run the sync, commit both. The check is still the gate; the
+// writer only ever produces what the check would accept.
 package main
 
 import (
+	"bytes"
 	"encoding/json"
+	"flag"
 	"fmt"
 	"os"
 	"regexp"
@@ -163,7 +174,112 @@ func expectedVersions() (map[string]string, error) {
 	}, nil
 }
 
+// manifestKeys returns the top-level keys of a JSON object in file order —
+// consumers diff versions.json, so -write must not reshuffle it the way a
+// map round-trip would.
+func manifestKeys(raw []byte) ([]string, error) {
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	tok, err := dec.Token()
+	if err != nil {
+		return nil, err
+	}
+	if delim, ok := tok.(json.Delim); !ok || delim != '{' {
+		return nil, fmt.Errorf("versions.json is not a JSON object")
+	}
+	var keys []string
+	for dec.More() {
+		tok, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+		key, ok := tok.(string)
+		if !ok {
+			return nil, fmt.Errorf("versions.json: unexpected token %v", tok)
+		}
+		keys = append(keys, key)
+		// Consume (and discard) the value; the string values are re-read
+		// through the map below.
+		var v json.RawMessage
+		if err := dec.Decode(&v); err != nil {
+			return nil, err
+		}
+	}
+	return keys, nil
+}
+
+// syncManifest rewrites raw (the current versions.json) so every key with a
+// wired source of truth carries the repo's actual pin. It preserves key
+// order, leaves the release-stamped template field and any unknown keys
+// alone (the check rejects those; the writer must not hide them), and
+// appends newly wired keys at the end. It returns the new file content and a
+// human-readable change list; content is byte-identical to raw when nothing
+// changed.
+func syncManifest(raw []byte, expected map[string]string) ([]byte, []string, error) {
+	var manifest map[string]string
+	if err := json.Unmarshal(raw, &manifest); err != nil {
+		return nil, nil, fmt.Errorf("parse versions.json: %w", err)
+	}
+	keys, err := manifestKeys(raw)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parse versions.json: %w", err)
+	}
+
+	var changes []string
+	values := make(map[string]string, len(manifest))
+	for _, key := range keys {
+		values[key] = manifest[key]
+		want, wired := expected[key]
+		if key == "template" || !wired || want == "" || want == manifest[key] {
+			continue
+		}
+		changes = append(changes, fmt.Sprintf("%s: %q -> %q", key, manifest[key], want))
+		values[key] = want
+	}
+	// Newly wired keys (present in expected, absent from the file) are
+	// appended in a stable order so the output is deterministic.
+	var added []string
+	for key, want := range expected {
+		if _, present := manifest[key]; present || key == "template" || want == "" {
+			continue
+		}
+		added = append(added, key)
+	}
+	sortStrings(added)
+	for _, key := range added {
+		keys = append(keys, key)
+		values[key] = expected[key]
+		changes = append(changes, fmt.Sprintf("%s: (missing) -> %q", key, expected[key]))
+	}
+
+	var buf bytes.Buffer
+	buf.WriteString("{\n")
+	for i, key := range keys {
+		k, _ := json.Marshal(key)
+		v, _ := json.Marshal(values[key])
+		fmt.Fprintf(&buf, "  %s: %s", k, v)
+		if i < len(keys)-1 {
+			buf.WriteString(",")
+		}
+		buf.WriteString("\n")
+	}
+	buf.WriteString("}\n")
+	return buf.Bytes(), changes, nil
+}
+
+// sortStrings is an insertion sort — the slices here are a handful of keys,
+// and it keeps the script free of imports beyond the ones it already has.
+func sortStrings(s []string) {
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0 && s[j] < s[j-1]; j-- {
+			s[j], s[j-1] = s[j-1], s[j]
+		}
+	}
+}
+
 func main() {
+	write := flag.Bool("write", false, "rewrite versions.json from the repo's pins instead of checking it")
+	flag.Parse()
+
 	manifestRaw, err := os.ReadFile("versions.json")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "❌ %v\n", err)
@@ -179,6 +295,27 @@ func main() {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "❌ %v\n", err)
 		os.Exit(1)
+	}
+
+	if *write {
+		synced, changes, err := syncManifest(manifestRaw, expected)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "❌ %v\n", err)
+			os.Exit(1)
+		}
+		if len(changes) == 0 {
+			fmt.Println("✅ versions.json already matches the repo's actual pins — nothing written")
+			return
+		}
+		if err := os.WriteFile("versions.json", synced, 0o644); err != nil {
+			fmt.Fprintf(os.Stderr, "❌ write versions.json: %v\n", err)
+			os.Exit(1)
+		}
+		for _, c := range changes {
+			fmt.Printf("   %s\n", c)
+		}
+		fmt.Printf("✅ versions.json synced (%d key(s) updated) — review and commit it with the pin change\n", len(changes))
+		return
 	}
 
 	failed := false

--- a/scripts/checkversions/write_test.go
+++ b/scripts/checkversions/write_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSyncManifest proves -write rewrites versions.json from the repo's pins
+// without disturbing the parts the ADR-030 contract says it must not touch:
+// key order (consumers diff the file), the release-stamped template field,
+// and formatting (two-space indent, trailing newline).
+func TestSyncManifest(t *testing.T) {
+	const manifest = `{
+  "template": "v0.8.0",
+  "go": "1.26.5",
+  "go-minimum": "1.25.0",
+  "chi": "5.3.1"
+}
+`
+	tests := []struct {
+		name        string
+		manifest    string
+		expected    map[string]string
+		want        string
+		wantChanges []string
+		wantErr     bool
+	}{
+		{
+			name:     "stale pin is rewritten in place, template and order kept",
+			manifest: manifest,
+			expected: map[string]string{"go": "1.26.6", "go-minimum": "1.25.0", "chi": "5.3.1"},
+			want: `{
+  "template": "v0.8.0",
+  "go": "1.26.6",
+  "go-minimum": "1.25.0",
+  "chi": "5.3.1"
+}
+`,
+			wantChanges: []string{`go: "1.26.5" -> "1.26.6"`},
+		},
+		{
+			name:        "already in sync is a byte-for-byte no-op",
+			manifest:    manifest,
+			expected:    map[string]string{"go": "1.26.5", "go-minimum": "1.25.0", "chi": "5.3.1"},
+			want:        manifest,
+			wantChanges: nil,
+		},
+		{
+			name:     "a newly wired key is appended after the existing ones",
+			manifest: manifest,
+			expected: map[string]string{"go": "1.26.5", "go-minimum": "1.25.0", "chi": "5.3.1", "pgx": "5.10.0"},
+			want: `{
+  "template": "v0.8.0",
+  "go": "1.26.5",
+  "go-minimum": "1.25.0",
+  "chi": "5.3.1",
+  "pgx": "5.10.0"
+}
+`,
+			wantChanges: []string{`pgx: (missing) -> "5.10.0"`},
+		},
+		{
+			name:     "unknown manifest keys survive untouched for the check to reject",
+			manifest: "{\n  \"template\": \"v0.8.0\",\n  \"mystery\": \"1\"\n}\n",
+			expected: map[string]string{},
+			want:     "{\n  \"template\": \"v0.8.0\",\n  \"mystery\": \"1\"\n}\n",
+		},
+		{
+			name:     "template is never rewritten even if expected names it",
+			manifest: manifest,
+			expected: map[string]string{"template": "v9.9.9", "go": "1.26.5", "go-minimum": "1.25.0", "chi": "5.3.1"},
+			want:     manifest,
+		},
+		{
+			name:     "unparseable manifest errors",
+			manifest: "{not json",
+			expected: map[string]string{},
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, changes, err := syncManifest([]byte(tt.manifest), tt.expected)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if string(got) != tt.want {
+				t.Errorf("manifest mismatch\n got: %q\nwant: %q", got, tt.want)
+			}
+			if strings.Join(changes, "|") != strings.Join(tt.wantChanges, "|") {
+				t.Errorf("changes = %q, want %q", changes, tt.wantChanges)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- `go run ./scripts/checkversions -write` (new `task versions:sync`) rewrites `versions.json` from the same in-repo sources the check already reads — so a toolchain/dependency bump is a one-file edit followed by `task versions:sync`, instead of a hand-sync that fails CI when forgotten (the go1.26.6 bump that spawned #100).
- Narrow by design (ADR-030): preserves key order, never touches the release-stamped `template`, leaves unknown keys for the check to reject, appends newly wired keys at the end, byte-identical output on an in-sync repo.
- `task versions:check` stays the gate in `task ci`; `-write` is a convenience that only produces what the check would accept.
- Docs: `stack.md` Key Commands (+ regenerated `AGENTS.md`), README versions.json section.

Closes #100

## Verification
- Table-driven `TestSyncManifest` (stale pin rewritten / no-op / new key appended / unknown keys untouched / template never rewritten / bad JSON).
- Manual: set `"go": "1.26.5"` → check fails → `-write` → `git diff versions.json` empty → check passes.
- `task ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)