### PR TITLE
fix(agentsmd): normalize layer endings and detect ATX headings per CommonMark

### DIFF
--- a/scripts/agentsmd/main.go
+++ b/scripts/agentsmd/main.go
@@ -83,7 +83,11 @@ func generate(root string) ([]byte, error) {
 		}
 		b.WriteString("\n---\n\n")
 		fmt.Fprintf(&b, "<!-- source: %s -->\n\n", rel)
-		b.WriteString(rewriteParentLinks(demoteHeadings(string(raw))))
+		// Normalize each layer to end with exactly one newline (#116): a layer
+		// without one would make the next joint "text\n---", which Markdown
+		// reads as a setext H2 underline rather than a thematic break.
+		layer := strings.TrimRight(string(raw), "\n") + "\n"
+		b.WriteString(rewriteParentLinks(demoteHeadings(layer)))
 	}
 
 	out := strings.TrimRight(b.String(), "\n") + "\n"
@@ -92,6 +96,8 @@ func generate(root string) ([]byte, error) {
 
 // demoteHeadings adds one '#' to every ATX heading, capping at H6, while leaving
 // content inside fenced code blocks untouched (so shell '#' comments survive).
+// Per CommonMark, an ATX heading is 1-6 hashes followed by a space, a tab, or
+// the end of the line — "#hashtag" is plain text and passes through (#116).
 func demoteHeadings(s string) string {
 	lines := strings.Split(s, "\n")
 	inFence := false
@@ -104,14 +110,25 @@ func demoteHeadings(s string) string {
 		if inFence {
 			continue
 		}
-		if strings.HasPrefix(line, "#") {
+		if isATXHeading(line) {
 			level := len(line) - len(strings.TrimLeft(line, "#"))
-			if level >= 1 && level <= 5 {
+			if level <= 5 {
 				lines[i] = "#" + line
 			}
 		}
 	}
 	return strings.Join(lines, "\n")
+}
+
+// isATXHeading reports whether line opens with 1-6 '#' followed by a space, a
+// tab, or the end of the line (CommonMark §4.2).
+func isATXHeading(line string) bool {
+	rest := strings.TrimLeft(line, "#")
+	level := len(line) - len(rest)
+	if level < 1 || level > 6 {
+		return false
+	}
+	return rest == "" || rest[0] == ' ' || rest[0] == '\t'
 }
 
 // rewriteParentLinks rewrites markdown link targets that climb out of the

--- a/scripts/agentsmd/main_test.go
+++ b/scripts/agentsmd/main_test.go
@@ -108,6 +108,9 @@ func TestGenerate(t *testing.T) {
 		want    string // exact output when non-empty
 		wantEnd string // required suffix when want is empty
 		wantErr string // substring of the error
+		// wantContains / wantAbsent pin the shape of a layer joint (#116).
+		wantContains string
+		wantAbsent   string
 	}{
 		{
 			name: "concatenates layers in order with demoted headings and root-relative links",
@@ -119,6 +122,24 @@ func TestGenerate(t *testing.T) {
 				files[".claude/stack.md"] = "# Stack\n\n###### Budgets\n\n\n\n"
 			},
 			wantEnd: "## Stack\n\n###### Budgets\n",
+		},
+		{
+			// A layer without a trailing newline used to yield "text\n---\n",
+			// which Markdown reads as a setext H2 underline, not a rule.
+			name: "layer without a trailing newline still joins with a thematic break",
+			files: func(files map[string]string) {
+				files[".claude/workflow.md"] = "# Workflow\n\nThree passes."
+			},
+			wantContains: "Three passes.\n\n---\n\n<!-- source: .claude/stack.md -->",
+			wantAbsent:   "Three passes.\n---",
+		},
+		{
+			name: "extra trailing newlines in a middle layer collapse before the joint",
+			files: func(files map[string]string) {
+				files[".claude/workflow.md"] = "# Workflow\n\nThree passes.\n\n\n\n"
+			},
+			wantContains: "Three passes.\n\n---\n\n<!-- source: .claude/stack.md -->",
+			wantAbsent:   "Three passes.\n\n\n",
 		},
 		{
 			name: "missing source layer errors naming the layer",
@@ -159,6 +180,12 @@ func TestGenerate(t *testing.T) {
 			}
 			if tt.want != "" && string(got) != tt.want {
 				t.Errorf("generated output mismatch\n--- got ---\n%s\n--- want ---\n%s", got, tt.want)
+			}
+			if tt.wantContains != "" && !strings.Contains(string(got), tt.wantContains) {
+				t.Errorf("output missing %q:\n%s", tt.wantContains, got)
+			}
+			if tt.wantAbsent != "" && strings.Contains(string(got), tt.wantAbsent) {
+				t.Errorf("output contains %q, want it absent:\n%s", tt.wantAbsent, got)
 			}
 			if tt.wantEnd != "" {
 				if !strings.HasSuffix(string(got), tt.wantEnd) {
@@ -249,6 +276,33 @@ func TestDemoteHeadings(t *testing.T) {
 			name: "empty input",
 			in:   "",
 			want: "",
+		},
+		// CommonMark ATX headings need a space, tab, or end of line after the
+		// opening hashes (#116); "#hashtag" is plain text.
+		{
+			name: "hashtag without a space is not a heading",
+			in:   "#hashtag",
+			want: "#hashtag",
+		},
+		{
+			name: "hashtag after a heading stays untouched while the heading is demoted",
+			in:   "# A\n#tag\n## B",
+			want: "## A\n#tag\n### B",
+		},
+		{
+			name: "hash followed by a tab is a heading",
+			in:   "#\tTabbed",
+			want: "##\tTabbed",
+		},
+		{
+			name: "empty heading of hashes alone is a heading",
+			in:   "##",
+			want: "###",
+		},
+		{
+			name: "seven hashes is not a heading",
+			in:   "####### Seven",
+			want: "####### Seven",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Closes #116.

- `generate` normalizes every source layer to end with exactly one `\n` before writing the `---` joint, so a layer without a trailing newline can no longer produce `text\n---` (a setext H2 underline in Markdown) and extra blank lines collapse.
- `demoteHeadings` uses a new `isATXHeading` predicate: 1–6 `#` followed by a space, a tab, or end of line (CommonMark §4.2). `#hashtag` lines pass through; `#`, `#\tX`, and seven-hash lines behave per spec.
- Table cases pin both joint shapes and the new heading edges; package coverage 95.3% → 95.7%.

`task agents:check` confirms AGENTS.md is byte-identical — neither shape exists in today's layers, this closes the corruption path.

## Verification

- `task ci` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)