### PR TITLE
docs: update rate limiter snippets for the context signature; drop stale main.go placeholders

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -14,7 +14,6 @@ import (
 	"github.com/joho/godotenv"
 
 	"github.com/clownware/go-performance-starter/internal/config"
-	_ "github.com/clownware/go-performance-starter/internal/database" // Keep for sqlc generated types, alias not needed directly here
 	"github.com/clownware/go-performance-starter/internal/jobs"
 	"github.com/clownware/go-performance-starter/internal/middleware"
 	"github.com/clownware/go-performance-starter/internal/repository/postgres"
@@ -93,17 +92,9 @@ func main() {
 	defer db.Close()
 	slog.Info("Database connection established successfully")
 
-	// Note: The following line is commented out because sqlc code generation hasn't been run yet
-	// When sqlc is run, it will generate the New() function to create queries
-	// queries := database.New(db)
-	// Repositories will be created here in later phases
-	_ = "queries will be used in Phase 3-4"
-
-	// At this point, we would set up repositories and handlers, but that's for Phase 3-4
-	// We'll just create a simple endpoint to verify our setup
-
-	// Initialize the router with middleware and routes
-	srv, err := server.New(cfg, db) // Pass db connection to server
+	// Wire the router: middleware stack, repositories, and routes live in
+	// internal/server; main only injects the pool.
+	srv, err := server.New(cfg, db)
 	if err != nil {
 		slog.Error("Failed to create server", "error", err)
 		os.Exit(1)

--- a/docs/implementation-guides/07-auth-security.md
+++ b/docs/implementation-guides/07-auth-security.md
@@ -78,15 +78,16 @@ func CSRFProtection(next http.Handler) http.Handler {
 Implement rate limiting for sensitive endpoints, especially authentication. The starter's rate limiter is an in-memory per-IP token bucket built on `golang.org/x/time/rate` (ADR-014 §4) — no Redis and no third-party limiter; the stack has no Redis (caching is in-memory plus the Cloudflare edge per ADR-016):
 
 ```go
-// internal/middleware/ratelimit.go — RateLimiter(rps, burst) keeps a
-// token bucket per client IP and evicts stale entries in the background.
+// internal/middleware/ratelimit.go — RateLimiter(ctx, rps, burst) keeps a
+// token bucket per client IP and evicts stale entries in the background
+// until ctx is cancelled (the server owns that context; Server.Close ends it).
 import "golang.org/x/time/rate"
 
-// A global RateLimiter(50, 10) is already applied in the server
+// A global RateLimiter(ctx, 50, 10) is already applied in the server
 // middleware stack; add stricter tiers on route groups:
 r.Route("/auth", func(authRouter chi.Router) {
     authRouter.Group(func(strict chi.Router) {
-        strict.Use(mw.RateLimiter(5.0/60.0, 5)) // 5 attempts/min, burst 5
+        strict.Use(mw.RateLimiter(ctx, 5.0/60.0, 5)) // 5 attempts/min, burst 5
         // login, signup, password reset...
     })
 })

--- a/docs/product/security-overview.md
+++ b/docs/product/security-overview.md
@@ -85,13 +85,15 @@ func CSRFProtection(next http.Handler) http.Handler {
 ### Configuration
 ```go
 // Per-IP token bucket built on golang.org/x/time/rate
-// (internal/middleware/ratelimit.go), tiered via route groups (ADR-014)
+// (internal/middleware/ratelimit.go), tiered via route groups (ADR-014).
+// ctx is the server's lifecycle context: idle-bucket eviction stops when
+// Server.Close cancels it (#117).
 
 // Global limit: 50 req/sec, burst 10
-r.Use(mw.RateLimiter(50, 10))
+r.Use(mw.RateLimiter(ctx, 50, 10))
 
 // Strict tier on credential endpoints: 5 attempts per minute, burst 5
-strict.Use(mw.RateLimiter(5.0/60.0, 5))
+strict.Use(mw.RateLimiter(ctx, 5.0/60.0, 5))
 ```
 
 ## Database Security


### PR DESCRIPTION
## Summary

Follow-up to #124 found work.

- `docs/product/security-overview.md` and `docs/implementation-guides/07-auth-security.md`: the rate limiter snippets now show `RateLimiter(ctx, rps, burst)` and explain that eviction stops when `Server.Close` cancels the context.
- `cmd/api/main.go`: removed the pre-sqlc "Phase 3-4" placeholder comments and the blank `internal/database` import that existed only to justify them. Behaviour unchanged; the server package already imports `database`.

## Verification

- `task ci` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)