### PR TITLE
fix(middleware): stop RateLimiter eviction goroutine with the server

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -156,6 +156,7 @@ func main() {
 		slog.Error("Server shutdown failed", "error", err)
 		os.Exit(1)
 	}
+	srv.Close() // stop router-owned goroutines once no requests remain (#117)
 
 	slog.Info("Server stopped gracefully")
 }

--- a/internal/handler/home_explainer.go
+++ b/internal/handler/home_explainer.go
@@ -43,7 +43,7 @@ func ExplainerNodes() []pages.ExplainerNode {
 				Snippet: `s.router.Use(mw.SecurityHeaders(isProd))
 s.router.Use(mw.RequestID)
 s.router.Use(mw.RealIP(s.cfg.TrustedProxyCIDRs, s.cfg.ClientIPHeader)) // before the limiter
-s.router.Use(mw.RateLimiter(50, 10))
+s.router.Use(mw.RateLimiter(ctx, 50, 10)) // eviction stops with the server (#117)
 s.router.Use(mw.Compress(5))
 s.router.Use(mw.Metrics)
 s.router.Use(mw.RequestLogger)
@@ -55,7 +55,7 @@ r.Group(func(learn chi.Router) {
     learn.Use(mw.GuestSession(s.authClient, isProd)) // anonymous identity on first touch
     learn.Use(mw.OptionalAuth(s.authClient, isProd))
     learn.Use(mw.OptionalUserLoader(userRepo))
-    learn.Use(mw.RateLimiter(30.0/60.0, 20))         // stricter tier, anonymous-writable
+    learn.Use(mw.RateLimiter(ctx, 30.0/60.0, 20))    // stricter tier, anonymous-writable
     handler.QuizRoutes(learn, quizRepo)
 })`,
 			},

