### PR TITLE
feat(home): landing architecture explainer with live perf stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now CI-enforced by `internal/view/tokens_contrast_test.go`.
 
 ### Added
+- Landing architecture explainer (ADR-024 surface 1, #67): the home page
+  now walks one request through the stack in five anchored nodes — Chi
+  router + middleware, handler, repository/sqlc/RLS, templ/HTMX/Alpine,
+  performance budgets — each with prose, a native `<details>` source peek
+  of the real file (no JS), its ADR link, and a hand-off to the quiz topic
+  it feeds; plus a live budgets grid rendered from
+  `internal/performance/budgets.go` constants on every request. The hero
+  and surface directory stay as the navigational skeleton
 - Password reset flow (#71): request page (`/auth/recover`, anti-enumeration
   generic response), server-side `token_hash` verification via direct GoTrue
   REST (`/auth/reset` — no client JS; requires the Reset Password email

--- a/internal/handler/home_explainer.go
+++ b/internal/handler/home_explainer.go
@@ -1,0 +1,217 @@
+package handler
+
+import (
+	"fmt"
+
+	"github.com/clownware/go-performance-starter/internal/performance"
+	"github.com/clownware/go-performance-starter/internal/view/pages"
+)
+
+// The landing explainer is ADR-024 surface 1 (#67): a server-rendered
+// walkthrough of this system's own architecture, narrated as a request's
+// journey (design brief §Explainer content map). Each node carries prose, a
+// source peek and its ADR link, and is keyed to the quiz topic that draws
+// from it, so the loop closes: read → quiz → flashcards. The live budget
+// stats are rendered from internal/performance constants at request time —
+// server-rendered dynamic content as its own demo (brief §Live performance
+// stats: "render from constants, never hardcode").
+
+const adrBase = "https://github.com/clownware/go-performance-starter/blob/master/docs/adr/"
+
+func adrLink(file, label string) pages.ExplainerLink {
+	return pages.ExplainerLink{Href: adrBase + file, Label: label}
+}
+
+// ExplainerNodes returns the five-step spine in request order. Source peeks
+// are abridged excerpts of the real files they cite (same hand-maintained
+// convention as the patterns catalogue; #73 tracks generating them).
+func ExplainerNodes() []pages.ExplainerNode {
+	return []pages.ExplainerNode{
+		{
+			Step:      1,
+			Anchor:    "routing",
+			QuizTopic: "routing",
+			Title:     "Request in: Chi router + middleware stack",
+			Summary:   "One deliberate chain — security headers, request ID, trusted-proxy client IP, rate limits, compression, metrics, logging, recovery, timeout, CSRF — then the session middlewares per route group.",
+			Prose: []string{
+				"Every request enters through a single chi router whose middleware order is a design decision, not an accident: SecurityHeaders first, RealIP before the rate limiter (so limits key on the real client behind the Cloudflare proxy), CSRF before any handler runs.",
+				"Identity is layered per route group rather than globally. Public pages carry no session at all; /learn mounts GuestSession → OptionalAuth → OptionalUserLoader so a visitor gets a real anonymous Supabase identity on first touch; /profile and /auth/* add the strict tiers. Credential endpoints sit under a second, tighter rate limiter on top of the global one.",
+			},
+			ADR: adrLink("ADR-014-Security-Patterns-and-Threat-Model.md", "ADR-014 Security patterns · ADR-027 trusted proxies"),
+			Source: pages.ExplainerSource{
+				File: "internal/server/server.go",
+				Snippet: `s.router.Use(mw.SecurityHeaders(isProd))
+s.router.Use(mw.RequestID)
+s.router.Use(mw.RealIP(s.cfg.TrustedProxyCIDRs, s.cfg.ClientIPHeader)) // before the limiter
+s.router.Use(mw.RateLimiter(50, 10))
+s.router.Use(mw.Compress(5))
+s.router.Use(mw.Metrics)
+s.router.Use(mw.RequestLogger)
+s.router.Use(mw.Recoverer)
+s.router.Use(mw.Timeout(30 * time.Second))
+s.router.Use(mw.CSRF(isProd))
+
+r.Group(func(learn chi.Router) {
+    learn.Use(mw.GuestSession(s.authClient, isProd)) // anonymous identity on first touch
+    learn.Use(mw.OptionalAuth(s.authClient, isProd))
+    learn.Use(mw.OptionalUserLoader(userRepo))
+    learn.Use(mw.RateLimiter(30.0/60.0, 20))         // stricter tier, anonymous-writable
+    handler.QuizRoutes(learn, quizRepo)
+})`,
+			},
+		},
+		{
+			Step:      2,
+			Anchor:    "handlers",
+			QuizTopic: "handlers",
+			Title:     "Handler resolves typed input",
+			Summary:   "Handlers parse the form, validate at the boundary, call a repository interface, and hand a typed props struct to a templ view — one render path for pages and fragments.",
+			Prose: []string{
+				"A handler never sees SQL and never builds a map[string]interface{}. It reads its input, validates once at the system boundary, talks to a repository interface (the concrete Postgres type is injected), and constructs a typed props struct that the template was compiled against — a missing field is a build error, not a runtime surprise.",
+				"view.Render is the single render path. The same handler answers a full navigation with the page and an HTMX request with just the partial, decided by view.IsHTMXRequest — which is what makes progressive enhancement cheap: the page works as plain forms, HTMX upgrades it.",
+			},
+			ADR: adrLink("ADR-017-Templ-Adoption.md", "ADR-017 templ · ADR-012 routing & UI patterns"),
+			Source: pages.ExplainerSource{
+				File: "internal/handler/profile_handlers.go",
+				Snippet: `func ProfileUpdate(w http.ResponseWriter, r *http.Request) {
+    name := strings.TrimSpace(r.FormValue("name"))
+    if name == "" { /* 422 with a field error, partial or page */ }
+
+    repo := webutil.GetUserRepoFromContext(r.Context()) // repository interface, not *pgxpool.Pool
+    if _, err := repo.UpdateName(r.Context(), user.ID, name); err != nil { /* 500 */ }
+
+    if view.IsHTMXRequest(r) {
+        view.SetHXTrigger(w, "Profile updated successfully!")
+        view.Render(w, r, http.StatusOK, partials.ProfileForm(partials.ProfileFormProps{Name: name, Success: true}))
+        return
+    }
+    http.Redirect(w, r, "/profile", http.StatusSeeOther)
+}`,
+			},
+		},
+		{
+			Step:      3,
+			Anchor:    "database",
+			QuizTopic: "database",
+			Title:     "Repository → sqlc → Postgres, scoped by RLS",
+			Summary:   "Queries are declared in SQL and compiled by sqlc into typed Go; the repository runs each one inside a transaction that carries the request's JWT claims, so Row Level Security scopes every row to auth.uid().",
+			Prose: []string{
+				"Data access is a compile step, not string concatenation: sql/queries/*.sql is the source, sqlc generates the typed Go in internal/database, and the repository layer is the only thing that calls it. A regeneration-drift check keeps the generated code honest against its sources.",
+				"The tenant boundary lives in the database. The repository opens a transaction, sets the request's JWT claims as a local setting, and switches to the authenticated role — so users_self_access (auth_id = auth.uid()) is enforced by Postgres on every read and write. Anonymous guests are scoped by exactly the same policy as registered users: no parallel code path, no way for a handler to forget.",
+			},
+			ADR: adrLink("ADR-003-SQL-Code-Generation-and-Data-Access.md", "ADR-003 sqlc + repositories · ADR-004 RLS"),
+			Source: pages.ExplainerSource{
+				File: "sql/queries/flashcards.sql",
+				Snippet: `-- name: ListFlashcardsByUser :many
+SELECT id, user_id, question_id, front, back, is_known, created_at, updated_at
+FROM flashcards
+WHERE user_id = $1
+ORDER BY created_at DESC;
+
+-- migrations/000003_add_quiz_flashcards.up.sql
+ALTER TABLE flashcards ENABLE ROW LEVEL SECURITY;
+ALTER TABLE flashcards FORCE ROW LEVEL SECURITY;
+CREATE POLICY flashcards_self_access ON flashcards
+    USING      (EXISTS (SELECT 1 FROM users u WHERE u.id = flashcards.user_id AND u.auth_id = auth.uid()::text))
+    WITH CHECK (EXISTS (SELECT 1 FROM users u WHERE u.id = flashcards.user_id AND u.auth_id = auth.uid()::text));`,
+			},
+		},
+		{
+			Step:      4,
+			Anchor:    "frontend",
+			QuizTopic: "frontend",
+			Title:     "templ renders, HTMX swaps, Alpine sprinkles",
+			Summary:   "Components are typed Go functions compiled from .templ files; HTMX requests fragments and swaps them in place; Alpine handles the light client-only interactivity. Role tokens, not raw colors, so dark mode flips variables instead of components.",
+			Prose: []string{
+				"templ compiles every template to Go, so props are structs and the view layer type-checks with the rest of the build. Pages compose a layout; partials render standalone so an HTMX fragment is exactly the markup the page would contain.",
+				"HTMX is the interaction model — hx-get/hx-post on plain elements, the server answering with HTML, swaps targeted by id — and every page must still work when it is not there (progressive enhancement). Alpine is reserved for client-only state like tabs and modals. Styling speaks role tokens (bg-surface, text-muted-foreground); a CI scan fails the build on raw palette colors or dark: variants.",
+			},
+			ADR: adrLink("ADR-007-Frontend-Stack-Selection.md", "ADR-007 frontend stack · ADR-029 role tokens"),
+			Source: pages.ExplainerSource{
+				File: "internal/view/partials/quiz_question.templ",
+				Snippet: `// A standalone fragment for HTMX swaps AND a plain form without JS:
+// hx-post swaps the card in place, the form action posts the same payload full-page.
+templ QuizQuestionCard(props QuizQuestionProps) {
+    <form
+        method="post"
+        action={ templ.SafeURL(quizAnswerAction(props.Slug)) }
+        hx-post={ quizAnswerAction(props.Slug) }
+        hx-target="#quiz-card"
+        hx-swap="innerHTML"
+    >
+        @components.CSRFField()
+        for i, choice := range props.Choices {
+            <label class="flex items-center gap-3 p-3 rounded-md border border-border hover:border-primary">
+                <input type="radio" name="choice" value={ fmt.Sprintf("%d", i) } required/>
+                <span>{ choice }</span>
+            </label>
+        }
+        <button type="submit" class="btn btn-primary">Check answer</button>
+    </form>
+}`,
+			},
+		},
+		{
+			Step:      5,
+			Anchor:    "performance",
+			QuizTopic: "performance",
+			Title:     "Performance budgets, enforced in CI and observed in production",
+			Summary:   "Binary, memory, startup and gzipped JS/CSS budgets are constants in Go, gated by task ci, and observed via Prometheus — the numbers below are rendered from those constants on every request.",
+			Prose: []string{
+				"ADR-000 states the budgets once, in internal/performance/budgets.go. task ci builds the stripped binary and measures it, gzips the shipped JS and CSS and measures those, and runs the budget tests with the race detector — so a regression is a red build, not a slow page someone notices later.",
+				"At runtime the same constants feed this page: the stats grid is not a hardcoded list, it is a handler reading the constants and a templ component rendering them — dynamic server-rendered content with zero client JavaScript. Request latency and memory are exported to Prometheus at /metrics (bearer-gated in production).",
+			},
+			ADR: adrLink("ADR-000-Performance-Budgets-and-Quality-Attributes.md", "ADR-000 performance budgets · ADR-021 quality gate"),
+			Source: pages.ExplainerSource{
+				File: "internal/performance/budgets.go",
+				Snippet: `const (
+    MaxP95ResponseTime = 100 * time.Millisecond
+    MaxP99ResponseTime = 200 * time.Millisecond
+    MaxBinarySize      = 20 * 1024 * 1024  // stripped linux build
+    MaxMemoryUsage     = 128 * 1024 * 1024
+    MaxStartupTime     = 500 * time.Millisecond
+    MaxJavaScriptSize  = 50 * 1024         // gzipped
+    MaxCSSSize         = 30 * 1024         // gzipped
+)
+// task ci → test:binary-size, test:asset-budgets, go test ./internal/performance/...`,
+			},
+		},
+	}
+}
+
+// PerfBudgetStats renders the ADR-000 budgets from the constants in
+// internal/performance — never from literals here, so the landing page can
+// only ever show what CI actually enforces.
+func PerfBudgetStats() []pages.BudgetStat {
+	return []pages.BudgetStat{
+		{Label: "P50 response", Value: performance.MaxP50ResponseTime.String(), Note: "median latency target"},
+		{Label: "P95 response", Value: performance.MaxP95ResponseTime.String(), Note: "enforced by the budget tests"},
+		{Label: "P99 response", Value: performance.MaxP99ResponseTime.String(), Note: "tail latency ceiling"},
+		{Label: "Binary size", Value: formatBudgetBytes(performance.MaxBinarySize), Note: "stripped linux build, gated in task ci"},
+		{Label: "Memory", Value: formatBudgetBytes(performance.MaxMemoryUsage), Note: "steady state"},
+		{Label: "Peak memory", Value: formatBudgetBytes(performance.MaxPeakMemory), Note: "under load"},
+		{Label: "Startup", Value: performance.MaxStartupTime.String(), Note: "process start to listening"},
+		{Label: "JavaScript", Value: formatBudgetBytes(performance.MaxJavaScriptSize), Note: "gzipped — htmx + Alpine + app.js"},
+		{Label: "CSS", Value: formatBudgetBytes(performance.MaxCSSSize), Note: "gzipped Tailwind build"},
+		{Label: "Total page", Value: formatBudgetBytes(performance.MaxTotalPageSize), Note: "HTML + assets"},
+	}
+}
+
+// formatBudgetBytes renders byte budgets in the units ADR-000 states them
+// in (whole KB/MB when exact, one decimal otherwise).
+func formatBudgetBytes(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := int64(unit), 0
+	for m := n / unit; m >= unit; m /= unit {
+		div *= unit
+		exp++
+	}
+	value := float64(n) / float64(div)
+	if value == float64(int64(value)) {
+		return fmt.Sprintf("%d %cB", int64(value), "KMGTPE"[exp])
+	}
+	return fmt.Sprintf("%.1f %cB", value, "KMGTPE"[exp])
+}

--- a/internal/handler/home_explainer_test.go
+++ b/internal/handler/home_explainer_test.go
@@ -1,0 +1,121 @@
+package handler
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/clownware/go-performance-starter/internal/performance"
+)
+
+// TestExplainerNodes pins the teachable spine (ADR-024 surface 1, #67): the
+// explainer narrates a request's journey in five fixed steps, each anchored,
+// linked to its ADR, backed by a real source peek, and keyed to the quiz
+// topic that draws from it — so read → quiz → flashcards closes the loop.
+func TestExplainerNodes(t *testing.T) {
+	nodes := ExplainerNodes()
+
+	wantOrder := []struct{ anchor, topic, adr string }{
+		{"routing", "routing", "ADR-014"},
+		{"handlers", "handlers", "ADR-017"},
+		{"database", "database", "ADR-003"},
+		{"frontend", "frontend", "ADR-007"},
+		{"performance", "performance", "ADR-000"},
+	}
+	if len(nodes) != len(wantOrder) {
+		t.Fatalf("got %d nodes, want %d", len(nodes), len(wantOrder))
+	}
+	seenAnchors := map[string]bool{}
+	for i, want := range wantOrder {
+		n := nodes[i]
+		if n.Step != i+1 {
+			t.Errorf("node %d Step = %d, want %d", i, n.Step, i+1)
+		}
+		if n.Anchor != want.anchor {
+			t.Errorf("node %d Anchor = %q, want %q", i, n.Anchor, want.anchor)
+		}
+		if seenAnchors[n.Anchor] {
+			t.Errorf("duplicate anchor %q", n.Anchor)
+		}
+		seenAnchors[n.Anchor] = true
+		if n.QuizTopic != want.topic {
+			t.Errorf("node %d QuizTopic = %q, want %q (must match the seeded quiz_questions.topic)", i, n.QuizTopic, want.topic)
+		}
+		if !strings.Contains(n.ADR.Label, want.adr) || !strings.Contains(n.ADR.Href, want.adr) {
+			t.Errorf("node %d ADR = %+v, want it to name %s", i, n.ADR, want.adr)
+		}
+		if n.Title == "" || n.Summary == "" || len(n.Prose) == 0 {
+			t.Errorf("node %d is missing title/summary/prose: %+v", i, n)
+		}
+		if n.Source.File == "" || !strings.Contains(n.Source.Snippet, "\n") {
+			t.Errorf("node %d needs a source peek with a file path and a multi-line snippet", i)
+		}
+		if !strings.HasPrefix(n.Source.File, "internal/") && !strings.HasPrefix(n.Source.File, "sql/") && !strings.HasPrefix(n.Source.File, "migrations/") {
+			t.Errorf("node %d Source.File = %q should point into the repo tree", i, n.Source.File)
+		}
+	}
+}
+
+// TestPerfBudgetStats pins the "render from constants, never hardcode" rule
+// (design brief §Live performance stats): every stat is derived from
+// internal/performance at request time, so a budget change in ADR-000's
+// constants changes the landing page without anyone editing a template.
+func TestPerfBudgetStats(t *testing.T) {
+	stats := PerfBudgetStats()
+
+	want := map[string]string{
+		"P50 response":  performance.MaxP50ResponseTime.String(),
+		"P95 response":  performance.MaxP95ResponseTime.String(),
+		"P99 response":  performance.MaxP99ResponseTime.String(),
+		"Binary size":   "20 MB",
+		"Memory":        "128 MB",
+		"Startup":       performance.MaxStartupTime.String(),
+		"JavaScript":    "50 KB",
+		"CSS":           "30 KB",
+		"Total page":    "500 KB",
+		"Docker image":  "", // not a performance constant — must NOT appear
+		"Peak memory":   "256 MB",
+		"Response time": "", // generic label must not appear; the three percentiles do
+	}
+	got := map[string]string{}
+	for _, s := range stats {
+		if s.Label == "" || s.Value == "" {
+			t.Errorf("stat with empty label/value: %+v", s)
+		}
+		got[s.Label] = s.Value
+	}
+	for label, value := range want {
+		if value == "" {
+			if _, ok := got[label]; ok {
+				t.Errorf("stat %q should not be rendered (no constant backs it)", label)
+			}
+			continue
+		}
+		if got[label] != value {
+			t.Errorf("stat %q = %q, want %q (from internal/performance)", label, got[label], value)
+		}
+	}
+	if len(stats) != 10 {
+		t.Errorf("got %d stats, want 10 (three latency percentiles, four resource, three frontend)", len(stats))
+	}
+}
+
+// TestFormatBudgetBytes pins the human units the stats use.
+func TestFormatBudgetBytes(t *testing.T) {
+	tests := []struct {
+		in   int64
+		want string
+	}{
+		{512, "512 B"},
+		{50 * 1024, "50 KB"},
+		{30 * 1024, "30 KB"},
+		{500 * 1024, "500 KB"},
+		{20 * 1024 * 1024, "20 MB"},
+		{128 * 1024 * 1024, "128 MB"},
+		{1536, "1.5 KB"},
+	}
+	for _, tt := range tests {
+		if got := formatBudgetBytes(tt.in); got != tt.want {
+			t.Errorf("formatBudgetBytes(%d) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -245,8 +245,13 @@ func (s *Server) AuthClient() *auth.AuthClient {
 }
 
 func homeHandler(w http.ResponseWriter, r *http.Request) {
+	// The explainer spine and the live budget stats are built per request
+	// from code and constants (ADR-024 surface 1, #67) — server-rendered
+	// dynamic content is part of what the page demonstrates.
 	props := pages.HomePageProps{
 		BaseProps: view.NewBaseProps("Go Performance Starter"),
+		Nodes:     handler.ExplainerNodes(),
+		Stats:     handler.PerfBudgetStats(),
 	}
 	if err := view.Render(w, r, http.StatusOK, pages.HomePage(props)); err != nil {
 		slog.Error("Failed to render home page", "error", err)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -244,3 +244,54 @@ func TestServer_AssetCacheBusting(t *testing.T) {
 		t.Error("page still renders the retired full-screen loading overlay")
 	}
 }
+
+// TestServer_HomeExplainer pins ADR-024 surface 1 (#67): the landing page
+// renders the five-node architecture walkthrough with anchors, source
+// peeks and ADR links, plus the live budget grid whose values come from
+// internal/performance — while the original hero and surface directory
+// stay in place (the directory is the skeleton the explainer grows around).
+func TestServer_HomeExplainer(t *testing.T) {
+	srv := newTestServer(t, "development")
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET / status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+
+	if !strings.Contains(body, `data-testid="explainer"`) {
+		t.Fatal("home page missing the architecture explainer section")
+	}
+	if got := strings.Count(body, `data-testid="explainer-node"`); got != 5 {
+		t.Errorf("explainer renders %d nodes, want 5 (routing, handlers, database, frontend, performance)", got)
+	}
+	for _, anchor := range []string{`id="routing"`, `id="handlers"`, `id="database"`, `id="frontend"`, `id="performance"`} {
+		if !strings.Contains(body, anchor) {
+			t.Errorf("explainer missing node anchor %s", anchor)
+		}
+	}
+	for _, adr := range []string{"ADR-014-", "ADR-017-", "ADR-003-", "ADR-007-", "ADR-000-"} {
+		if !strings.Contains(body, "docs/adr/"+adr) {
+			t.Errorf("explainer missing a link to %s", adr)
+		}
+	}
+	if got := strings.Count(body, "<details"); got != 5 {
+		t.Errorf("explainer renders %d source peeks, want 5 (one <details> per node, no JS required)", got)
+	}
+	if !strings.Contains(body, `href="/learn/quiz"`) {
+		t.Error("explainer must hand off to the quiz (read → quiz → flashcards)")
+	}
+
+	if !strings.Contains(body, `data-testid="perf-stats"`) {
+		t.Fatal("home page missing the live performance budgets section")
+	}
+	if got := strings.Count(body, `data-testid="perf-stat"`); got != 10 {
+		t.Errorf("budget grid renders %d stats, want 10", got)
+	}
+	// Values come from the constants, not the template: spot-check two.
+	for _, want := range []string{"&lt; 100ms", "&lt; 20 MB", "&lt; 50 KB"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("budget grid missing %q (rendered from internal/performance)", want)
+		}
+	}
+}

--- a/internal/view/pages/home.templ
+++ b/internal/view/pages/home.templ
@@ -1,14 +1,52 @@
 package pages
 
 import (
+	"fmt"
 	"github.com/clownware/go-performance-starter/internal/view"
 	"github.com/clownware/go-performance-starter/internal/view/components"
 	"github.com/clownware/go-performance-starter/internal/view/layouts"
 )
 
-// HomePageProps holds data for the home landing page.
+// HomePageProps holds data for the home landing page. Nodes and Stats are
+// built by the handler (internal/handler/home_explainer.go): the explainer
+// spine and the live ADR-000 budgets rendered from constants (#67).
 type HomePageProps struct {
 	view.BaseProps
+	Nodes []ExplainerNode
+	Stats []BudgetStat
+}
+
+// ExplainerNode is one step of the request's journey through the stack
+// (ADR-024 surface 1): prose, a source peek, its ADR, and the quiz topic
+// that draws from it.
+type ExplainerNode struct {
+	Step      int
+	Anchor    string // fragment id, e.g. "routing"
+	QuizTopic string // matches quiz_questions.topic
+	Title     string
+	Summary   string
+	Prose     []string
+	ADR       ExplainerLink
+	Source    ExplainerSource
+}
+
+// ExplainerLink is an outbound reference (an ADR on GitHub).
+type ExplainerLink struct {
+	Href  string
+	Label string
+}
+
+// ExplainerSource is an abridged excerpt of a real file in this repo.
+type ExplainerSource struct {
+	File    string
+	Snippet string
+}
+
+// BudgetStat is one ADR-000 budget, rendered from internal/performance.
+type BudgetStat struct {
+	Label string
+	Value string
+	Note  string
 }
 
 // surface is one entry in the home directory of demo surfaces.
@@ -18,9 +56,8 @@ type surface struct {
 	Description string
 }
 
-// homeSurfaces lists the demo surfaces in tour order — the interim
-// navigational directory until the full ADR-024 architecture explainer
-// lands on this page.
+// homeSurfaces lists the demo surfaces in tour order — the navigational
+// skeleton the explainer grows around (ADR-024).
 func homeSurfaces() []surface {
 	return []surface{
 		{
@@ -60,6 +97,7 @@ templ HomePage(props HomePageProps) {
 			</p>
 			<div class="flex flex-wrap justify-center gap-3 mb-12">
 				<a href="/patterns" class="btn btn-primary inline-block">Explore the patterns</a>
+				<a href="#architecture" class="btn btn-secondary inline-block">Follow a request through the stack</a>
 				<a href="https://github.com/clownware/go-performance-starter" target="_blank" rel="noopener noreferrer" class="btn btn-secondary inline-block">View on GitHub</a>
 			</div>
 		</section>
@@ -75,5 +113,100 @@ templ HomePage(props HomePageProps) {
 				</a>
 			}
 		</section>
+		if len(props.Nodes) > 0 {
+			@explainer(props.Nodes)
+		}
+		if len(props.Stats) > 0 {
+			@perfStats(props.Stats)
+		}
 	}
+}
+
+// explainer is the architecture walkthrough (ADR-024 surface 1): the five
+// nodes of a request's journey, each with prose, an ADR link, a native
+// <details> source peek (no JavaScript needed), and the quiz hand-off.
+templ explainer(nodes []ExplainerNode) {
+	<section id="architecture" data-testid="explainer" aria-labelledby="architecture-heading" class="max-w-3xl mx-auto py-12 scroll-mt-20">
+		<header class="mb-8 text-center">
+			<p class="text-sm uppercase tracking-wide text-muted-foreground mb-2">Architecture tour</p>
+			<h2 id="architecture-heading" class="text-2xl font-bold mb-3">Follow one request through the stack</h2>
+			<p class="text-muted-foreground max-w-xl mx-auto">
+				Five stops from the socket to the pixel. Each is a live part of this
+				very page, links to the decision record that shaped it, and feeds the
+				quiz — so what you read here is what you'll be asked.
+			</p>
+		</header>
+		<nav aria-label="Tour steps" class="mb-8">
+			<ol class="flex flex-wrap justify-center gap-2 text-sm">
+				for _, n := range nodes {
+					<li>
+						<a href={ templ.SafeURL("#" + n.Anchor) } class="inline-block px-3 py-1 rounded-full border border-border bg-surface text-link hover:border-primary focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary">
+							{ fmt.Sprintf("%d · %s", n.Step, n.QuizTopic) }
+						</a>
+					</li>
+				}
+			</ol>
+		</nav>
+		<ol class="space-y-6">
+			for _, n := range nodes {
+				<li id={ n.Anchor } data-testid="explainer-node" class="bg-surface rounded-lg shadow-md p-6 scroll-mt-20">
+					<div class="flex items-start gap-4">
+						<span aria-hidden="true" class="shrink-0 flex h-9 w-9 items-center justify-center rounded-full bg-primary/10 text-link font-semibold">{ fmt.Sprintf("%d", n.Step) }</span>
+						<div class="min-w-0 flex-1">
+							<h3 class="text-lg font-semibold mb-1">
+								<span class="sr-only">{ fmt.Sprintf("Step %d: ", n.Step) }</span>
+								{ n.Title }
+							</h3>
+							<p class="text-sm text-muted-foreground mb-4">{ n.Summary }</p>
+							for _, p := range n.Prose {
+								<p class="mb-3 text-foreground">{ p }</p>
+							}
+							<details class="mt-4 rounded-md border border-border bg-background/60 open:bg-surface-hover">
+								<summary class="cursor-pointer select-none px-4 py-2 text-sm font-medium text-link hover:underline">
+									Source peek — <code class="text-xs text-foreground">{ n.Source.File }</code>
+								</summary>
+								<pre class="p-4 text-xs overflow-x-auto border-t border-border"><code>{ n.Source.Snippet }</code></pre>
+							</details>
+							<p class="mt-4 flex flex-wrap gap-x-4 gap-y-1 text-sm">
+								<a href={ templ.SafeURL(n.ADR.Href) } target="_blank" rel="noopener noreferrer" class="text-link hover:underline">{ n.ADR.Label } ↗</a>
+								<a href="/learn/quiz" class="text-link hover:underline">{ "Quiz yourself on " + n.QuizTopic + " →" }</a>
+							</p>
+						</div>
+					</div>
+				</li>
+			}
+		</ol>
+		<div class="mt-10 text-center">
+			<p class="text-muted-foreground mb-4">Read it? Now prove it — wrong answers become flashcards you can keep.</p>
+			<a href="/learn/quiz" class="btn btn-primary inline-block">Take the architecture quiz</a>
+		</div>
+	</section>
+}
+
+// perfStats renders the ADR-000 budgets. The values arrive from the handler,
+// which reads internal/performance at request time — this component never
+// hardcodes a number, which is the point it demonstrates.
+templ perfStats(stats []BudgetStat) {
+	<section id="budgets" data-testid="perf-stats" aria-labelledby="budgets-heading" class="max-w-3xl mx-auto pb-12 scroll-mt-20">
+		<header class="mb-6 text-center">
+			<p class="text-sm uppercase tracking-wide text-muted-foreground mb-2">Live performance budgets</p>
+			<h2 id="budgets-heading" class="text-2xl font-bold mb-3">What CI refuses to ship past</h2>
+			<p class="text-muted-foreground max-w-xl mx-auto">
+				Rendered on this request from the constants in
+				<code class="text-xs px-1 rounded bg-primary/10 text-link">internal/performance/budgets.go</code>
+				— the same values <code class="text-xs px-1 rounded bg-primary/10 text-link">task ci</code> enforces. Change the constant, and this grid changes; no template edit involved.
+			</p>
+		</header>
+		<dl class="grid gap-3 grid-cols-2 sm:grid-cols-3 lg:grid-cols-5">
+			for _, s := range stats {
+				<div data-testid="perf-stat" class="bg-surface rounded-lg shadow-sm p-4 text-center">
+					<dt class="text-xs uppercase tracking-wide text-muted-foreground">{ s.Label }</dt>
+					<dd class="mt-1">
+						<span class="block text-xl font-semibold text-foreground">{ "< " + s.Value }</span>
+						<span class="block text-xs text-muted-foreground mt-1">{ s.Note }</span>
+					</dd>
+				</div>
+			}
+		</dl>
+	</section>
 }

--- a/internal/view/pages/home_templ.go
+++ b/internal/view/pages/home_templ.go
@@ -9,14 +9,52 @@ import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
 import (
+	"fmt"
 	"github.com/clownware/go-performance-starter/internal/view"
 	"github.com/clownware/go-performance-starter/internal/view/components"
 	"github.com/clownware/go-performance-starter/internal/view/layouts"
 )
 
-// HomePageProps holds data for the home landing page.
+// HomePageProps holds data for the home landing page. Nodes and Stats are
+// built by the handler (internal/handler/home_explainer.go): the explainer
+// spine and the live ADR-000 budgets rendered from constants (#67).
 type HomePageProps struct {
 	view.BaseProps
+	Nodes []ExplainerNode
+	Stats []BudgetStat
+}
+
+// ExplainerNode is one step of the request's journey through the stack
+// (ADR-024 surface 1): prose, a source peek, its ADR, and the quiz topic
+// that draws from it.
+type ExplainerNode struct {
+	Step      int
+	Anchor    string // fragment id, e.g. "routing"
+	QuizTopic string // matches quiz_questions.topic
+	Title     string
+	Summary   string
+	Prose     []string
+	ADR       ExplainerLink
+	Source    ExplainerSource
+}
+
+// ExplainerLink is an outbound reference (an ADR on GitHub).
+type ExplainerLink struct {
+	Href  string
+	Label string
+}
+
+// ExplainerSource is an abridged excerpt of a real file in this repo.
+type ExplainerSource struct {
+	File    string
+	Snippet string
+}
+
+// BudgetStat is one ADR-000 budget, rendered from internal/performance.
+type BudgetStat struct {
+	Label string
+	Value string
+	Note  string
 }
 
 // surface is one entry in the home directory of demo surfaces.
@@ -26,9 +64,8 @@ type surface struct {
 	Description string
 }
 
-// homeSurfaces lists the demo surfaces in tour order — the interim
-// navigational directory until the full ADR-024 architecture explainer
-// lands on this page.
+// homeSurfaces lists the demo surfaces in tour order — the navigational
+// skeleton the explainer grows around (ADR-024).
 func homeSurfaces() []surface {
 	return []surface{
 		{
@@ -95,7 +132,7 @@ func HomePage(props HomePageProps) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div><h1 class=\"text-3xl font-bold mb-3\">Go Performance Starter</h1><p class=\"text-muted-foreground mb-6 max-w-xl mx-auto\">A server-rendered Go + HTMX starter that proves its own architecture: typed templates, RLS-scoped data access, and performance budgets enforced in CI — demonstrated live by the surfaces below.</p><div class=\"flex flex-wrap justify-center gap-3 mb-12\"><a href=\"/patterns\" class=\"btn btn-primary inline-block\">Explore the patterns</a> <a href=\"https://github.com/clownware/go-performance-starter\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"btn btn-secondary inline-block\">View on GitHub</a></div></section><section data-testid=\"surface-directory\" aria-label=\"Demo surfaces\" class=\"max-w-3xl mx-auto grid gap-4 sm:grid-cols-2 pb-8\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div><h1 class=\"text-3xl font-bold mb-3\">Go Performance Starter</h1><p class=\"text-muted-foreground mb-6 max-w-xl mx-auto\">A server-rendered Go + HTMX starter that proves its own architecture: typed templates, RLS-scoped data access, and performance budgets enforced in CI — demonstrated live by the surfaces below.</p><div class=\"flex flex-wrap justify-center gap-3 mb-12\"><a href=\"/patterns\" class=\"btn btn-primary inline-block\">Explore the patterns</a> <a href=\"#architecture\" class=\"btn btn-secondary inline-block\">Follow a request through the stack</a> <a href=\"https://github.com/clownware/go-performance-starter\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"btn btn-secondary inline-block\">View on GitHub</a></div></section><section data-testid=\"surface-directory\" aria-label=\"Demo surfaces\" class=\"max-w-3xl mx-auto grid gap-4 sm:grid-cols-2 pb-8\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -107,7 +144,7 @@ func HomePage(props HomePageProps) templ.Component {
 				var templ_7745c5c3_Var3 templ.SafeURL
 				templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(s.Href))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 70, Col: 33}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 108, Col: 33}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 				if templ_7745c5c3_Err != nil {
@@ -120,7 +157,7 @@ func HomePage(props HomePageProps) templ.Component {
 				var templ_7745c5c3_Var4 string
 				templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(s.Title)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 73, Col: 63}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 111, Col: 63}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 				if templ_7745c5c3_Err != nil {
@@ -133,7 +170,7 @@ func HomePage(props HomePageProps) templ.Component {
 				var templ_7745c5c3_Var5 string
 				templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(s.Description)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 74, Col: 61}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 112, Col: 61}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 				if templ_7745c5c3_Err != nil {
@@ -148,9 +185,337 @@ func HomePage(props HomePageProps) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
+			if len(props.Nodes) > 0 {
+				templ_7745c5c3_Err = explainer(props.Nodes).Render(ctx, templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, " ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			if len(props.Stats) > 0 {
+				templ_7745c5c3_Err = perfStats(props.Stats).Render(ctx, templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
 			return nil
 		})
 		templ_7745c5c3_Err = layouts.Base(props.BaseProps).Render(templ.WithChildren(ctx, templ_7745c5c3_Var2), templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// explainer is the architecture walkthrough (ADR-024 surface 1): the five
+// nodes of a request's journey, each with prose, an ADR link, a native
+// <details> source peek (no JavaScript needed), and the quiz hand-off.
+func explainer(nodes []ExplainerNode) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var6 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var6 == nil {
+			templ_7745c5c3_Var6 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<section id=\"architecture\" data-testid=\"explainer\" aria-labelledby=\"architecture-heading\" class=\"max-w-3xl mx-auto py-12 scroll-mt-20\"><header class=\"mb-8 text-center\"><p class=\"text-sm uppercase tracking-wide text-muted-foreground mb-2\">Architecture tour</p><h2 id=\"architecture-heading\" class=\"text-2xl font-bold mb-3\">Follow one request through the stack</h2><p class=\"text-muted-foreground max-w-xl mx-auto\">Five stops from the socket to the pixel. Each is a live part of this very page, links to the decision record that shaped it, and feeds the quiz — so what you read here is what you'll be asked.</p></header><nav aria-label=\"Tour steps\" class=\"mb-8\"><ol class=\"flex flex-wrap justify-center gap-2 text-sm\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		for _, n := range nodes {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<li><a href=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var7 templ.SafeURL
+			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL("#" + n.Anchor))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 143, Col: 45}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "\" class=\"inline-block px-3 py-1 rounded-full border border-border bg-surface text-link hover:border-primary focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var8 string
+			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d · %s", n.Step, n.QuizTopic))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 144, Col: 53}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</a></li>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "</ol></nav><ol class=\"space-y-6\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		for _, n := range nodes {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "<li id=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var9 string
+			templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.ResolveAttributeValue(n.Anchor)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 152, Col: 21}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var9)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "\" data-testid=\"explainer-node\" class=\"bg-surface rounded-lg shadow-md p-6 scroll-mt-20\"><div class=\"flex items-start gap-4\"><span aria-hidden=\"true\" class=\"shrink-0 flex h-9 w-9 items-center justify-center rounded-full bg-primary/10 text-link font-semibold\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var10 string
+			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", n.Step))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 154, Col: 167}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</span><div class=\"min-w-0 flex-1\"><h3 class=\"text-lg font-semibold mb-1\"><span class=\"sr-only\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var11 string
+			templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("Step %d: ", n.Step))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 157, Col: 64}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "</span> ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var12 string
+			templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(n.Title)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 158, Col: 17}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "</h3><p class=\"text-sm text-muted-foreground mb-4\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var13 string
+			templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(n.Summary)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 160, Col: 64}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "</p>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			for _, p := range n.Prose {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "<p class=\"mb-3 text-foreground\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var14 string
+				templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(p)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 162, Col: 43}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "</p>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "<details class=\"mt-4 rounded-md border border-border bg-background/60 open:bg-surface-hover\"><summary class=\"cursor-pointer select-none px-4 py-2 text-sm font-medium text-link hover:underline\">Source peek — <code class=\"text-xs text-foreground\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var15 string
+			templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(n.Source.File)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 166, Col: 78}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "</code></summary><pre class=\"p-4 text-xs overflow-x-auto border-t border-border\"><code>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var16 string
+			templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(n.Source.Snippet)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 168, Col: 96}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "</code></pre></details><p class=\"mt-4 flex flex-wrap gap-x-4 gap-y-1 text-sm\"><a href=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var17 templ.SafeURL
+			templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(n.ADR.Href))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 171, Col: 43}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"text-link hover:underline\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var18 string
+			templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(n.ADR.Label)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 171, Col: 135}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, " ↗</a> <a href=\"/learn/quiz\" class=\"text-link hover:underline\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var19 string
+			templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs("Quiz yourself on " + n.QuizTopic + " →")
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 172, Col: 108}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "</a></p></div></div></li>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "</ol><div class=\"mt-10 text-center\"><p class=\"text-muted-foreground mb-4\">Read it? Now prove it — wrong answers become flashcards you can keep.</p><a href=\"/learn/quiz\" class=\"btn btn-primary inline-block\">Take the architecture quiz</a></div></section>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// perfStats renders the ADR-000 budgets. The values arrive from the handler,
+// which reads internal/performance at request time — this component never
+// hardcodes a number, which is the point it demonstrates.
+func perfStats(stats []BudgetStat) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var20 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var20 == nil {
+			templ_7745c5c3_Var20 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "<section id=\"budgets\" data-testid=\"perf-stats\" aria-labelledby=\"budgets-heading\" class=\"max-w-3xl mx-auto pb-12 scroll-mt-20\"><header class=\"mb-6 text-center\"><p class=\"text-sm uppercase tracking-wide text-muted-foreground mb-2\">Live performance budgets</p><h2 id=\"budgets-heading\" class=\"text-2xl font-bold mb-3\">What CI refuses to ship past</h2><p class=\"text-muted-foreground max-w-xl mx-auto\">Rendered on this request from the constants in <code class=\"text-xs px-1 rounded bg-primary/10 text-link\">internal/performance/budgets.go</code> — the same values <code class=\"text-xs px-1 rounded bg-primary/10 text-link\">task ci</code> enforces. Change the constant, and this grid changes; no template edit involved.</p></header><dl class=\"grid gap-3 grid-cols-2 sm:grid-cols-3 lg:grid-cols-5\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		for _, s := range stats {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "<div data-testid=\"perf-stat\" class=\"bg-surface rounded-lg shadow-sm p-4 text-center\"><dt class=\"text-xs uppercase tracking-wide text-muted-foreground\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var21 string
+			templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(s.Label)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 203, Col: 80}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "</dt><dd class=\"mt-1\"><span class=\"block text-xl font-semibold text-foreground\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var22 string
+			templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs("< " + s.Value)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 205, Col: 80}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "</span> <span class=\"block text-xs text-muted-foreground mt-1\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var23 string
+			templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(s.Note)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 206, Col: 69}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "</span></dd></div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "</dl></section>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
## Summary
ADR-024 surface 1 (P1) — the landing page stops being an interim hero and becomes the interactive walkthrough of the system's own architecture, per the design brief's explainer content map.

