### PR TITLE
chore(lint): pin golangci-lint to v2.13.1 and track it in versions.json (ADR-030)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Two hooks are the only blocking layer: a **Stop-gate** (agents can't finish a tu
 
 [`versions.json`](versions.json) at the repo root is a machine-readable manifest of what this template ships — its own release version (`template`) plus one key per meaningful stack pin (Go, templ, HTMX, Alpine, Tailwind, sqlc, …). External consumers fetch it raw from the default branch at build time, so treat it as a consumption contract: **adding keys is fine; renaming or removing keys is a breaking change.**
 
-It cannot drift: `task versions:check` (part of `task ci`) fails when any key disagrees with its in-repo source of truth (`go.mod`, `package-lock.json`, vendored JS bundles, sqlc headers, workflow pins), and the release workflow stamps the `template` field from the git tag ([ADR-030](docs/adr/ADR-030-Versions-Manifest-Contract.md)). After bumping a pin, `task versions:sync` rewrites the manifest from those same sources so the bump stays a one-file edit — the check remains the gate.
+It cannot drift: `task versions:check` (part of `task ci`) fails when any key disagrees with its in-repo source of truth (`go.mod`, `package-lock.json`, vendored JS bundles, sqlc headers, workflow pins, Taskfile tool pins), and the release workflow stamps the `template` field from the git tag ([ADR-030](docs/adr/ADR-030-Versions-Manifest-Contract.md)). After bumping a pin, `task versions:sync` rewrites the manifest from those same sources so the bump stays a one-file edit — the check remains the gate.
 
 ## Architecture Decisions
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -5,6 +5,12 @@ version: '3'
 # (a missing .env is a no-op here). See .env.tpl / .env.example.
 dotenv: ['.env']
 
+vars:
+  # Pinned so lint results are reproducible and CI never resolves @latest over
+  # the network. Tracked in versions.json (ADR-030) — bump here, then run
+  # `task versions:sync`.
+  GOLANGCI_LINT_VERSION: 2.13.1
+
 tasks:
   # Development tasks
   dev:
@@ -35,9 +41,10 @@ tasks:
   lint:install:
     desc: Install golangci-lint for local development
     cmds:
-      - go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+      - go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v{{.GOLANGCI_LINT_VERSION}}
     status:
-      - which golangci-lint
+      # Version-aware so a stale local binary gets upgraded, not silently kept.
+      - golangci-lint version | grep -qF "version {{.GOLANGCI_LINT_VERSION}} "
 
   lint:
     desc: Run linters

--- a/scripts/checkversions/main.go
+++ b/scripts/checkversions/main.go
@@ -39,6 +39,10 @@ var migrateVersionRe = regexp.MustCompile(`golang-migrate/migrate/releases/downl
 // nodeVersionRe matches the CI Node pin (`node-version: '20'`).
 var nodeVersionRe = regexp.MustCompile(`node-version:\s*['"]?([0-9]+(?:\.[0-9]+)*)`)
 
+// golangciLintVersionRe matches the Taskfile var behind lint:install
+// (`GOLANGCI_LINT_VERSION: 2.13.1`).
+var golangciLintVersionRe = regexp.MustCompile(`GOLANGCI_LINT_VERSION:\s*['"]?([0-9]+(?:\.[0-9]+)+)`)
+
 // templateRe is the only key not checked against a source file: the release
 // workflow stamps it from the git tag, so CI just enforces the tag format.
 var templateRe = regexp.MustCompile(`^v[0-9]+\.[0-9]+\.[0-9]+$`)
@@ -156,6 +160,10 @@ func expectedVersions() (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	golangciLint, err := firstMatch("Taskfile.yml", golangciLintVersionRe)
+	if err != nil {
+		return nil, err
+	}
 
 	return map[string]string{
 		"go":             mod["toolchain"],
@@ -171,6 +179,7 @@ func expectedVersions() (map[string]string, error) {
 		"sqlc":           sqlc,
 		"golang-migrate": migrateVersion,
 		"node":           node,
+		"golangci-lint":  golangciLint,
 	}, nil
 }
 

--- a/scripts/checkversions/main_test.go
+++ b/scripts/checkversions/main_test.go
@@ -88,6 +88,16 @@ package database
     steps:
       - run: curl -L https://github.com/golang-migrate/migrate/releases/download/v4.19.1/migrate.linux-amd64.tar.gz | tar xvz
 `,
+		"Taskfile.yml": `version: '3'
+
+vars:
+  GOLANGCI_LINT_VERSION: 2.99.5
+
+tasks:
+  lint:install:
+    cmds:
+      - go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v{{.GOLANGCI_LINT_VERSION}}
+`,
 	}
 }
 
@@ -108,6 +118,7 @@ func fakeManifest() map[string]string {
 		"sqlc":           "1.31.1",
 		"golang-migrate": "4.19.1",
 		"node":           "20",
+		"golangci-lint":  "2.99.5",
 	}
 }
 
@@ -261,6 +272,7 @@ func TestExpectedVersions(t *testing.T) {
 				"sqlc":           "1.31.1",
 				"golang-migrate": "4.19.1",
 				"node":           "20",
+				"golangci-lint":  "2.99.5",
 			},
 		},
 		{
@@ -330,6 +342,19 @@ func TestExpectedVersions(t *testing.T) {
 			wantErr: "release.yml",
 		},
 		{
+			name:    "missing Taskfile errors",
+			edit:    func(files map[string]string) { delete(files, "Taskfile.yml") },
+			wantErr: "Taskfile.yml",
+		},
+		{
+			name: "Taskfile without a golangci-lint pin errors",
+			edit: func(files map[string]string) {
+				files["Taskfile.yml"] = strings.Replace(
+					files["Taskfile.yml"], "GOLANGCI_LINT_VERSION: 2.99.5\n", "", 1)
+			},
+			wantErr: "Taskfile.yml: no match",
+		},
+		{
 			name: "ci workflow without a node pin errors",
 			edit: func(files map[string]string) {
 				files[".github/workflows/ci.yml"] = strings.Replace(
@@ -383,7 +408,7 @@ func TestMainVerdict(t *testing.T) {
 		{
 			name:     "manifest matching every pin passes and reports the key count",
 			wantExit: 0,
-			wantOut:  "✅ versions.json matches the repo's actual pins (14 keys)",
+			wantOut:  "✅ versions.json matches the repo's actual pins (15 keys)",
 		},
 		{
 			name:         "drifted pin fails naming the key and both values",
@@ -602,13 +627,15 @@ func TestVersionRegexes(t *testing.T) {
 		{name: "sqlc header", re: "sqlc", input: "// versions:\n//   sqlc v1.31.1\n", want: "1.31.1"},
 		{name: "migrate download url", re: "migrate", input: "https://github.com/golang-migrate/migrate/releases/download/v4.19.1/migrate.linux-amd64.tar.gz", want: "4.19.1"},
 		{name: "node ci pin", re: "node", input: "node-version: '20'", want: "20"},
+		{name: "golangci-lint taskfile var", re: "golangci", input: "vars:\n  GOLANGCI_LINT_VERSION: 2.13.1\n", want: "2.13.1"},
 	}
 
 	res := map[string]interface{ FindStringSubmatch(string) []string }{
-		"js":      jsVersionRe,
-		"sqlc":    sqlcVersionRe,
-		"migrate": migrateVersionRe,
-		"node":    nodeVersionRe,
+		"js":       jsVersionRe,
+		"sqlc":     sqlcVersionRe,
+		"migrate":  migrateVersionRe,
+		"node":     nodeVersionRe,
+		"golangci": golangciLintVersionRe,
 	}
 
 	for _, tt := range tests {

--- a/versions.json
+++ b/versions.json
@@ -12,5 +12,6 @@
   "tailwindcss": "4.3.3",
   "sqlc": "1.31.1",
   "golang-migrate": "4.19.1",
-  "node": "20"
+  "node": "20",
+  "golangci-lint": "2.13.1"
 }


### PR DESCRIPTION
## Why

`task lint:install` resolved `golangci-lint@latest`, which is non-reproducible (lint findings can change under CI without a code change) and network-fragile — master CI run 32994372574 failed on a transient proxy.golang.org stream error while resolving `@latest`. CI runs `task ci`, so the Taskfile is the single install path for both local and CI lint.

## What changed

- **Taskfile.yml** — the pin lives once, in a `GOLANGCI_LINT_VERSION: 2.13.1` var (the version CI last resolved, and current latest). `lint:install` installs `@v{{.GOLANGCI_LINT_VERSION}}`, and its `status:` check is now version-aware (`golangci-lint version | grep`) instead of `which`, so a stale local binary gets upgraded instead of silently kept — local lint can no longer diverge from CI.
- **scripts/checkversions** — new `golangci-lint` key wired to the Taskfile var as its source of truth, following the existing regex-per-source pattern. Tests extended first per ADR-023: fake-repo Taskfile, regex case, missing-file/missing-pin error cases, key count 14→15.
- **versions.json** — `"golangci-lint": "2.13.1"` appended via `task versions:sync`. Additive key, explicitly allowed by ADR-030 §1; a future bump is edit-the-var + sync, and drift fails `task ci`.
- **README.md** — added "Taskfile tool pins" to the versions.json source-of-truth list.

No ADR change: ADR-030 TC-1 is written generically over all non-`template` keys, and the ADR record is append-only (ADR-033).

## Verification

`task ci` passes end to end on this branch (rebased on master): fmt, lint under the pinned binary, race tests, agents:check, versions:check (15 keys), ADR suite (11 pass), generated-code drift, binary size 13.78 MB, asset budgets, govulncheck clean. The version-aware `status:` check proved itself locally by upgrading a stale 2.12.2 install to 2.13.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)