--- a/internal/handler/upgrade_handlers.go
+++ b/internal/handler/upgrade_handlers.go
@@ -30,11 +30,12 @@ type anonUpgrader interface {
 
 // UpgradeRoutes registers the guest → registered upgrade flow (ADR-024, #68)
 // on the /learn group. The credential-setting POST gets the strict rate tier
-// like the other credential endpoints (ADR-014 §4).
-func UpgradeRoutes(r chi.Router, upgrader anonUpgrader, secureCookie bool) {
+// like the other credential endpoints (ADR-014 §4). ctx bounds the tier's
+// background eviction (#117); the server passes its lifecycle context.
+func UpgradeRoutes(ctx context.Context, r chi.Router, upgrader anonUpgrader, secureCookie bool) {
 	r.Get("/learn/upgrade", UpgradePage)
 	r.Group(func(strict chi.Router) {
-		strict.Use(mw.RateLimiter(5.0/60.0, 5))
+		strict.Use(mw.RateLimiter(ctx, 5.0/60.0, 5))
 		strict.Post("/learn/upgrade", UpgradeSubmit(upgrader, secureCookie))
 	})
 }

--- a/internal/handler/upgrade_handlers_test.go
+++ b/internal/handler/upgrade_handlers_test.go
@@ -285,7 +285,7 @@ func TestUpgradeSubmit(t *testing.T) {
 // is about which requests the limiter lets through at all.
 func TestUpgradeRoutes_RateLimitTier(t *testing.T) {
 	router := chi.NewRouter()
-	UpgradeRoutes(router, &fakeUpgrader{}, false)
+	UpgradeRoutes(t.Context(), router, &fakeUpgrader{}, false)
 
 	post := func() int {
 		req := formRequest("/learn/upgrade", "email=a@b.co&password=12345678")

--- a/internal/middleware/ratelimit.go
+++ b/internal/middleware/ratelimit.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"context"
 	"net/http"
 	"sync"
 	"time"
@@ -8,61 +9,99 @@ import (
 	"golang.org/x/time/rate"
 )
 
+const (
+	// evictInterval is how often idle buckets are swept.
+	evictInterval = 3 * time.Minute
+	// staleAfter is how long a client may be idle before its bucket is dropped.
+	staleAfter = 10 * time.Minute
+)
+
 type limiterEntry struct {
 	limiter  *rate.Limiter
 	lastSeen time.Time
 }
 
-// RateLimiter returns middleware that limits requests per IP address using a
-// token bucket algorithm. Per ADR-014 Security Patterns, tiered rates should
-// be applied via route groups:
-//
-//	auth routes:   RateLimiter(5, 5)    // 5 req/sec, burst 5
-//	API routes:    RateLimiter(100, 20) // 100 req/sec, burst 20
-//	public routes: RateLimiter(50, 10)  // 50 req/sec, burst 10
-func RateLimiter(rps float64, burst int) func(http.Handler) http.Handler {
-	var (
-		mu       sync.Mutex
-		limiters = make(map[string]*limiterEntry)
-	)
+// limiterStore holds one token bucket per client IP. It is the state behind
+// RateLimiter, split out so the eviction rule and loop are testable on their
+// own (ADR-032 keeps this package in the mutation-testing set).
+type limiterStore struct {
+	mu      sync.Mutex
+	entries map[string]*limiterEntry
+	rps     rate.Limit
+	burst   int
+}
 
-	// Evict stale entries every 3 minutes
-	go func() {
-		ticker := time.NewTicker(3 * time.Minute)
-		defer ticker.Stop()
-		for range ticker.C {
-			mu.Lock()
-			for ip, entry := range limiters {
-				if time.Since(entry.lastSeen) > 10*time.Minute {
-					delete(limiters, ip)
-				}
-			}
-			mu.Unlock()
-		}
-	}()
-
-	getLimiter := func(ip string) *rate.Limiter {
-		mu.Lock()
-		defer mu.Unlock()
-
-		entry, exists := limiters[ip]
-		if !exists {
-			entry = &limiterEntry{
-				limiter:  rate.NewLimiter(rate.Limit(rps), burst),
-				lastSeen: time.Now(),
-			}
-			limiters[ip] = entry
-		} else {
-			entry.lastSeen = time.Now()
-		}
-		return entry.limiter
+func newLimiterStore(rps float64, burst int) *limiterStore {
+	return &limiterStore{
+		entries: make(map[string]*limiterEntry),
+		rps:     rate.Limit(rps),
+		burst:   burst,
 	}
+}
+
+// get returns the bucket for ip, creating it on first sight and refreshing
+// lastSeen on every call so active clients are never evicted.
+func (s *limiterStore) get(ip string) *rate.Limiter {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	entry, exists := s.entries[ip]
+	if !exists {
+		entry = &limiterEntry{
+			limiter:  rate.NewLimiter(s.rps, s.burst),
+			lastSeen: time.Now(),
+		}
+		s.entries[ip] = entry
+	} else {
+		entry.lastSeen = time.Now()
+	}
+	return entry.limiter
+}
+
+// evict drops every bucket idle for longer than staleAfter as of now.
+func (s *limiterStore) evict(now time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for ip, entry := range s.entries {
+		if now.Sub(entry.lastSeen) > staleAfter {
+			delete(s.entries, ip)
+		}
+	}
+}
+
+// run sweeps idle buckets every interval until ctx is done. Tying the loop
+// to a context (#117) lets an embedder — or a test — construct servers
+// repeatedly without leaking a goroutine per limiter.
+func (s *limiterStore) run(ctx context.Context, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now := <-ticker.C:
+			s.evict(now)
+		}
+	}
+}
+
+// RateLimiter returns middleware that limits requests per IP address using a
+// token bucket algorithm. The background eviction of idle buckets stops when
+// ctx is cancelled; server.New owns that context for the app's limiters. Per
+// ADR-014 Security Patterns, tiered rates should be applied via route groups:
+//
+//	auth routes:   RateLimiter(ctx, 5, 5)    // 5 req/sec, burst 5
+//	API routes:    RateLimiter(ctx, 100, 20) // 100 req/sec, burst 20
+//	public routes: RateLimiter(ctx, 50, 10)  // 50 req/sec, burst 10
+func RateLimiter(ctx context.Context, rps float64, burst int) func(http.Handler) http.Handler {
+	store := newLimiterStore(rps, burst)
+	go store.run(ctx, evictInterval)
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ip := r.RemoteAddr // RealIP middleware normalizes this upstream
 
-			if !getLimiter(ip).Allow() {
+			if !store.get(ip).Allow() {
 				http.Error(w, "Too Many Requests", http.StatusTooManyRequests)
 				return
 			}

--- a/internal/middleware/ratelimit_test.go
+++ b/internal/middleware/ratelimit_test.go
@@ -1,9 +1,11 @@
 package middleware
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 func TestRateLimiter(t *testing.T) {
@@ -37,7 +39,7 @@ func TestRateLimiter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			h := RateLimiter(tt.rps, tt.burst)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			h := RateLimiter(t.Context(), tt.rps, tt.burst)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
 			}))
 
@@ -52,5 +54,132 @@ func TestRateLimiter(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestLimiterStore_Evict pins the staleness rule: an entry is dropped only
+// once it has been idle for longer than staleAfter (#117; mutation set per
+// ADR-032, so the boundary is exercised explicitly).
+func TestLimiterStore_Evict(t *testing.T) {
+	now := time.Date(2026, 9, 9, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name     string
+		lastSeen map[string]time.Time
+		wantKept []string
+		wantGone []string
+	}{
+		{
+			name:     "fresh entries are kept",
+			lastSeen: map[string]time.Time{"10.0.0.1": now, "10.0.0.2": now.Add(-staleAfter / 2)},
+			wantKept: []string{"10.0.0.1", "10.0.0.2"},
+		},
+		{
+			name:     "entries idle longer than staleAfter are evicted",
+			lastSeen: map[string]time.Time{"10.0.0.1": now.Add(-staleAfter - time.Second), "10.0.0.2": now},
+			wantKept: []string{"10.0.0.2"},
+			wantGone: []string{"10.0.0.1"},
+		},
+		{
+			name:     "an entry idle exactly staleAfter is kept",
+			lastSeen: map[string]time.Time{"10.0.0.1": now.Add(-staleAfter)},
+			wantKept: []string{"10.0.0.1"},
+		},
+		{
+			name:     "empty store is a no-op",
+			lastSeen: map[string]time.Time{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newLimiterStore(1, 1)
+			for ip, seen := range tt.lastSeen {
+				s.get(ip)
+				s.entries[ip].lastSeen = seen
+			}
+
+			s.evict(now)
+
+			for _, ip := range tt.wantKept {
+				if _, ok := s.entries[ip]; !ok {
+					t.Errorf("evict() dropped %s, want kept", ip)
+				}
+			}
+			for _, ip := range tt.wantGone {
+				if _, ok := s.entries[ip]; ok {
+					t.Errorf("evict() kept %s, want dropped", ip)
+				}
+			}
+		})
+	}
+}
+
+// TestLimiterStore_RunEvictsOnTick proves the loop actually calls evict on
+// each tick, not just that it sleeps.
+func TestLimiterStore_RunEvictsOnTick(t *testing.T) {
+	s := newLimiterStore(1, 1)
+	s.get("10.0.0.1")
+	s.entries["10.0.0.1"].lastSeen = time.Now().Add(-staleAfter - time.Minute)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		s.run(ctx, time.Millisecond)
+		close(done)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		<-done
+	})
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		s.mu.Lock()
+		_, present := s.entries["10.0.0.1"]
+		s.mu.Unlock()
+		if !present {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("run() never evicted the stale entry")
+}
+
+// TestLimiterStore_RunStopsOnContextCancel is the #117 fix: the eviction
+// loop must return once its context is done instead of living until process
+// exit.
+func TestLimiterStore_RunStopsOnContextCancel(t *testing.T) {
+	s := newLimiterStore(1, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		s.run(ctx, time.Hour)
+		close(done)
+	}()
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("run() did not return after context cancellation")
+	}
+}
+
+// TestLimiterStore_GetRefreshesLastSeen guards the eviction input: a hit
+// must move lastSeen forward so active clients are never evicted.
+func TestLimiterStore_GetRefreshesLastSeen(t *testing.T) {
+	s := newLimiterStore(1, 1)
+	first := s.get("10.0.0.1")
+	s.entries["10.0.0.1"].lastSeen = time.Now().Add(-staleAfter - time.Minute)
+
+	second := s.get("10.0.0.1")
+
+	if first != second {
+		t.Fatal("get() returned a new limiter for a known IP, want the same bucket")
+	}
+	if age := time.Since(s.entries["10.0.0.1"].lastSeen); age > time.Second {
+		t.Errorf("get() left lastSeen %v old, want refreshed", age)
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -28,7 +29,9 @@ type Server struct {
 	cfg        *config.Config
 	db         *pgxpool.Pool
 	authClient *auth.AuthClient
-	// Add other dependencies like database connections here as needed
+	// stop cancels the lifecycle context handed to background goroutines the
+	// router owns (rate-limiter eviction, #117); Close calls it.
+	stop context.CancelFunc
 }
 
 // New creates a new Server instance.
@@ -52,11 +55,13 @@ func New(cfg *config.Config, db *pgxpool.Pool) (*Server, error) {
 
 	r := chi.NewRouter()
 
+	ctx, stop := context.WithCancel(context.Background())
 	s := &Server{
 		router:     r,
 		cfg:        cfg,
 		db:         db,
 		authClient: authClient,
+		stop:       stop,
 	}
 
 	// Initialize health check with DB pool for connectivity checks. The pool
@@ -68,10 +73,17 @@ func New(cfg *config.Config, db *pgxpool.Pool) (*Server, error) {
 	}
 	handler.InitHealth(pinger)
 
-	s.setupMiddleware()
-	s.setupRoutes()
+	s.setupMiddleware(ctx)
+	s.setupRoutes(ctx)
 
 	return s, nil
+}
+
+// Close stops the background goroutines the server started (#117). It does
+// not affect in-flight requests — the HTTP server's Shutdown handles those —
+// and is safe to call more than once.
+func (s *Server) Close() {
+	s.stop()
 }
 
 // fileServer conveniently sets up a http.FileServer handler to serve static files
@@ -154,7 +166,7 @@ func isFileType(filePath string, extensions ...string) bool {
 	return false
 }
 
-func (s *Server) setupMiddleware() {
+func (s *Server) setupMiddleware(ctx context.Context) {
 	isProd := s.cfg.IsProduction()
 
 	// Basic middleware (order matters!)
@@ -162,7 +174,7 @@ func (s *Server) setupMiddleware() {
 	s.router.Use(mw.RequestID)                                             // Generate request ID
 	s.router.Use(mw.RealIP(s.cfg.TrustedProxyCIDRs, s.cfg.ClientIPHeader)) // Resolve client IP via trusted proxies (ADR-027; before rate limiter)
 	s.router.Use(mw.MaxBodyBytes(s.cfg.MaxRequestBodyBytes))               // Cap request body size (2026-07-06 audit)
-	s.router.Use(mw.RateLimiter(50, 10))                                   // Global rate limit (ADR-014)
+	s.router.Use(mw.RateLimiter(ctx, 50, 10))                              // Global rate limit (ADR-014)
 	s.router.Use(mw.Compress(5))                                           // gzip/deflate responses
 	s.router.Use(mw.Metrics)                                               // Track metrics (uses RequestID)
 	s.router.Use(mw.RequestLogger)                                         // Log requests with context
@@ -179,7 +191,7 @@ func (s *Server) setupMiddleware() {
 	fileServer(s.router, "/static", http.Dir("./web/static"))
 }
 
-func (s *Server) setupRoutes() {
+func (s *Server) setupRoutes(ctx context.Context) {
 	r := s.router // Use the router from the Server struct
 
 	// Static & Informational Pages
@@ -209,7 +221,7 @@ func (s *Server) setupRoutes() {
 			protectedRouter.Post("/profile", handler.ProfileUpdate)
 			// Change password (#97): the session token is the credential, so
 			// it sits on the strict credential tier like /auth/reset.
-			protectedRouter.With(mw.RateLimiter(5.0/60.0, 5)).
+			protectedRouter.With(mw.RateLimiter(ctx, 5.0/60.0, 5)).
 				Post("/profile/password", handler.ProfilePasswordUpdate(s.authClient))
 			handler.FirstRunHandlers(protectedRouter)
 		})
@@ -234,7 +246,7 @@ func (s *Server) setupRoutes() {
 			learn.Use(mw.OptionalUserLoader(postgres.NewUserRepo(s.db, database.New(s.db))))
 			// Anonymous-writable surface: stricter tier on top of the global
 			// limiter (ADR-024 accompanying constraints).
-			learn.Use(mw.RateLimiter(30.0/60.0, 20))
+			learn.Use(mw.RateLimiter(ctx, 30.0/60.0, 20))
 			quizRepo := postgres.NewQuizRepo(s.db, database.New(s.db))
 			cardRepo := postgres.NewFlashcardRepo(s.db, database.New(s.db))
 			handler.QuizRoutes(learn, quizRepo)
@@ -244,7 +256,7 @@ func (s *Server) setupRoutes() {
 			handler.DashboardRoutes(learn, quizRepo, cardRepo)
 			// Guest → registered upgrade (#68): same identity chain as the
 			// other /learn surfaces; the POST adds the strict credential tier.
-			handler.UpgradeRoutes(learn, s.authClient, s.cfg.IsProduction())
+			handler.UpgradeRoutes(ctx, learn, s.authClient, s.cfg.IsProduction())
 		})
 	} else {
 		// No identity chain to mount under: keep the dashboard shell routed
@@ -263,7 +275,7 @@ func (s *Server) setupRoutes() {
 			// Credential endpoints get the strict tier: 5 attempts/min
 			// per IP (ADR-014 §4), on top of the global limiter.
 			authRouter.Group(func(strict chi.Router) {
-				strict.Use(mw.RateLimiter(5.0/60.0, 5))
+				strict.Use(mw.RateLimiter(ctx, 5.0/60.0, 5))
 				strict.Post("/login", handler.AuthLoginPost(s.authClient, s.cfg.IsProduction())) // Handle login
 				strict.Post("/signup", handler.AuthSignupPost(s.authClient))                     // Handle signup
 				strict.Post("/recover", handler.AuthRecoverPost(s.authClient))                   // Send reset email

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -32,6 +32,7 @@ func newServer(t *testing.T, cfg *config.Config, db *pgxpool.Pool) *Server {
 	if err != nil {
 		t.Fatalf("New() error: %v", err)
 	}
+	t.Cleanup(srv.Close)
 	return srv
 }
 
@@ -344,5 +345,23 @@ func TestServer_HomeExplainer(t *testing.T) {
 		if !strings.Contains(body, want) {
 			t.Errorf("budget grid missing %q (rendered from internal/performance)", want)
 		}
+	}
+}
+
+// TestServer_CloseIsIdempotentAndKeepsServing pins the #117 lifecycle
+// contract: Close releases router-owned goroutines, may be called more than
+// once, and never breaks request handling — the rate limiter keeps limiting
+// without its eviction sweep.
+func TestServer_CloseIsIdempotentAndKeepsServing(t *testing.T) {
+	srv := newTestServer(t, "development")
+
+	srv.Close()
+	srv.Close()
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /healthz after Close() status = %d, want %d", rec.Code, http.StatusOK)
 	}
 }


### PR DESCRIPTION
## Summary

Closes #117.

- `mw.RateLimiter` now takes a `context.Context`; the idle-bucket eviction loop returns when it is cancelled instead of living until process exit.
- `server.New` owns that context and `Server.Close()` cancels it. `cmd/api` calls `Close` after `httpServer.Shutdown` drains in-flight requests; server tests release it via `t.Cleanup`.
- `handler.UpgradeRoutes` takes the context first (engineering.md: ctx is the first argument) since it builds the strict credential tier itself.
- The per-IP state is extracted into `limiterStore` so the staleness boundary, the tick → evict path, and the stop-on-cancel path each have a table-driven or targeted test (ADR-023; `internal/middleware` is in the ADR-032 mutation set).
- The landing explainer's source peek for the middleware stack mirrors the new call.

No behaviour change for requests: limits, tiers, and the 429 path are unchanged. After `Close`, a limiter keeps limiting; only the sweep stops.

## Verification

- `task ci` green locally (fmt, lint, race tests, agents/versions/adr/generated checks, binary + asset budgets, govulncheck).
- `docs/product/security-overview.md` still shows the old two-argument call in a prose snippet; left as-is because `docs/` is read-only under ADR-019 without an explicit ask.

🤖 Generated with [Claude Code](https://claude.com/claude-code)