- **Five-node request journey** (`#routing → #handlers → #database → #frontend → #performance`): each node has prose, an abridged **source peek of the real file it cites** in a native `<details>` (zero JS to read), its **ADR link**, and a **quiz hand-off** — node topics match the seeded `quiz_questions.topic` spine exactly, so read → quiz → flashcards closes the loop. A pill nav jumps between steps; the hero gains a "Follow a request through the stack" CTA.
- **Live performance budgets grid**: `PerfBudgetStats()` reads `internal/performance/budgets.go` constants at request time — no literals in the handler or template, so the page can only show what `task ci` enforces. Change `MaxP95ResponseTime` and the landing page changes; that's the server-rendered-dynamic-content demo the brief asks for.
- The hero and surface directory **stay** as the navigational skeleton (per the issue: "extend, not disappear").
- Content builders live handler-side (`internal/handler/home_explainer.go`) with typed props (ADR-017); role tokens only (ADR-029). CHANGELOG `Unreleased › Added`.

Closes #67

## Verification
- `TestExplainerNodes`: order/anchors/quiz-topic keys/ADR names/multi-line real-path source peeks; `TestPerfBudgetStats`: every stat equals its constant, unbacked stats (Docker image) excluded; `TestFormatBudgetBytes`.
- `TestServer_HomeExplainer` (router level): 5 nodes, 5 `<details>`, all anchors, all 5 ADR links, 10 stats, spot-checked live values (`< 100ms`, `< 20 MB`, `< 50 KB`), quiz hand-off present.
- Verified in the browser against a real Postgres in light **and** dark at 1280px: hero CTA, pill nav, node cards, opened source peek (x-scroll contained), budgets grid.
- `task ci` green; CSS 7.9 KB gzipped (budget 30 KB), JS unchanged.

## Notes
- Source snippets are hand-abridged excerpts, same convention as the patterns catalogue — #73 already tracks generating them from source at build time.
- The quiz hand-off links to `/learn/quiz` (the quiz serves questions in sequence; per-topic entry would be a quiz-handler feature, not a landing feature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)