### PR TITLE
feat(quiz): per-topic entry so explainer hand-offs land on their topic

### DIFF
--- a/internal/handler/quiz_handlers.go
+++ b/internal/handler/quiz_handlers.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/a-h/templ"
 	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
 
 	"github.com/clownware/go-performance-starter/internal/database"
 	"github.com/clownware/go-performance-starter/internal/repository"
@@ -32,6 +33,12 @@ import (
 // the question card; the answer form POSTs and works without JS (full result
 // page), while HTMX swaps just the card. A wrong answer offers "save as
 // flashcard" — the offer markup ships here, its endpoint ships in Slice B.
+//
+// Per-topic entry (#118): the landing explainer hands off with ?topic=<slug>.
+// A known topic narrows the run to that topic's questions (landing on one the
+// user has not attempted yet) and every link carries the scope forward; an
+// unknown topic is ignored so a stray query never changes behaviour. The
+// running score stays whole-quiz — it counts rows, not runs.
 
 // QuizRoutes registers the quiz flow backed by the RLS-scoped quiz repository.
 func QuizRoutes(r chi.Router, repo repository.QuizRepository) {
@@ -71,15 +78,26 @@ func quizPage(repo repository.QuizRepository) http.HandlerFunc {
 			return
 		}
 
+		topic := resolveQuizTopic(questions, r.URL.Query().Get("topic"))
+		run := quizRun(questions, topic)
+
 		idx := 0
 		if slug := r.URL.Query().Get("q"); slug != "" {
 			var ok bool
-			if idx, ok = questionIndexBySlug(questions, slug); !ok {
+			if idx, ok = questionIndexBySlug(run, slug); !ok {
 				http.NotFound(w, r)
 				return
 			}
+		} else if topic != "" {
+			attempts, err := repo.ListAttemptsByUser(r.Context(), user.ID, quizTopicAttemptWindow, 0)
+			if err != nil {
+				slog.Error("Failed to list quiz attempts for topic entry", "topic", topic, "error", err)
+				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+				return
+			}
+			idx = firstUnattempted(run, attempts)
 		}
-		question := questions[idx]
+		question := run[idx]
 
 		choices, err := decodeQuizChoices(question.Choices)
 		if err != nil {
@@ -94,7 +112,7 @@ func quizPage(repo repository.QuizRepository) http.HandlerFunc {
 			return
 		}
 
-		qProps := quizQuestionProps(question, choices)
+		qProps := quizQuestionProps(question, choices, topic)
 		if view.IsHTMXRequest(r) {
 			renderQuiz(w, r, http.StatusOK, partials.QuizQuestionCard(qProps))
 			return
@@ -124,13 +142,16 @@ func quizAnswer(repo repository.QuizRepository) http.HandlerFunc {
 			return
 		}
 
+		topic := resolveQuizTopic(questions, r.URL.Query().Get("topic"))
+		run := quizRun(questions, topic)
+
 		slug := chi.URLParam(r, "slug")
-		idx, ok := questionIndexBySlug(questions, slug)
+		idx, ok := questionIndexBySlug(run, slug)
 		if !ok {
 			http.NotFound(w, r)
 			return
 		}
-		question := questions[idx]
+		question := run[idx]
 
 		choices, err := decodeQuizChoices(question.Choices)
 		if err != nil {
@@ -141,7 +162,7 @@ func quizAnswer(repo repository.QuizRepository) http.HandlerFunc {
 
 		selected, err := strconv.Atoi(r.PostFormValue("choice"))
 		if err != nil || selected < 0 || selected >= len(choices) {
-			qProps := quizQuestionProps(question, choices)
+			qProps := quizQuestionProps(question, choices, topic)
 			qProps.Error = "Pick one of the answers before checking."
 			if view.IsHTMXRequest(r) {
 				renderQuiz(w, r, http.StatusUnprocessableEntity, partials.QuizQuestionCard(qProps))
@@ -177,14 +198,15 @@ func quizAnswer(repo repository.QuizRepository) http.HandlerFunc {
 		resProps := partials.QuizResultProps{
 			Correct:        isCorrect,
 			Explanation:    question.Explanation,
-			Done:           idx == len(questions)-1,
+			Done:           idx == len(run)-1,
+			RunTopic:       topic,
 			OfferFlashcard: !isCorrect,
 			FlashcardFront: question.Prompt,
 			FlashcardBack:  question.Explanation,
 			Score:          score,
 		}
 		if !resProps.Done {
-			resProps.NextSlug = questions[idx+1].Slug
+			resProps.NextSlug = run[idx+1].Slug
 		}
 
 		if view.IsHTMXRequest(r) {
@@ -198,6 +220,51 @@ func quizAnswer(repo repository.QuizRepository) http.HandlerFunc {
 		}
 		renderQuiz(w, r, http.StatusOK, pages.QuizPage(props))
 	}
+}
+
+// quizTopicAttemptWindow bounds the attempt history read on topic entry:
+// far more than the seeded question count, without an unbounded scan.
+const quizTopicAttemptWindow = 200
+
+// resolveQuizTopic validates a requested topic against the question set.
+// Unknown or empty topics resolve to "" — the full sequence — so a stray
+// ?topic= neither changes behaviour nor gets echoed into links.
+func resolveQuizTopic(questions []database.QuizQuestion, topic string) string {
+	for i := range questions {
+		if questions[i].Topic == topic {
+			return topic
+		}
+	}
+	return ""
+}
+
+// quizRun narrows the display order to one topic; "" keeps the whole sequence.
+func quizRun(questions []database.QuizQuestion, topic string) []database.QuizQuestion {
+	if topic == "" {
+		return questions
+	}
+	run := make([]database.QuizQuestion, 0, len(questions))
+	for _, q := range questions {
+		if q.Topic == topic {
+			run = append(run, q)
+		}
+	}
+	return run
+}
+
+// firstUnattempted picks the topic-entry question: the first in the run the
+// user has never attempted, or the first in the run once all are attempted.
+func firstUnattempted(run []database.QuizQuestion, attempts []database.QuizAttempt) int {
+	attempted := make(map[uuid.UUID]struct{}, len(attempts))
+	for _, a := range attempts {
+		attempted[a.QuestionID] = struct{}{}
+	}
+	for i := range run {
+		if _, ok := attempted[run[i].ID]; !ok {
+			return i
+		}
+	}
+	return 0
 }
 
 // questionIndexBySlug finds a question's position in display order.
@@ -227,13 +294,15 @@ func quizScore(r *http.Request, repo repository.QuizRepository, user *database.U
 	return view.QuizScore{Correct: int(correct), Total: total}, nil
 }
 
-// quizQuestionProps maps a database question to its card props.
-func quizQuestionProps(q database.QuizQuestion, choices []string) partials.QuizQuestionProps {
+// quizQuestionProps maps a database question to its card props; runTopic is
+// the topic scope the card's links must carry forward ("" for the full run).
+func quizQuestionProps(q database.QuizQuestion, choices []string, runTopic string) partials.QuizQuestionProps {
 	return partials.QuizQuestionProps{
-		Slug:    q.Slug,
-		Topic:   q.Topic,
-		Prompt:  q.Prompt,
-		Choices: choices,
+		Slug:     q.Slug,
+		Topic:    q.Topic,
+		Prompt:   q.Prompt,
+		Choices:  choices,
+		RunTopic: runTopic,
 	}
 }
 

--- a/internal/handler/quiz_handlers_test.go
+++ b/internal/handler/quiz_handlers_test.go
@@ -141,6 +141,20 @@ func quizFixtures() []database.QuizQuestion {
 	}
 }
 
+// quizTopicFixtures extends quizFixtures with a second "database" question so
+// the per-topic run (#118) has an order to walk and an unanswered one to prefer.
+func quizTopicFixtures() []database.QuizQuestion {
+	return append(quizFixtures(), database.QuizQuestion{
+		ID:           uuid.New(),
+		Slug:         "rls-policies",
+		Topic:        "database",
+		Prompt:       "Where do the RLS policies live?",
+		Choices:      []byte(`["In migrations","In handlers","In templ"]`),
+		CorrectIndex: 0,
+		Explanation:  "Policies are versioned SQL in migrations/.",
+	})
+}
+
 func newQuizRouter(repo repository.QuizRepository) http.Handler {
 	r := chi.NewRouter()
 	QuizRoutes(r, repo)
@@ -165,6 +179,14 @@ func asQuizUser(r *http.Request, user *database.User) *http.Request {
 func TestQuizPage(t *testing.T) {
 	questions := quizFixtures()
 	user := &database.User{ID: uuid.New(), IsAnonymous: true}
+	topicQuestions := quizTopicFixtures()
+	// answeredFirst has attempted the first database question only.
+	answeredFirst := []database.QuizAttempt{{QuestionID: topicQuestions[1].ID, UserID: user.ID}}
+	// answeredAll has attempted both database questions.
+	answeredAll := []database.QuizAttempt{
+		{QuestionID: topicQuestions[3].ID, UserID: user.ID},
+		{QuestionID: topicQuestions[1].ID, UserID: user.ID},
+	}
 
 	tests := []struct {
 		name         string
@@ -269,6 +291,85 @@ func TestQuizPage(t *testing.T) {
 				`data-testid="quiz-question"`,
 			},
 		},
+		// Per-topic entry (#118): the explainer hands off with ?topic=<slug> and
+		// the quiz lands on that topic instead of the generic first question.
+		{
+			name:       "topic entry lands on the first question of that topic",
+			target:     "/learn/quiz?topic=database",
+			repo:       &fakeQuizRepo{questions: topicQuestions},
+			user:       user,
+			wantStatus: http.StatusOK,
+			wantContains: []string{
+				"What scopes every query to the requesting user?",
+				`action="/learn/quiz/rls-scoping/answer?topic=database"`,
+			},
+			wantAbsent: []string{
+				"Which router assembles the middleware stack?",
+			},
+		},
+		{
+			name:       "topic entry prefers a question the user has not attempted",
+			target:     "/learn/quiz?topic=database",
+			repo:       &fakeQuizRepo{questions: topicQuestions, history: answeredFirst},
+			user:       user,
+			wantStatus: http.StatusOK,
+			wantContains: []string{
+				"Where do the RLS policies live?",
+				`action="/learn/quiz/rls-policies/answer?topic=database"`,
+			},
+			wantAbsent: []string{
+				"What scopes every query to the requesting user?",
+			},
+		},
+		{
+			name:       "topic entry with every question attempted restarts the topic",
+			target:     "/learn/quiz?topic=database",
+			repo:       &fakeQuizRepo{questions: topicQuestions, history: answeredAll},
+			user:       user,
+			wantStatus: http.StatusOK,
+			wantContains: []string{
+				"What scopes every query to the requesting user?",
+			},
+		},
+		{
+			name:       "explicit slug inside the topic keeps the topic scope",
+			target:     "/learn/quiz?topic=database&q=rls-policies",
+			repo:       &fakeQuizRepo{questions: topicQuestions},
+			user:       user,
+			wantStatus: http.StatusOK,
+			wantContains: []string{
+				"Where do the RLS policies live?",
+				`action="/learn/quiz/rls-policies/answer?topic=database"`,
+			},
+		},
+		{
+			name:       "slug outside the topic is a 404",
+			target:     "/learn/quiz?topic=database&q=middleware-stack",
+			repo:       &fakeQuizRepo{questions: topicQuestions},
+			user:       user,
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name:       "unknown topic falls back to the full sequence",
+			target:     "/learn/quiz?topic=no-such-topic",
+			repo:       &fakeQuizRepo{questions: topicQuestions},
+			user:       user,
+			wantStatus: http.StatusOK,
+			wantContains: []string{
+				"Which router assembles the middleware stack?",
+				`action="/learn/quiz/middleware-stack/answer"`,
+			},
+			wantAbsent: []string{
+				"topic=",
+			},
+		},
+		{
+			name:       "attempt history failure on topic entry is a 500",
+			target:     "/learn/quiz?topic=database",
+			repo:       &fakeQuizRepo{questions: topicQuestions, listAttemptsErr: errFake},
+			user:       user,
+			wantStatus: http.StatusInternalServerError,
+		},
 	}
 
 	for _, tt := range tests {
@@ -312,6 +413,7 @@ func TestQuizAnswer(t *testing.T) {
 	tests := []struct {
 		name         string
 		slug         string
+		query        string // raw query string appended to the answer URL (topic scope)
 		form         url.Values
 		repo         *fakeQuizRepo
 		user         *database.User
@@ -451,11 +553,99 @@ func TestQuizAnswer(t *testing.T) {
 			wantStatus:   http.StatusSeeOther,
 			wantLocation: "/auth/page",
 		},
+		// Topic-scoped runs (#118): next/done are computed within the topic
+		// and every link carries the scope forward.
+		{
+			name:       "topic-scoped answer links to the next question in the topic",
+			slug:       "rls-scoping",
+			query:      "?topic=database",
+			form:       url.Values{"choice": {"0"}},
+			repo:       &fakeQuizRepo{questions: quizTopicFixtures()},
+			user:       user,
+			htmx:       true,
+			wantStatus: http.StatusOK,
+			wantContains: []string{
+				`data-testid="quiz-result"`,
+				"/learn/quiz?q=rls-policies&amp;topic=database",
+				"0 of 4", // the score stays whole-quiz, not per topic
+			},
+			wantAbsent: []string{
+				`data-testid="quiz-done"`,
+			},
+			wantAttempt: &database.CreateQuizAttemptParams{
+				UserID:        user.ID,
+				SelectedIndex: 0,
+				IsCorrect:     true,
+			},
+		},
+		{
+			name:       "last question of a topic marks the topic run done",
+			slug:       "rls-scoping",
+			query:      "?topic=database",
+			form:       url.Values{"choice": {"0"}},
+			repo:       &fakeQuizRepo{questions: questions},
+			user:       user,
+			htmx:       true,
+			wantStatus: http.StatusOK,
+			wantContains: []string{
+				`data-testid="quiz-done"`,
+				"last database question",
+				`href="/learn/quiz"`, // continue with the whole sequence
+			},
+			wantAttempt: &database.CreateQuizAttemptParams{
+				UserID:        user.ID,
+				SelectedIndex: 0,
+				IsCorrect:     true,
+			},
+		},
+		{
+			name:       "unknown topic on answer falls back to the full sequence",
+			slug:       "middleware-stack",
+			query:      "?topic=no-such-topic",
+			form:       url.Values{"choice": {"0"}},
+			repo:       &fakeQuizRepo{questions: questions},
+			user:       user,
+			htmx:       true,
+			wantStatus: http.StatusOK,
+			wantContains: []string{
+				"/learn/quiz?q=rls-scoping",
+			},
+			wantAbsent: []string{
+				"topic=",
+			},
+			wantAttempt: &database.CreateQuizAttemptParams{
+				UserID:        user.ID,
+				SelectedIndex: 0,
+				IsCorrect:     true,
+			},
+		},
+		{
+			name:       "slug outside the topic is a 404 and records nothing",
+			slug:       "middleware-stack",
+			query:      "?topic=database",
+			form:       url.Values{"choice": {"0"}},
+			repo:       &fakeQuizRepo{questions: questions},
+			user:       user,
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name:       "invalid choice re-render keeps the topic scope",
+			slug:       "rls-scoping",
+			query:      "?topic=database",
+			form:       url.Values{},
+			repo:       &fakeQuizRepo{questions: questions},
+			user:       user,
+			htmx:       true,
+			wantStatus: http.StatusUnprocessableEntity,
+			wantContains: []string{
+				`action="/learn/quiz/rls-scoping/answer?topic=database"`,
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			target := "/learn/quiz/" + tt.slug + "/answer"
+			target := "/learn/quiz/" + tt.slug + "/answer" + tt.query
 			req := httptest.NewRequest(http.MethodPost, target, strings.NewReader(tt.form.Encode()))
 			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 			req = asQuizUser(req, tt.user)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -329,8 +329,10 @@ func TestServer_HomeExplainer(t *testing.T) {
 	if got := strings.Count(body, "<details"); got != 5 {
 		t.Errorf("explainer renders %d source peeks, want 5 (one <details> per node, no JS required)", got)
 	}
-	if !strings.Contains(body, `href="/learn/quiz"`) {
-		t.Error("explainer must hand off to the quiz (read → quiz → flashcards)")
+	for _, topic := range []string{"routing", "handlers", "database", "frontend", "performance"} {
+		if !strings.Contains(body, `href="/learn/quiz?topic=`+topic+`"`) {
+			t.Errorf("explainer must hand off to the quiz on its own topic %q (read → quiz → flashcards, #118)", topic)
+		}
 	}
 
 	if !strings.Contains(body, `data-testid="perf-stats"`) {

--- a/internal/view/pages/home.templ
+++ b/internal/view/pages/home.templ
@@ -2,6 +2,7 @@ package pages
 
 import (
 	"fmt"
+	"net/url"
 	"github.com/clownware/go-performance-starter/internal/view"
 	"github.com/clownware/go-performance-starter/internal/view/components"
 	"github.com/clownware/go-performance-starter/internal/view/layouts"
@@ -81,6 +82,11 @@ func homeSurfaces() []surface {
 			Description: "Your progress, live from your own rows: quiz score history and cards to review, loaded with the skeleton pattern.",
 		},
 	}
+}
+
+// quizTopicURL is the explainer's hand-off into the quiz on its own topic (#118).
+func quizTopicURL(topic string) string {
+	return "/learn/quiz?" + url.Values{"topic": {topic}}.Encode()
 }
 
 templ HomePage(props HomePageProps) {
@@ -169,7 +175,7 @@ templ explainer(nodes []ExplainerNode) {
 							</details>
 							<p class="mt-4 flex flex-wrap gap-x-4 gap-y-1 text-sm">
 								<a href={ templ.SafeURL(n.ADR.Href) } target="_blank" rel="noopener noreferrer" class="text-link hover:underline">{ n.ADR.Label } ↗</a>
-								<a href="/learn/quiz" class="text-link hover:underline">{ "Quiz yourself on " + n.QuizTopic + " →" }</a>
+								<a href={ templ.SafeURL(quizTopicURL(n.QuizTopic)) } class="text-link hover:underline">{ "Quiz yourself on " + n.QuizTopic + " →" }</a>
 							</p>
 						</div>
 					</div>

--- a/internal/view/pages/home_templ.go
+++ b/internal/view/pages/home_templ.go
@@ -13,6 +13,7 @@ import (
 	"github.com/clownware/go-performance-starter/internal/view"
 	"github.com/clownware/go-performance-starter/internal/view/components"
 	"github.com/clownware/go-performance-starter/internal/view/layouts"
+	"net/url"
 )
 
 // HomePageProps holds data for the home landing page. Nodes and Stats are
@@ -91,6 +92,11 @@ func homeSurfaces() []surface {
 	}
 }
 
+// quizTopicURL is the explainer's hand-off into the quiz on its own topic (#118).
+func quizTopicURL(topic string) string {
+	return "/learn/quiz?" + url.Values{"topic": {topic}}.Encode()
+}
+
 func HomePage(props HomePageProps) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
@@ -144,7 +150,7 @@ func HomePage(props HomePageProps) templ.Component {
 				var templ_7745c5c3_Var3 templ.SafeURL
 				templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(s.Href))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 108, Col: 33}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 114, Col: 33}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 				if templ_7745c5c3_Err != nil {
@@ -157,7 +163,7 @@ func HomePage(props HomePageProps) templ.Component {
 				var templ_7745c5c3_Var4 string
 				templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(s.Title)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 111, Col: 63}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 117, Col: 63}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 				if templ_7745c5c3_Err != nil {
@@ -170,7 +176,7 @@ func HomePage(props HomePageProps) templ.Component {
 				var templ_7745c5c3_Var5 string
 				templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(s.Description)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 112, Col: 61}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 118, Col: 61}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 				if templ_7745c5c3_Err != nil {
@@ -247,7 +253,7 @@ func explainer(nodes []ExplainerNode) templ.Component {
 			var templ_7745c5c3_Var7 templ.SafeURL
 			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL("#" + n.Anchor))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 143, Col: 45}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 149, Col: 45}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 			if templ_7745c5c3_Err != nil {
@@ -260,7 +266,7 @@ func explainer(nodes []ExplainerNode) templ.Component {
 			var templ_7745c5c3_Var8 string
 			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d · %s", n.Step, n.QuizTopic))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 144, Col: 53}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 150, Col: 53}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 			if templ_7745c5c3_Err != nil {
@@ -283,7 +289,7 @@ func explainer(nodes []ExplainerNode) templ.Component {
 			var templ_7745c5c3_Var9 string
 			templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.ResolveAttributeValue(n.Anchor)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 152, Col: 21}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 158, Col: 21}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var9)
 			if templ_7745c5c3_Err != nil {
@@ -296,7 +302,7 @@ func explainer(nodes []ExplainerNode) templ.Component {
 			var templ_7745c5c3_Var10 string
 			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", n.Step))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 154, Col: 167}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 160, Col: 167}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 			if templ_7745c5c3_Err != nil {
@@ -309,7 +315,7 @@ func explainer(nodes []ExplainerNode) templ.Component {
 			var templ_7745c5c3_Var11 string
 			templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("Step %d: ", n.Step))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 157, Col: 64}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 163, Col: 64}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 			if templ_7745c5c3_Err != nil {
@@ -322,7 +328,7 @@ func explainer(nodes []ExplainerNode) templ.Component {
 			var templ_7745c5c3_Var12 string
 			templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(n.Title)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 158, Col: 17}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 164, Col: 17}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 			if templ_7745c5c3_Err != nil {
@@ -335,7 +341,7 @@ func explainer(nodes []ExplainerNode) templ.Component {
 			var templ_7745c5c3_Var13 string
 			templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(n.Summary)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 160, Col: 64}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 166, Col: 64}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 			if templ_7745c5c3_Err != nil {
@@ -353,7 +359,7 @@ func explainer(nodes []ExplainerNode) templ.Component {
 				var templ_7745c5c3_Var14 string
 				templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(p)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 162, Col: 43}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 168, Col: 43}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 				if templ_7745c5c3_Err != nil {
@@ -371,7 +377,7 @@ func explainer(nodes []ExplainerNode) templ.Component {
 			var templ_7745c5c3_Var15 string
 			templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(n.Source.File)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 166, Col: 78}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 172, Col: 78}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
 			if templ_7745c5c3_Err != nil {
@@ -384,7 +390,7 @@ func explainer(nodes []ExplainerNode) templ.Component {
 			var templ_7745c5c3_Var16 string
 			templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(n.Source.Snippet)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 168, Col: 96}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 174, Col: 96}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
 			if templ_7745c5c3_Err != nil {
@@ -397,7 +403,7 @@ func explainer(nodes []ExplainerNode) templ.Component {
 			var templ_7745c5c3_Var17 templ.SafeURL
 			templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(n.ADR.Href))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 171, Col: 43}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 177, Col: 43}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 			if templ_7745c5c3_Err != nil {
@@ -410,31 +416,44 @@ func explainer(nodes []ExplainerNode) templ.Component {
 			var templ_7745c5c3_Var18 string
 			templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(n.ADR.Label)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 171, Col: 135}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 177, Col: 135}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, " ↗</a> <a href=\"/learn/quiz\" class=\"text-link hover:underline\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, " ↗</a> <a href=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var19 string
-			templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs("Quiz yourself on " + n.QuizTopic + " →")
+			var templ_7745c5c3_Var19 templ.SafeURL
+			templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(quizTopicURL(n.QuizTopic)))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 172, Col: 108}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 178, Col: 58}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "</a></p></div></div></li>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "\" class=\"text-link hover:underline\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var20 string
+			templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs("Quiz yourself on " + n.QuizTopic + " →")
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 178, Col: 139}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "</a></p></div></div></li>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "</ol><div class=\"mt-10 text-center\"><p class=\"text-muted-foreground mb-4\">Read it? Now prove it — wrong answers become flashcards you can keep.</p><a href=\"/learn/quiz\" class=\"btn btn-primary inline-block\">Take the architecture quiz</a></div></section>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "</ol><div class=\"mt-10 text-center\"><p class=\"text-muted-foreground mb-4\">Read it? Now prove it — wrong answers become flashcards you can keep.</p><a href=\"/learn/quiz\" class=\"btn btn-primary inline-block\">Take the architecture quiz</a></div></section>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -461,61 +480,61 @@ func perfStats(stats []BudgetStat) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var20 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var20 == nil {
-			templ_7745c5c3_Var20 = templ.NopComponent
+		templ_7745c5c3_Var21 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var21 == nil {
+			templ_7745c5c3_Var21 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "<section id=\"budgets\" data-testid=\"perf-stats\" aria-labelledby=\"budgets-heading\" class=\"max-w-3xl mx-auto pb-12 scroll-mt-20\"><header class=\"mb-6 text-center\"><p class=\"text-sm uppercase tracking-wide text-muted-foreground mb-2\">Live performance budgets</p><h2 id=\"budgets-heading\" class=\"text-2xl font-bold mb-3\">What CI refuses to ship past</h2><p class=\"text-muted-foreground max-w-xl mx-auto\">Rendered on this request from the constants in <code class=\"text-xs px-1 rounded bg-primary/10 text-link\">internal/performance/budgets.go</code> — the same values <code class=\"text-xs px-1 rounded bg-primary/10 text-link\">task ci</code> enforces. Change the constant, and this grid changes; no template edit involved.</p></header><dl class=\"grid gap-3 grid-cols-2 sm:grid-cols-3 lg:grid-cols-5\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "<section id=\"budgets\" data-testid=\"perf-stats\" aria-labelledby=\"budgets-heading\" class=\"max-w-3xl mx-auto pb-12 scroll-mt-20\"><header class=\"mb-6 text-center\"><p class=\"text-sm uppercase tracking-wide text-muted-foreground mb-2\">Live performance budgets</p><h2 id=\"budgets-heading\" class=\"text-2xl font-bold mb-3\">What CI refuses to ship past</h2><p class=\"text-muted-foreground max-w-xl mx-auto\">Rendered on this request from the constants in <code class=\"text-xs px-1 rounded bg-primary/10 text-link\">internal/performance/budgets.go</code> — the same values <code class=\"text-xs px-1 rounded bg-primary/10 text-link\">task ci</code> enforces. Change the constant, and this grid changes; no template edit involved.</p></header><dl class=\"grid gap-3 grid-cols-2 sm:grid-cols-3 lg:grid-cols-5\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		for _, s := range stats {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "<div data-testid=\"perf-stat\" class=\"bg-surface rounded-lg shadow-sm p-4 text-center\"><dt class=\"text-xs uppercase tracking-wide text-muted-foreground\">")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var21 string
-			templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(s.Label)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 203, Col: 80}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "</dt><dd class=\"mt-1\"><span class=\"block text-xl font-semibold text-foreground\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "<div data-testid=\"perf-stat\" class=\"bg-surface rounded-lg shadow-sm p-4 text-center\"><dt class=\"text-xs uppercase tracking-wide text-muted-foreground\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var22 string
-			templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs("< " + s.Value)
+			templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs(s.Label)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 205, Col: 80}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 209, Col: 80}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "</span> <span class=\"block text-xs text-muted-foreground mt-1\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "</dt><dd class=\"mt-1\"><span class=\"block text-xl font-semibold text-foreground\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var23 string
-			templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(s.Note)
+			templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs("< " + s.Value)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 206, Col: 69}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 211, Col: 80}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "</span></dd></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "</span> <span class=\"block text-xs text-muted-foreground mt-1\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var24 string
+			templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(s.Note)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 212, Col: 69}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "</span></dd></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "</dl></section>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "</dl></section>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/view/partials/quiz_question.templ
+++ b/internal/view/partials/quiz_question.templ
@@ -2,6 +2,7 @@ package partials
 
 import (
 	"fmt"
+	"net/url"
 	"github.com/clownware/go-performance-starter/internal/view/components"
 )
 
@@ -13,10 +14,17 @@ type QuizQuestionProps struct {
 	Choices []string
 	// Error is the validation message shown when a submit had no usable choice.
 	Error string
+	// RunTopic scopes the run to one topic (#118); empty for the full sequence.
+	// Links carry it forward so next/done are computed within the topic.
+	RunTopic string
 }
 
-func quizAnswerAction(slug string) string {
-	return fmt.Sprintf("/learn/quiz/%s/answer", slug)
+func quizAnswerAction(slug, runTopic string) string {
+	action := "/learn/quiz/" + slug + "/answer"
+	if runTopic != "" {
+		action += "?" + url.Values{"topic": {runTopic}}.Encode()
+	}
+	return action
 }
 
 // QuizQuestionCard renders the answer form for one question. It is a
@@ -34,8 +42,8 @@ templ QuizQuestionCard(props QuizQuestionProps) {
 		}
 		<form
 			method="post"
-			action={ templ.SafeURL(quizAnswerAction(props.Slug)) }
-			hx-post={ quizAnswerAction(props.Slug) }
+			action={ templ.SafeURL(quizAnswerAction(props.Slug, props.RunTopic)) }
+			hx-post={ quizAnswerAction(props.Slug, props.RunTopic) }
 			hx-target="#quiz-card"
 			hx-swap="innerHTML"
 		>

--- a/internal/view/partials/quiz_question_templ.go
+++ b/internal/view/partials/quiz_question_templ.go
@@ -11,6 +11,7 @@ import templruntime "github.com/a-h/templ/runtime"
 import (
 	"fmt"
 	"github.com/clownware/go-performance-starter/internal/view/components"
+	"net/url"
 )
 
 // QuizQuestionProps holds data for the quiz question card (ADR-024).
@@ -21,10 +22,17 @@ type QuizQuestionProps struct {
 	Choices []string
 	// Error is the validation message shown when a submit had no usable choice.
 	Error string
+	// RunTopic scopes the run to one topic (#118); empty for the full sequence.
+	// Links carry it forward so next/done are computed within the topic.
+	RunTopic string
 }
 
-func quizAnswerAction(slug string) string {
-	return fmt.Sprintf("/learn/quiz/%s/answer", slug)
+func quizAnswerAction(slug, runTopic string) string {
+	action := "/learn/quiz/" + slug + "/answer"
+	if runTopic != "" {
+		action += "?" + url.Values{"topic": {runTopic}}.Encode()
+	}
+	return action
 }
 
 // QuizQuestionCard renders the answer form for one question. It is a
@@ -58,7 +66,7 @@ func QuizQuestionCard(props QuizQuestionProps) templ.Component {
 		var templ_7745c5c3_Var2 string
 		templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(props.Topic)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/quiz_question.templ`, Line: 30, Col: 85}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/quiz_question.templ`, Line: 38, Col: 85}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 		if templ_7745c5c3_Err != nil {
@@ -71,7 +79,7 @@ func QuizQuestionCard(props QuizQuestionProps) templ.Component {
 		var templ_7745c5c3_Var3 string
 		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(props.Prompt)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/quiz_question.templ`, Line: 31, Col: 55}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/quiz_question.templ`, Line: 39, Col: 55}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 		if templ_7745c5c3_Err != nil {
@@ -89,7 +97,7 @@ func QuizQuestionCard(props QuizQuestionProps) templ.Component {
 			var templ_7745c5c3_Var4 string
 			templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(props.Error)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/quiz_question.templ`, Line: 33, Col: 57}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/quiz_question.templ`, Line: 41, Col: 57}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 			if templ_7745c5c3_Err != nil {
@@ -105,9 +113,9 @@ func QuizQuestionCard(props QuizQuestionProps) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var5 templ.SafeURL
-		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(quizAnswerAction(props.Slug)))
+		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(quizAnswerAction(props.Slug, props.RunTopic)))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/quiz_question.templ`, Line: 37, Col: 55}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/quiz_question.templ`, Line: 45, Col: 71}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 		if templ_7745c5c3_Err != nil {
@@ -118,9 +126,9 @@ func QuizQuestionCard(props QuizQuestionProps) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var6 string
-		templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.ResolveAttributeValue(quizAnswerAction(props.Slug))
+		templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.ResolveAttributeValue(quizAnswerAction(props.Slug, props.RunTopic))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/quiz_question.templ`, Line: 38, Col: 41}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/quiz_question.templ`, Line: 46, Col: 57}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var6)
 		if templ_7745c5c3_Err != nil {
@@ -146,7 +154,7 @@ func QuizQuestionCard(props QuizQuestionProps) templ.Component {
 			var templ_7745c5c3_Var7 string
 			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprintf("%d", i))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/quiz_question.templ`, Line: 50, Col: 35}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/quiz_question.templ`, Line: 58, Col: 35}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var7)
 			if templ_7745c5c3_Err != nil {
@@ -159,7 +167,7 @@ func QuizQuestionCard(props QuizQuestionProps) templ.Component {
 			var templ_7745c5c3_Var8 string
 			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(choice)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/quiz_question.templ`, Line: 54, Col: 20}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/quiz_question.templ`, Line: 62, Col: 20}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 			if templ_7745c5c3_Err != nil {

--- a/internal/view/partials/quiz_result.templ
+++ b/internal/view/partials/quiz_result.templ
@@ -2,6 +2,7 @@ package partials
 
 import (
 	"fmt"
+	"net/url"
 	"github.com/clownware/go-performance-starter/internal/view"
 	"github.com/clownware/go-performance-starter/internal/view/components"
 )
@@ -12,8 +13,11 @@ type QuizResultProps struct {
 	Explanation string
 	// NextSlug is the following question in display order; empty when Done.
 	NextSlug string
-	// Done marks the last question answered.
+	// Done marks the last question answered — of the topic run when RunTopic
+	// is set (#118), otherwise of the whole sequence.
 	Done bool
+	// RunTopic scopes the run to one topic; empty for the full sequence.
+	RunTopic string
 	// OfferFlashcard renders the save-as-flashcard affordance (wrong answers).
 	// The endpoint it posts to ships in Slice B; the form is progressive
 	// enhancement either way.
@@ -23,8 +27,12 @@ type QuizResultProps struct {
 	Score          view.QuizScore
 }
 
-func quizNextURL(slug string) string {
-	return fmt.Sprintf("/learn/quiz?q=%s", slug)
+func quizNextURL(slug, runTopic string) string {
+	query := url.Values{"q": {slug}}
+	if runTopic != "" {
+		query.Set("topic", runTopic)
+	}
+	return "/learn/quiz?" + query.Encode()
 }
 
 // QuizResult renders the outcome of an answer: verdict, explanation, updated
@@ -60,13 +68,26 @@ templ QuizResult(props QuizResultProps) {
 		<div class="mt-6">
 			if props.Done {
 				<div data-testid="quiz-done">
-					<p class="font-medium mb-2">That was the last question — quiz complete.</p>
-					<a href="/patterns" class="text-link underline">Explore the pattern showcase</a>
+					if props.RunTopic != "" {
+						<p class="font-medium mb-2">{ "That was the last " + props.RunTopic + " question." }</p>
+						<a
+							href="/learn/quiz"
+							hx-get="/learn/quiz"
+							hx-target="#quiz-card"
+							hx-swap="innerHTML"
+							class="btn btn-primary inline-block"
+						>
+							Continue with the full quiz
+						</a>
+					} else {
+						<p class="font-medium mb-2">That was the last question — quiz complete.</p>
+						<a href="/patterns" class="text-link underline">Explore the pattern showcase</a>
+					}
 				</div>
 			} else {
 				<a
-					href={ templ.SafeURL(quizNextURL(props.NextSlug)) }
-					hx-get={ quizNextURL(props.NextSlug) }
+					href={ templ.SafeURL(quizNextURL(props.NextSlug, props.RunTopic)) }
+					hx-get={ quizNextURL(props.NextSlug, props.RunTopic) }
 					hx-target="#quiz-card"
 					hx-swap="innerHTML"
 					class="btn btn-primary inline-block"

--- a/internal/view/partials/quiz_result_templ.go
+++ b/internal/view/partials/quiz_result_templ.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"github.com/clownware/go-performance-starter/internal/view"
 	"github.com/clownware/go-performance-starter/internal/view/components"
+	"net/url"
 )
 
 // QuizResultProps holds data for the answer result card (ADR-024).
@@ -20,8 +21,11 @@ type QuizResultProps struct {
 	Explanation string
 	// NextSlug is the following question in display order; empty when Done.
 	NextSlug string
-	// Done marks the last question answered.
+	// Done marks the last question answered — of the topic run when RunTopic
+	// is set (#118), otherwise of the whole sequence.
 	Done bool
+	// RunTopic scopes the run to one topic; empty for the full sequence.
+	RunTopic string
 	// OfferFlashcard renders the save-as-flashcard affordance (wrong answers).
 	// The endpoint it posts to ships in Slice B; the form is progressive
 	// enhancement either way.
@@ -31,8 +35,12 @@ type QuizResultProps struct {
 	Score          view.QuizScore
 }
 
-func quizNextURL(slug string) string {
-	return fmt.Sprintf("/learn/quiz?q=%s", slug)
+func quizNextURL(slug, runTopic string) string {
+	query := url.Values{"q": {slug}}
+	if runTopic != "" {
+		query.Set("topic", runTopic)
+	}
+	return "/learn/quiz?" + query.Encode()
 }
 
 // QuizResult renders the outcome of an answer: verdict, explanation, updated
@@ -80,7 +88,7 @@ func QuizResult(props QuizResultProps) templ.Component {
 		var templ_7745c5c3_Var2 string
 		templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(props.Explanation)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/quiz_result.templ`, Line: 42, Col: 37}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/quiz_result.templ`, Line: 50, Col: 37}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 		if templ_7745c5c3_Err != nil {
@@ -110,7 +118,7 @@ func QuizResult(props QuizResultProps) templ.Component {
 			var templ_7745c5c3_Var3 string
 			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.ResolveAttributeValue(props.FlashcardFront)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/quiz_result.templ`, Line: 54, Col: 66}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/quiz_result.templ`, Line: 62, Col: 66}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var3)
 			if templ_7745c5c3_Err != nil {
@@ -123,7 +131,7 @@ func QuizResult(props QuizResultProps) templ.Component {
 			var templ_7745c5c3_Var4 string
 			templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.ResolveAttributeValue(props.FlashcardBack)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/quiz_result.templ`, Line: 55, Col: 64}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/quiz_result.templ`, Line: 63, Col: 64}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var4)
 			if templ_7745c5c3_Err != nil {
@@ -139,43 +147,71 @@ func QuizResult(props QuizResultProps) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		if props.Done {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<div data-testid=\"quiz-done\"><p class=\"font-medium mb-2\">That was the last question — quiz complete.</p><a href=\"/patterns\" class=\"text-link underline\">Explore the pattern showcase</a></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<div data-testid=\"quiz-done\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			if props.RunTopic != "" {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<p class=\"font-medium mb-2\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var5 string
+				templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs("That was the last " + props.RunTopic + " question.")
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/quiz_result.templ`, Line: 72, Col: 88}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "</p><a href=\"/learn/quiz\" hx-get=\"/learn/quiz\" hx-target=\"#quiz-card\" hx-swap=\"innerHTML\" class=\"btn btn-primary inline-block\">Continue with the full quiz</a>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			} else {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "<p class=\"font-medium mb-2\">That was the last question — quiz complete.</p><a href=\"/patterns\" class=\"text-link underline\">Explore the pattern showcase</a>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<a href=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "<a href=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var5 templ.SafeURL
-			templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(quizNextURL(props.NextSlug)))
+			var templ_7745c5c3_Var6 templ.SafeURL
+			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(quizNextURL(props.NextSlug, props.RunTopic)))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/quiz_result.templ`, Line: 68, Col: 54}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/quiz_result.templ`, Line: 89, Col: 70}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "\" hx-get=\"")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var6 string
-			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.ResolveAttributeValue(quizNextURL(props.NextSlug))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/quiz_result.templ`, Line: 69, Col: 41}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var6)
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "\" hx-get=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "\" hx-target=\"#quiz-card\" hx-swap=\"innerHTML\" class=\"btn btn-primary inline-block\">Next question</a>")
+			var templ_7745c5c3_Var7 string
+			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.ResolveAttributeValue(quizNextURL(props.NextSlug, props.RunTopic))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/quiz_result.templ`, Line: 90, Col: 57}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var7)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "\" hx-target=\"#quiz-card\" hx-swap=\"innerHTML\" class=\"btn btn-primary inline-block\">Next question</a>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "</div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "</div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -200,25 +236,25 @@ func QuizScoreBadge(score view.QuizScore) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var7 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var7 == nil {
-			templ_7745c5c3_Var7 = templ.NopComponent
+		templ_7745c5c3_Var8 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var8 == nil {
+			templ_7745c5c3_Var8 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "<p data-testid=\"quiz-score\" class=\"text-sm text-muted-foreground\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "<p data-testid=\"quiz-score\" class=\"text-sm text-muted-foreground\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var8 string
-		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d of %d", score.Correct, score.Total))
+		var templ_7745c5c3_Var9 string
+		templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d of %d", score.Correct, score.Total))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/quiz_result.templ`, Line: 84, Col: 55}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/partials/quiz_result.templ`, Line: 105, Col: 55}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, " answered correctly</p>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, " answered correctly</p>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
## Summary

Closes #118.

- `GET /learn/quiz?topic=<slug>`: a topic present in the question set narrows the run to that topic and lands on the first question the user has not attempted (falls back to the topic's first question once all are attempted). Unknown topics are ignored — the full sequence renders and no `topic=` is echoed into any link.
- The answer form action and the next-question link carry `?topic=` forward, so next/done are computed within the topic; `?q=` outside the topic is a 404. The invalid-choice re-render keeps the scope.
- Finishing a topic renders "That was the last `<topic>` question." with a link into the full quiz instead of the pattern showcase.
- The five explainer hand-offs on `/` now link to `/learn/quiz?topic=<topic>`; the home-page test asserts all five.
- The running score stays whole-quiz — it counts attempts, not runs.

## Design notes

- No new sqlc query: the handler filters the question list it already fetches for the score, avoiding a second RLS-scoped transaction per request for a ten-row set (ADR-000 budgets; engineering.md "three similar lines beat a premature helper"). The topic index stays available if the seed ever grows.
- Topic entry reads a bounded attempt window (200) through the existing repository method; unattempted-first is best-effort by design.
- Table-driven cases for entry, unattempted-first, all-attempted restart, explicit slug in/out of topic, unknown topic, history failure, and the topic-scoped answer/done/422 paths (ADR-023).

## Verification

- `task ci` green locally (fmt, lint, race tests, agents/versions/adr/generated checks, binary + asset budgets, govulncheck).

🤖 Generated with [Claude Code](https://claude.com/claude-code)