### PR TITLE
feat(perf): observed-vs-budget grid and Server-Timing (ADR-034)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Observed-vs-budget grid (ADR-034): the landing page's budgets section now
+  shows, per budget, what this process observed since boot — p50/p95/p99
+  over the last 4096 requests, memory and its high-water mark, startup
+  (process start → listening socket, measured in `main`), the executable
+  size, and the shipped assets gzipped — with pass/fail and the ADR-000
+  class (Enforced/Monitored/Aspirational). Unmeasured values say so
+  instead of showing a passing zero. Every response also carries
+  `Server-Timing: app;dur=<ms>`. The asset file lists now live in
+  `internal/performance` so the CI gate and the runtime measure the same
+  files
 - Share and crawl surface: every page carries a real meta description,
   Open Graph and Twitter card tags, and — when `PUBLIC_BASE_URL` is set —
   a canonical link plus absolute `og:url`/`og:image` (a 1200×630 share

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -16,6 +17,7 @@ import (
 	"github.com/clownware/go-performance-starter/internal/config"
 	"github.com/clownware/go-performance-starter/internal/jobs"
 	"github.com/clownware/go-performance-starter/internal/middleware"
+	"github.com/clownware/go-performance-starter/internal/performance"
 	"github.com/clownware/go-performance-starter/internal/repository/postgres"
 	"github.com/clownware/go-performance-starter/internal/server"
 	"github.com/clownware/go-performance-starter/internal/view"
@@ -23,6 +25,10 @@ import (
 
 // version is set at build time via -ldflags "-X main.version=..."
 var version = "dev"
+
+// processStart anchors the ADR-000 startup budget: process start → listening
+// socket, recorded into the observer once the listener is bound (ADR-034).
+var processStart = time.Now()
 
 func main() {
 	// Manually load .env and set environment variables (before logger setup
@@ -126,10 +132,22 @@ func main() {
 	addr := fmt.Sprintf(":%s", cfg.HTTPPort)
 	httpServer := newHTTPServer(addr, srv)
 
-	// Start the server in a goroutine
+	// Bind first so "startup" means what ADR-000 says — process start to a
+	// listening socket — then serve on the bound listener.
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		slog.Error("Error binding listener", "addr", addr, "error", err)
+		os.Exit(1)
+	}
+	startup := time.Since(processStart)
+	performance.Default.RecordStartup(startup)
+	if err := performance.CheckStartupTime(startup); err != nil {
+		slog.Warn("startup budget exceeded", "error", err)
+	}
+	slog.Info("Server listening on "+addr, "startup_ms", startup.Milliseconds())
+
 	go func() {
-		slog.Info("Server listening on " + addr)
-		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		if err := httpServer.Serve(ln); err != nil && err != http.ErrServerClosed {
 			slog.Error("Error starting server", "error", err)
 			os.Exit(1)
 		}

--- a/docs/adr/ADR-034-Live-Proof-Surfaces.md
+++ b/docs/adr/ADR-034-Live-Proof-Surfaces.md
@@ -1,0 +1,67 @@
+# ADR-034: Live Proof Surfaces
+
+**Date**: 2026-09-09
+
+## Status
+
+Accepted
+
+## Context
+
+The demo's brand line is "proved, not promised" (ADR-024), and the surfaces it shipped — the pattern showcase, the architecture tour, the RLS-scoped quiz and flashcards — do prove the *mechanics*. But the two headline claims stopped one step short of proof:
+
+- The landing page's "live performance budgets" grid rendered the ADR-000 **constants** only. A reader saw `< 100ms` and could not tell a ceiling from an observation; nothing on the page distinguished Enforced from Monitored from Aspirational, a classification that existed only inside ADR-000.
+- The flashcards page said "a real row scoped to you by Row Level Security" as prose. A visitor could not witness the boundary — the one differentiator every other starter lacks was a sentence.
+
+Meanwhile the process already had everything needed to show both: a request-duration histogram in the metrics middleware, `runtime.MemStats`, a measurable startup path, the shipped assets on disk, and repositories whose scoping comes purely from context claims (ADR-004). And the security tiers ADR-014 mandates — per-IP rate-limit tiers in particular — were invisible by construction; a 429 was plain text with no `Retry-After`.
+
+## Decision
+
+The demo gains three **proof surfaces**, each showing a claim rather than stating it, each built from the production code path it proves (no parallel demo-only mechanism):
+
+1. **Observed-vs-budget grid** (landing page). `internal/performance` gains an `Observer`: a ring of the last 4096 request durations (nearest-rank p50/p95/p99), memory from the runtime with a since-boot high-water mark, the startup duration recorded by `main` once the listener is bound (process start → listening socket, exactly as ADR-000 defines it), the running executable's size, and the gzipped totals of the shipped assets measured from the same file lists the CI gate uses (`ShippedJS`/`ShippedCSS`, stated once). The metrics middleware feeds it. The grid renders **budget, observed, pass/fail, and the ADR-000 class** per row. A zero observation renders as *not measured* — a proof surface must never show a passing zero. The Total Page budget stays visibly Aspirational until a measurement exists.
+2. **`Server-Timing` on every response.** The metrics middleware stamps `Server-Timing: app;dur=<ms>` (handler time to first byte) when headers are committed, so any browser's devtools show the server-side cost of the page being read.
+3. **RLS isolation check** (flashcards page) and **rate-limit demo** (`/patterns`), specified here and delivered in the two changes stacked on this one:
+   - The isolation check runs the visitor's own `ListByUser` query twice through the *same* repository interface: once with the request's claims, once with a freshly minted stranger identity (`authenticated` role, random `sub`) — same SQL, same `user_id` parameter, different `auth.uid()` — and renders both row counts next to the policy text. Zero rows for the stranger is Postgres refusing, not a `WHERE` clause. No other visitor's data is touched or counted.
+   - The rate-limit demo mounts the production `RateLimiter` on a `/patterns` fragment endpoint with a deliberately tight tier and lets the visitor hit 429. The limiter now sets `Retry-After` on every 429 (a correctness fix the demo made visible), and the limited response for the demo is an HTML fragment HTMX swaps in — the existing `htmx:beforeSwap` allow-list grows by "429 with an HTML body".
+
+### Observed values are readings, not SLOs
+
+The observed column is per-process, since boot, on whatever instance served the request (on the demo, a single scale-to-zero machine). It is a live reading that makes the budgets concrete, not a production baseline; ADR-000's graduation rule (Monitored → Enforced needs a baseline) is unchanged. The page says so in its legend.
+
+## Consequences
+
+- The landing page now depends on `internal/performance` for observations as well as constants; the observer is package-level (`performance.Default`) like the Prometheus collectors it sits beside, and tests construct their own.
+- `main` binds the listener explicitly (`net.Listen` + `Serve`) so startup can be measured; behaviour is otherwise unchanged.
+- The asset file lists move from `scripts/check-asset-budgets` into `internal/performance`; the CI gate and the runtime read one list.
+- Every response grows one small header. `Server-Timing` exposes handler duration only — no route, identity or infrastructure detail.
+- A dev build shows an unstripped, larger executable against the 20 MB budget and may read "over budget" locally; the note on the row says CI gates the stripped linux build. Honest beats flattering.
+
+## Alternatives Considered
+
+- **Read percentiles from the Prometheus histogram.** Rejected — histogram buckets give interpolated estimates, and the page would then depend on the metrics registry's label cardinality. A bounded ring gives exact nearest-rank values over recent traffic for a few kilobytes.
+- **A separate "status" page.** Rejected — the proof belongs next to the claim; the landing page already narrates the budgets in tour step 5.
+- **Prove isolation by reading another guest's rows under `service_role`.** Rejected — it would put a second identity's data (even a count) on a visitor's page, and it needs a system-role path the request handlers otherwise never touch. The stranger-identity check proves the same thing using only the visitor's own rows.
+- **Fake the 429 in a demo handler.** Rejected — the point is that the production limiter refuses; a handler pretending to would be exactly the promise-not-proof this ADR exists to end.
+
+## References
+
+- [ADR-000](ADR-000-Performance-Budgets-and-Quality-Attributes.md) budgets and their classification; [ADR-004](ADR-004-Authorization-Strategy-RLS.md) RLS; [ADR-014](ADR-014-Security-Patterns-and-Threat-Model.md) rate-limit tiers; [ADR-024](ADR-024-Demo-Application-Direction.md) demo direction; [ADR-031](ADR-031-Public-Demo-Operations.md) public demo operations.
+- `internal/performance/observed.go`, `internal/middleware/metrics.go`, `internal/handler/home_explainer.go`.
+
+## Enforcement
+<!-- added 2026-09-09, see ADR-033 (Enforcement Architecture) -->
+- **Testable consequences:**
+  - TC-1: Every budget row renders budget, observed value, status and ADR-000 class; an unmeasured value renders as unmeasured, never as a passing zero.
+  - TC-2: The CI asset gate and the runtime observer measure the same shipped-asset file lists.
+  - TC-3: Every response through the metrics middleware carries `Server-Timing: app;dur=<ms>`.
+  - TC-4: The isolation check goes through `repository.FlashcardRepository` only, and the stranger identity yields zero rows against real Postgres RLS.
+  - TC-5: Every 429 from `RateLimiter` carries `Retry-After`.
+- **Checks:**
+  - TC-1 → `internal/handler` `TestPerfBudgetStats_Observed`, `internal/server` `TestServer_HomeExplainer` (status: **block**, `task test`)
+  - TC-2 → `internal/performance` `TestShippedAssetPaths` + `scripts/check-asset-budgets` importing the lists (status: **block**, compile + `task test`)
+  - TC-3 → `internal/middleware` `TestMetrics_ServerTiming` (status: **block**, `task test`)
+  - TC-4 → `internal/handler` isolation-check tests with the fake repository; `internal/repository/postgres` `TestScopedRepoRLSIsolation` stranger case (status: **block**, `task test`; the Postgres leg runs in CI with `DATABASE_URL`)
+  - TC-5 → `internal/middleware` `TestRateLimiter_RetryAfter` (status: **block**, `task test`)
+- **Not machine-checkable:** that the observed column is *read* as a live reading rather than an SLO — the legend's wording is review territory.
+- **Graduation log:** _(empty)_

--- a/internal/handler/home_explainer.go
+++ b/internal/handler/home_explainer.go
@@ -2,6 +2,8 @@ package handler
 
 import (
 	"fmt"
+	"math"
+	"time"
 
 	"github.com/clownware/go-performance-starter/internal/performance"
 	"github.com/clownware/go-performance-starter/internal/view/pages"
@@ -156,10 +158,10 @@ templ QuizQuestionCard(props QuizQuestionProps) {
 			Anchor:    "performance",
 			QuizTopic: "performance",
 			Title:     "Performance budgets, enforced in CI and observed in production",
-			Summary:   "Binary, memory, startup and gzipped JS/CSS budgets are constants in Go, gated by task ci, and observed via Prometheus — the numbers below are rendered from those constants on every request.",
+			Summary:   "Binary, memory, startup and gzipped JS/CSS budgets are constants in Go, gated by task ci — and the grid below puts what this very process has observed since boot next to each one, on every request.",
 			Prose: []string{
 				"ADR-000 states the budgets once, in internal/performance/budgets.go. task ci builds the stripped binary and measures it, gzips the shipped JS and CSS and measures those, and runs the budget tests with the race detector — so a regression is a red build, not a slow page someone notices later.",
-				"At runtime the same constants feed this page: the stats grid is not a hardcoded list, it is a handler reading the constants and a templ component rendering them — dynamic server-rendered content with zero client JavaScript. Request latency and memory are exported to Prometheus at /metrics (bearer-gated in production).",
+				"At runtime the same constants feed this page next to live readings: the metrics middleware records every request into a rolling window, the runtime reports memory, main records process start → listening, and the shipped assets and executable are measured once. A handler reads all of that and a templ component renders it — dynamic server-rendered content with zero client JavaScript. Every response also carries a Server-Timing header, so your browser's devtools show the handler time for this page. Prometheus at /metrics (bearer-gated in production) has the long-run view.",
 			},
 			ADR: adrLink("ADR-000-Performance-Budgets-and-Quality-Attributes.md", "ADR-000 performance budgets · ADR-021 quality gate"),
 			Source: pages.ExplainerSource{
@@ -181,20 +183,62 @@ templ QuizQuestionCard(props QuizQuestionProps) {
 
 // PerfBudgetStats renders the ADR-000 budgets from the constants in
 // internal/performance — never from literals here, so the landing page can
-// only ever show what CI actually enforces.
-func PerfBudgetStats() []pages.BudgetStat {
-	return []pages.BudgetStat{
-		{Label: "P50 response", Value: performance.MaxP50ResponseTime.String(), Note: "median latency target"},
-		{Label: "P95 response", Value: performance.MaxP95ResponseTime.String(), Note: "enforced by the budget tests"},
-		{Label: "P99 response", Value: performance.MaxP99ResponseTime.String(), Note: "tail latency ceiling"},
-		{Label: "Binary size", Value: formatBudgetBytes(performance.MaxBinarySize), Note: "stripped linux build, gated in task ci"},
-		{Label: "Memory", Value: formatBudgetBytes(performance.MaxMemoryUsage), Note: "steady state"},
-		{Label: "Peak memory", Value: formatBudgetBytes(performance.MaxPeakMemory), Note: "under load"},
-		{Label: "Startup", Value: performance.MaxStartupTime.String(), Note: "process start to listening"},
-		{Label: "JavaScript", Value: formatBudgetBytes(performance.MaxJavaScriptSize), Note: "gzipped — htmx + Alpine + app.js"},
-		{Label: "CSS", Value: formatBudgetBytes(performance.MaxCSSSize), Note: "gzipped Tailwind build"},
-		{Label: "Total page", Value: formatBudgetBytes(performance.MaxTotalPageSize), Note: "HTML + assets"},
+// only ever show what CI actually enforces — next to what this process has
+// observed since boot (ADR-034). A zero observation means unmeasured and is
+// rendered as such: a page that proves must never show a passing zero.
+func PerfBudgetStats(snap performance.Snapshot) []pages.BudgetStat {
+	const unmeasured = "—"
+	latency := func(label string, budget, observed time.Duration, note string) pages.BudgetStat {
+		s := pages.BudgetStat{Label: label, Budget: budget.String(), Class: string(performance.ClassMonitored), Note: note, Observed: unmeasured, Status: "unmeasured"}
+		if snap.Samples > 0 {
+			s.Observed = formatObservedDuration(observed)
+			s.Status = passFail(observed <= budget)
+			s.Note = fmt.Sprintf("%s · last %d requests", note, snap.Samples)
+		}
+		return s
 	}
+	size := func(label string, budget, observed int64, class performance.Class, note string) pages.BudgetStat {
+		s := pages.BudgetStat{Label: label, Budget: formatBudgetBytes(budget), Class: string(class), Note: note, Observed: unmeasured, Status: "unmeasured"}
+		if observed > 0 {
+			s.Observed = formatBudgetBytes(observed)
+			s.Status = passFail(observed <= budget)
+		}
+		return s
+	}
+	startup := pages.BudgetStat{Label: "Startup", Budget: performance.MaxStartupTime.String(), Class: string(performance.ClassMonitored), Note: "process start to listening socket", Observed: unmeasured, Status: "unmeasured"}
+	if snap.Startup > 0 {
+		startup.Observed = formatObservedDuration(snap.Startup)
+		startup.Status = passFail(snap.Startup <= performance.MaxStartupTime)
+	}
+	return []pages.BudgetStat{
+		latency("P50 response", performance.MaxP50ResponseTime, snap.P50, "median handler time"),
+		latency("P95 response", performance.MaxP95ResponseTime, snap.P95, "budget tests + slow-request log"),
+		latency("P99 response", performance.MaxP99ResponseTime, snap.P99, "tail latency ceiling"),
+		size("Binary size", performance.MaxBinarySize, snap.BinarySize, performance.ClassEnforced, "this executable; CI gates the stripped linux build"),
+		size("Memory", performance.MaxMemoryUsage, bytesInt64(snap.Sys), performance.ClassMonitored, "obtained from the OS by this process"),
+		size("Peak memory", performance.MaxPeakMemory, bytesInt64(snap.PeakSys), performance.ClassMonitored, "high-water mark since boot"),
+		startup,
+		size("JavaScript", performance.MaxJavaScriptSize, snap.JSGzipped, performance.ClassEnforced, "gzipped — htmx + Alpine + app.js, as shipped"),
+		size("CSS", performance.MaxCSSSize, snap.CSSGzipped, performance.ClassEnforced, "gzipped Tailwind build, as shipped"),
+		{Label: "Total page", Budget: formatBudgetBytes(performance.MaxTotalPageSize), Class: string(performance.ClassAspirational), Note: "HTML + assets — no measurement exists yet (ADR-000 §1)", Observed: unmeasured, Status: "unmeasured"},
+	}
+}
+
+func passFail(ok bool) string {
+	if ok {
+		return "pass"
+	}
+	return "fail"
+}
+
+// formatObservedDuration rounds to a tenth of a millisecond so a 12.34ms
+// reading prints as 12.3ms; anything below that resolution prints as
+// "<0.1ms" rather than the misleading "0s".
+func formatObservedDuration(d time.Duration) string {
+	if d < 100*time.Microsecond {
+		return "<0.1ms"
+	}
+	return d.Round(100 * time.Microsecond).String()
 }
 
 // formatBudgetBytes renders byte budgets in the units ADR-000 states them
@@ -214,4 +258,13 @@ func formatBudgetBytes(n int64) string {
 		return fmt.Sprintf("%d %cB", int64(value), "KMGTPE"[exp])
 	}
 	return fmt.Sprintf("%.1f %cB", value, "KMGTPE"[exp])
+}
+
+// bytesInt64 narrows a runtime byte count for comparison with the int64
+// budgets, saturating rather than wrapping on the (impossible) overflow.
+func bytesInt64(u uint64) int64 {
+	if u > math.MaxInt64 {
+		return math.MaxInt64
+	}
+	return int64(u)
 }

--- a/internal/handler/home_explainer_test.go
+++ b/internal/handler/home_explainer_test.go
@@ -3,8 +3,10 @@ package handler
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/clownware/go-performance-starter/internal/performance"
+	"github.com/clownware/go-performance-starter/internal/view/pages"
 )
 
 // TestExplainerNodes pins the teachable spine (ADR-024 surface 1, #67): the
@@ -60,7 +62,7 @@ func TestExplainerNodes(t *testing.T) {
 // internal/performance at request time, so a budget change in ADR-000's
 // constants changes the landing page without anyone editing a template.
 func TestPerfBudgetStats(t *testing.T) {
-	stats := PerfBudgetStats()
+	stats := PerfBudgetStats(performance.Snapshot{})
 
 	want := map[string]string{
 		"P50 response":  performance.MaxP50ResponseTime.String(),
@@ -78,10 +80,10 @@ func TestPerfBudgetStats(t *testing.T) {
 	}
 	got := map[string]string{}
 	for _, s := range stats {
-		if s.Label == "" || s.Value == "" {
-			t.Errorf("stat with empty label/value: %+v", s)
+		if s.Label == "" || s.Budget == "" {
+			t.Errorf("stat with empty label/budget: %+v", s)
 		}
-		got[s.Label] = s.Value
+		got[s.Label] = s.Budget
 	}
 	for label, value := range want {
 		if value == "" {
@@ -116,6 +118,127 @@ func TestFormatBudgetBytes(t *testing.T) {
 	for _, tt := range tests {
 		if got := formatBudgetBytes(tt.in); got != tt.want {
 			t.Errorf("formatBudgetBytes(%d) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+// TestPerfBudgetStats_Observed pins the observed-vs-budget grid (ADR-034):
+// every row states its ADR-000 class, an unmeasured value renders as
+// unmeasured (never as a passing zero), and pass/fail is decided against the
+// constants in internal/performance — the same values task ci enforces.
+func TestPerfBudgetStats_Observed(t *testing.T) {
+	const mb = 1024 * 1024
+	healthy := performance.Snapshot{
+		Samples: 12, P50: 12 * time.Millisecond, P95: 40 * time.Millisecond, P99: 80 * time.Millisecond,
+		HeapInUse: 20 * mb, Sys: 60 * mb, PeakSys: 70 * mb,
+		Startup: 120 * time.Millisecond, BinarySize: 15 * mb,
+		JSGzipped: 32771, CSSGzipped: 7758,
+	}
+	breached := healthy
+	breached.P95 = 150 * time.Millisecond
+	breached.Sys = 200 * mb
+	breached.PeakSys = 300 * mb
+
+	type want struct {
+		status   string
+		class    string
+		observed string // substring; "" skips
+	}
+	tests := []struct {
+		name string
+		snap performance.Snapshot
+		rows map[string]want // keyed by Label
+	}{
+		{
+			name: "nothing measured yet",
+			snap: performance.Snapshot{},
+			rows: map[string]want{
+				"P50 response": {status: "unmeasured", class: "Monitored", observed: "—"},
+				"P95 response": {status: "unmeasured", class: "Monitored"},
+				"Startup":      {status: "unmeasured", class: "Monitored"},
+				"Binary size":  {status: "unmeasured", class: "Enforced"},
+				"JavaScript":   {status: "unmeasured", class: "Enforced"},
+				"Total page":   {status: "unmeasured", class: "Aspirational", observed: "—"},
+			},
+		},
+		{
+			name: "healthy instance passes every measured budget",
+			snap: healthy,
+			rows: map[string]want{
+				"P50 response": {status: "pass", class: "Monitored", observed: "12ms"},
+				"P95 response": {status: "pass", class: "Monitored", observed: "40ms"},
+				"P99 response": {status: "pass", class: "Monitored", observed: "80ms"},
+				"Binary size":  {status: "pass", class: "Enforced", observed: "15 MB"},
+				"Memory":       {status: "pass", class: "Monitored", observed: "60 MB"},
+				"Peak memory":  {status: "pass", class: "Monitored", observed: "70 MB"},
+				"Startup":      {status: "pass", class: "Monitored", observed: "120ms"},
+				"JavaScript":   {status: "pass", class: "Enforced", observed: "32.0 KB"},
+				"CSS":          {status: "pass", class: "Enforced", observed: "7.6 KB"},
+				"Total page":   {status: "unmeasured", class: "Aspirational"},
+			},
+		},
+		{
+			name: "breaches are reported, not hidden",
+			snap: breached,
+			rows: map[string]want{
+				"P95 response": {status: "fail", class: "Monitored", observed: "150ms"},
+				"P50 response": {status: "pass", class: "Monitored"},
+				"Memory":       {status: "fail", class: "Monitored", observed: "200 MB"},
+				"Peak memory":  {status: "fail", class: "Monitored", observed: "300 MB"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stats := PerfBudgetStats(tt.snap)
+			if len(stats) != 10 {
+				t.Fatalf("PerfBudgetStats returned %d rows, want 10", len(stats))
+			}
+			byLabel := map[string]pages.BudgetStat{}
+			for _, s := range stats {
+				byLabel[s.Label] = s
+				if s.Budget == "" || s.Class == "" || s.Status == "" || s.Observed == "" {
+					t.Errorf("row %q incomplete: %+v", s.Label, s)
+				}
+			}
+			for label, w := range tt.rows {
+				row, ok := byLabel[label]
+				if !ok {
+					t.Errorf("missing row %q", label)
+					continue
+				}
+				if row.Status != w.status {
+					t.Errorf("%s: Status = %q, want %q (observed %q)", label, row.Status, w.status, row.Observed)
+				}
+				if row.Class != w.class {
+					t.Errorf("%s: Class = %q, want %q", label, row.Class, w.class)
+				}
+				if w.observed != "" && !strings.Contains(row.Observed, w.observed) {
+					t.Errorf("%s: Observed = %q, want it to contain %q", label, row.Observed, w.observed)
+				}
+			}
+		})
+	}
+}
+
+// TestFormatObservedDuration pins the observed-column units: tenth-of-a-
+// millisecond rounding, and a floor label instead of "0s" for readings the
+// resolution cannot express (static files serve in tens of microseconds).
+func TestFormatObservedDuration(t *testing.T) {
+	tests := []struct {
+		in   time.Duration
+		want string
+	}{
+		{0, "<0.1ms"},
+		{40 * time.Microsecond, "<0.1ms"},
+		{100 * time.Microsecond, "100µs"},
+		{12340 * time.Microsecond, "12.3ms"},
+		{12 * time.Millisecond, "12ms"},
+		{1500 * time.Millisecond, "1.5s"},
+	}
+	for _, tt := range tests {
+		if got := formatObservedDuration(tt.in); got != tt.want {
+			t.Errorf("formatObservedDuration(%v) = %q, want %q", tt.in, got, tt.want)
 		}
 	}
 }

--- a/internal/middleware/metrics.go
+++ b/internal/middleware/metrics.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"fmt"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -78,19 +79,36 @@ var (
 	)
 )
 
-// responseWriter wraps http.ResponseWriter to capture status code and bytes written
+// responseWriter wraps http.ResponseWriter to capture status code and bytes
+// written, and to stamp Server-Timing the moment headers are committed —
+// the handler's time to first byte, visible in any browser's devtools
+// (ADR-034). Headers cannot change once the body streams, so the stamp
+// rides the first WriteHeader or Write, whichever comes first.
 type responseWriter struct {
 	http.ResponseWriter
 	statusCode   int
 	bytesWritten int
+	start        time.Time
+	wroteHeader  bool
 }
 
 func (rw *responseWriter) WriteHeader(code int) {
+	if rw.wroteHeader {
+		return
+	}
+	rw.wroteHeader = true
 	rw.statusCode = code
+	if !rw.start.IsZero() {
+		ms := float64(time.Since(rw.start).Microseconds()) / 1000
+		rw.Header().Set("Server-Timing", fmt.Sprintf("app;dur=%.1f", ms))
+	}
 	rw.ResponseWriter.WriteHeader(code)
 }
 
 func (rw *responseWriter) Write(b []byte) (int, error) {
+	if !rw.wroteHeader {
+		rw.WriteHeader(http.StatusOK)
+	}
 	n, err := rw.ResponseWriter.Write(b)
 	rw.bytesWritten += n
 	return n, err
@@ -107,6 +125,7 @@ func Metrics(next http.Handler) http.Handler {
 		ww := &responseWriter{
 			ResponseWriter: w,
 			statusCode:     http.StatusOK,
+			start:          start,
 		}
 
 		// Get route pattern (e.g., /api/posts/{id})
@@ -129,6 +148,9 @@ func Metrics(next http.Handler) http.Handler {
 		httpRequestsTotal.WithLabelValues(r.Method, routePattern, status).Inc()
 		httpRequestDuration.WithLabelValues(r.Method, routePattern, status).Observe(durationSeconds)
 		httpResponseSize.WithLabelValues(r.Method, routePattern).Observe(float64(ww.bytesWritten))
+
+		// Feed the process observer (landing page observed column, ADR-034)
+		performance.Default.RecordLatency(duration)
 
 		// Check performance budgets
 		checkPerformanceBudget(duration, routePattern, r.Method)
@@ -172,6 +194,7 @@ func getRoutePattern(r *http.Request) string {
 
 // UpdateMemoryMetrics updates memory usage metrics
 func UpdateMemoryMetrics() {
+	performance.Default.ObserveMemory() // advance the peak high-water mark (ADR-034)
 	stats := performance.GetMemoryStats()
 
 	if allocMB, ok := stats["alloc_mb"].(float64); ok {

--- a/internal/middleware/metrics_test.go
+++ b/internal/middleware/metrics_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strings"
 	"sync"
 	"testing"
@@ -220,5 +221,54 @@ func TestMetrics_SlowRequestLogged(t *testing.T) {
 	})).ServeHTTP(httptest.NewRecorder(), slow)
 	if !strings.Contains(logged(), "slow request detected") {
 		t.Error("request over the p95 budget must log a slow-request warning")
+	}
+}
+
+// TestMetrics_ServerTiming pins the Server-Timing header (ADR-034): the
+// handler's time to first byte, committed with the headers whether the
+// handler calls WriteHeader explicitly or writes the body straight away.
+func TestMetrics_ServerTiming(t *testing.T) {
+	tests := []struct {
+		name string
+		next http.HandlerFunc
+	}{
+		{
+			name: "explicit WriteHeader",
+			next: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusCreated)
+				_, _ = w.Write([]byte("ok"))
+			},
+		},
+		{
+			name: "implicit header via Write",
+			next: func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte("ok"))
+			},
+		},
+	}
+	re := regexp.MustCompile(`^app;dur=\d+(\.\d+)?$`)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			Metrics(tt.next).ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/timing", nil))
+			got := w.Header().Get("Server-Timing")
+			if !re.MatchString(got) {
+				t.Errorf("Server-Timing = %q, want app;dur=<ms>", got)
+			}
+		})
+	}
+}
+
+// TestMetrics_RecordsLatencyForObserver pins the feed for the landing page's
+// observed column: every request through the middleware lands one sample
+// in the process observer.
+func TestMetrics_RecordsLatencyForObserver(t *testing.T) {
+	before := performance.Default.Snapshot().Samples
+	w := httptest.NewRecorder()
+	Metrics(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})).ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/observed", nil))
+	if after := performance.Default.Snapshot().Samples; after != before+1 {
+		t.Errorf("observer samples = %d, want %d (one per request)", after, before+1)
 	}
 }

--- a/internal/performance/budgets.go
+++ b/internal/performance/budgets.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
 	"time"
 )
@@ -196,4 +197,22 @@ func GetMemoryStats() map[string]interface{} {
 		"heap_objects":    m.HeapObjects,
 		"stack_in_use_mb": float64(m.StackInuse) / 1024 / 1024,
 	}
+}
+
+// ShippedJS and ShippedCSS are the assets the base layout ships, relative to
+// the static root. They are stated once here so the CI gate
+// (scripts/check-asset-budgets) and the runtime observer (ADR-034) measure
+// exactly the same files.
+var (
+	ShippedJS  = []string{"js/htmx.min.js", "js/alpine.min.js", "js/app.js"}
+	ShippedCSS = []string{"css/app.css"}
+)
+
+// ShippedAssetPaths joins the relative asset list onto a static root.
+func ShippedAssetPaths(staticDir string, rel []string) []string {
+	out := make([]string, 0, len(rel))
+	for _, r := range rel {
+		out = append(out, filepath.Join(staticDir, filepath.FromSlash(r)))
+	}
+	return out
 }

--- a/internal/performance/observed.go
+++ b/internal/performance/observed.go
@@ -1,0 +1,216 @@
+package performance
+
+import (
+	"os"
+	"runtime"
+	"sort"
+	"sync"
+	"time"
+)
+
+// This file is the observation side of ADR-000 (ADR-034): what the running
+// process can measure about itself, so the landing page shows budget vs.
+// observed instead of the budget alone. Everything here is per-process and
+// since boot — a live reading, not an SLO — and every value has an honest
+// zero meaning "not measured", which the UI must render as such.
+
+// Class is the ADR-000 §1 classification of a budget.
+type Class string
+
+const (
+	ClassEnforced     Class = "Enforced"     // task ci fails on violation
+	ClassMonitored    Class = "Monitored"    // measured; informs, does not gate
+	ClassAspirational Class = "Aspirational" // no measurement exists yet
+)
+
+// DefaultLatencyWindow is how many recent requests the percentiles cover.
+const DefaultLatencyWindow = 4096
+
+// LatencyPercentiles is a nearest-rank summary of the recent window.
+type LatencyPercentiles struct {
+	P50, P95, P99 time.Duration
+	Samples       int // 0 means nothing has been measured
+}
+
+// LatencyRecorder keeps the last N request durations in a ring so the
+// percentiles reflect recent traffic on this process rather than its whole
+// lifetime. Safe for concurrent use.
+type LatencyRecorder struct {
+	mu      sync.Mutex
+	samples []time.Duration
+	next    int
+	filled  int
+}
+
+// NewLatencyRecorder returns a recorder covering the last size requests.
+func NewLatencyRecorder(size int) *LatencyRecorder {
+	if size < 1 {
+		size = 1
+	}
+	return &LatencyRecorder{samples: make([]time.Duration, size)}
+}
+
+// Record adds one request duration, evicting the oldest once the ring is full.
+func (r *LatencyRecorder) Record(d time.Duration) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.samples[r.next] = d
+	r.next = (r.next + 1) % len(r.samples)
+	if r.filled < len(r.samples) {
+		r.filled++
+	}
+}
+
+// Percentiles returns nearest-rank p50/p95/p99 over the recorded window.
+func (r *LatencyRecorder) Percentiles() LatencyPercentiles {
+	r.mu.Lock()
+	sorted := make([]time.Duration, r.filled)
+	copy(sorted, r.samples[:r.filled])
+	r.mu.Unlock()
+
+	n := len(sorted)
+	if n == 0 {
+		return LatencyPercentiles{}
+	}
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	rank := func(p float64) time.Duration {
+		idx := int(float64(n)*p+0.999999) - 1 // ceil(p*n) - 1, nearest-rank
+		if idx < 0 {
+			idx = 0
+		}
+		if idx >= n {
+			idx = n - 1
+		}
+		return sorted[idx]
+	}
+	return LatencyPercentiles{P50: rank(0.50), P95: rank(0.95), P99: rank(0.99), Samples: n}
+}
+
+// Snapshot is one reading of the process against the ADR-000 budgets. Zero
+// values mean "not measured" (no requests yet, startup not recorded, assets
+// or executable not found) — never "zero and therefore passing".
+type Snapshot struct {
+	Uptime     time.Duration
+	Goroutines int
+
+	// Request latency over the recent window (see DefaultLatencyWindow).
+	Samples       int
+	P50, P95, P99 time.Duration
+
+	// Memory from runtime.MemStats: heap in use, memory obtained from the OS,
+	// and the high-water mark of the latter since boot.
+	HeapInUse, Sys, PeakSys uint64
+
+	// Startup is process start → listening socket, recorded once by main.
+	Startup time.Duration
+
+	// BinarySize is the running executable's size on disk.
+	BinarySize int64
+
+	// Gzipped totals of the shipped assets (same lists the CI gate uses).
+	JSGzipped, CSSGzipped int64
+}
+
+// Observer aggregates the per-process measurements. One lives in Default,
+// fed by the metrics middleware and main; tests construct their own.
+type Observer struct {
+	latency   *LatencyRecorder
+	startedAt time.Time
+	staticDir string
+
+	mu      sync.Mutex
+	startup time.Duration
+	peakSys uint64
+
+	assetsOnce sync.Once
+	jsGz       int64
+	cssGz      int64
+
+	binaryOnce sync.Once
+	binarySize int64
+}
+
+// Default is the process-wide observer.
+var Default = NewObserver("web/static")
+
+// NewObserver returns an observer measuring the shipped assets under
+// staticDir (the directory the file server serves).
+func NewObserver(staticDir string) *Observer {
+	return &Observer{
+		latency:   NewLatencyRecorder(DefaultLatencyWindow),
+		startedAt: time.Now(),
+		staticDir: staticDir,
+	}
+}
+
+// RecordLatency adds one completed request's duration.
+func (o *Observer) RecordLatency(d time.Duration) {
+	o.latency.Record(d)
+}
+
+// RecordStartup records process start → listening. Startup happens once, so
+// the first call wins and later calls are ignored.
+func (o *Observer) RecordStartup(d time.Duration) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if o.startup == 0 && d > 0 {
+		o.startup = d
+	}
+}
+
+// ObserveMemory reads the runtime memory stats and advances the high-water
+// mark; the periodic metrics collector calls it so the peak is tracked even
+// when nobody is looking at the page.
+func (o *Observer) ObserveMemory() (heapInUse, sys, peakSys uint64) {
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if m.Sys > o.peakSys {
+		o.peakSys = m.Sys
+	}
+	return m.HeapInuse, m.Sys, o.peakSys
+}
+
+// Snapshot takes one reading. Asset and executable sizes are measured on the
+// first call and cached: they cannot change while the process runs.
+func (o *Observer) Snapshot() Snapshot {
+	heap, sys, peak := o.ObserveMemory()
+	p := o.latency.Percentiles()
+
+	o.assetsOnce.Do(func() {
+		if js, err := GzippedTotal(ShippedAssetPaths(o.staticDir, ShippedJS)...); err == nil {
+			o.jsGz = js
+		}
+		if css, err := GzippedTotal(ShippedAssetPaths(o.staticDir, ShippedCSS)...); err == nil {
+			o.cssGz = css
+		}
+	})
+	o.binaryOnce.Do(func() {
+		if exe, err := os.Executable(); err == nil {
+			if info, err := os.Stat(exe); err == nil {
+				o.binarySize = info.Size()
+			}
+		}
+	})
+
+	o.mu.Lock()
+	startup := o.startup
+	o.mu.Unlock()
+
+	return Snapshot{
+		Uptime:     time.Since(o.startedAt),
+		Goroutines: runtime.NumGoroutine(),
+		Samples:    p.Samples,
+		P50:        p.P50,
+		P95:        p.P95,
+		P99:        p.P99,
+		HeapInUse:  heap,
+		Sys:        sys,
+		PeakSys:    peak,
+		Startup:    startup,
+		BinarySize: o.binarySize,
+		JSGzipped:  o.jsGz,
+		CSSGzipped: o.cssGz,
+	}
+}

--- a/internal/performance/observed_test.go
+++ b/internal/performance/observed_test.go
@@ -1,0 +1,154 @@
+package performance
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestLatencyRecorder_Percentiles pins the nearest-rank percentiles over a
+// bounded ring: an empty recorder reports nothing (the UI must say
+// "unmeasured", not "0ms"), a full sequence yields the textbook ranks, and
+// once the ring wraps only the most recent window counts.
+func TestLatencyRecorder_Percentiles(t *testing.T) {
+	tests := []struct {
+		name    string
+		size    int
+		samples []time.Duration
+		want    LatencyPercentiles
+	}{
+		{
+			name: "empty recorder reports zero samples",
+			size: 8,
+			want: LatencyPercentiles{},
+		},
+		{
+			name:    "single sample is every percentile",
+			size:    8,
+			samples: []time.Duration{7 * time.Millisecond},
+			want:    LatencyPercentiles{P50: 7 * time.Millisecond, P95: 7 * time.Millisecond, P99: 7 * time.Millisecond, Samples: 1},
+		},
+		{
+			name:    "1..100ms yields nearest-rank 50/95/99",
+			size:    100,
+			samples: ramp(100),
+			want:    LatencyPercentiles{P50: 50 * time.Millisecond, P95: 95 * time.Millisecond, P99: 99 * time.Millisecond, Samples: 100},
+		},
+		{
+			name:    "ring keeps only the newest window",
+			size:    10,
+			samples: ramp(100), // last ten are 91..100ms
+			want:    LatencyPercentiles{P50: 95 * time.Millisecond, P95: 100 * time.Millisecond, P99: 100 * time.Millisecond, Samples: 10},
+		},
+		{
+			name:    "unsorted input is sorted before ranking",
+			size:    8,
+			samples: []time.Duration{9 * time.Millisecond, 1 * time.Millisecond, 5 * time.Millisecond, 3 * time.Millisecond},
+			want:    LatencyPercentiles{P50: 3 * time.Millisecond, P95: 9 * time.Millisecond, P99: 9 * time.Millisecond, Samples: 4},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewLatencyRecorder(tt.size)
+			for _, d := range tt.samples {
+				r.Record(d)
+			}
+			if got := r.Percentiles(); got != tt.want {
+				t.Errorf("Percentiles() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func ramp(n int) []time.Duration {
+	out := make([]time.Duration, 0, n)
+	for i := 1; i <= n; i++ {
+		out = append(out, time.Duration(i)*time.Millisecond)
+	}
+	return out
+}
+
+// TestObserver_Snapshot covers what the process can measure about itself:
+// shipped-asset sizes from the static dir (gzipped, same lists CI gates),
+// a startup duration recorded once, a memory high-water mark that never
+// falls, and honest zeros when a measurement is unavailable.
+func TestObserver_Snapshot(t *testing.T) {
+	staticDir := t.TempDir()
+	mustWrite(t, filepath.Join(staticDir, "js", "htmx.min.js"), 4000)
+	mustWrite(t, filepath.Join(staticDir, "js", "alpine.min.js"), 3000)
+	mustWrite(t, filepath.Join(staticDir, "js", "app.js"), 500)
+	mustWrite(t, filepath.Join(staticDir, "css", "app.css"), 2500)
+
+	o := NewObserver(staticDir)
+	o.RecordStartup(120 * time.Millisecond)
+	o.RecordStartup(900 * time.Millisecond) // second call is ignored: startup happens once
+	o.RecordLatency(20 * time.Millisecond)
+	o.RecordLatency(40 * time.Millisecond)
+
+	snap := o.Snapshot()
+	if snap.Startup != 120*time.Millisecond {
+		t.Errorf("Startup = %v, want 120ms (first RecordStartup wins)", snap.Startup)
+	}
+	if snap.Samples != 2 || snap.P50 != 20*time.Millisecond || snap.P99 != 40*time.Millisecond {
+		t.Errorf("latency snapshot = p50 %v p99 %v n=%d, want p50 20ms p99 40ms n=2", snap.P50, snap.P99, snap.Samples)
+	}
+	if snap.JSGzipped <= 0 || snap.JSGzipped >= 7500 {
+		t.Errorf("JSGzipped = %d, want a gzipped total below the 7500 raw bytes", snap.JSGzipped)
+	}
+	if snap.CSSGzipped <= 0 || snap.CSSGzipped >= 2500 {
+		t.Errorf("CSSGzipped = %d, want a gzipped total below the 2500 raw bytes", snap.CSSGzipped)
+	}
+	if snap.BinarySize <= 0 {
+		t.Errorf("BinarySize = %d, want the running executable's size", snap.BinarySize)
+	}
+	if snap.Sys == 0 || snap.HeapInUse == 0 {
+		t.Errorf("memory snapshot = sys %d heap %d, want non-zero", snap.Sys, snap.HeapInUse)
+	}
+	if snap.PeakSys < snap.Sys {
+		t.Errorf("PeakSys = %d < Sys = %d; the high-water mark must never trail the current value", snap.PeakSys, snap.Sys)
+	}
+	if snap.Uptime <= 0 || snap.Goroutines <= 0 {
+		t.Errorf("Uptime = %v, Goroutines = %d, want positive", snap.Uptime, snap.Goroutines)
+	}
+
+	// Missing assets: zeros, no panic, everything else still measured.
+	empty := NewObserver(filepath.Join(staticDir, "nope"))
+	es := empty.Snapshot()
+	if es.JSGzipped != 0 || es.CSSGzipped != 0 {
+		t.Errorf("missing static dir: JS %d CSS %d, want 0 (unmeasured)", es.JSGzipped, es.CSSGzipped)
+	}
+	if es.Startup != 0 || es.Samples != 0 {
+		t.Errorf("fresh observer: Startup %v Samples %d, want zero (unmeasured)", es.Startup, es.Samples)
+	}
+}
+
+func mustWrite(t *testing.T, path string, size int) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, size)
+	for i := range buf {
+		buf[i] = byte('a' + i%26)
+	}
+	if err := os.WriteFile(path, buf, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestShippedAssetPaths pins that the runtime observer and the CI gate
+// measure the same files: one list, joined onto whichever static root the
+// caller has.
+func TestShippedAssetPaths(t *testing.T) {
+	got := ShippedAssetPaths("web/static", ShippedJS)
+	want := []string{"web/static/js/htmx.min.js", "web/static/js/alpine.min.js", "web/static/js/app.js"}
+	if len(got) != len(want) {
+		t.Fatalf("ShippedAssetPaths = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("ShippedAssetPaths[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/clownware/go-performance-starter/internal/database"
 	"github.com/clownware/go-performance-starter/internal/handler"
 	mw "github.com/clownware/go-performance-starter/internal/middleware"
+	"github.com/clownware/go-performance-starter/internal/performance"
 	"github.com/clownware/go-performance-starter/internal/repository/postgres"
 	"github.com/clownware/go-performance-starter/internal/view"
 	"github.com/clownware/go-performance-starter/internal/view/pages"
@@ -317,7 +318,7 @@ func homeHandler(w http.ResponseWriter, r *http.Request) {
 	props := pages.HomePageProps{
 		BaseProps: base,
 		Nodes:     handler.ExplainerNodes(),
-		Stats:     handler.PerfBudgetStats(),
+		Stats:     handler.PerfBudgetStats(performance.Default.Snapshot()),
 	}
 	if err := view.Render(w, r, http.StatusOK, pages.HomePage(props)); err != nil {
 		slog.Error("Failed to render home page", "error", err)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -348,6 +348,16 @@ func TestServer_HomeExplainer(t *testing.T) {
 			t.Errorf("budget grid missing %q (rendered from internal/performance)", want)
 		}
 	}
+	// ADR-034: every budget row also shows what this instance observed and
+	// which ADR-000 class it belongs to — the page proves, it does not assert.
+	if got := strings.Count(body, `data-testid="perf-observed"`); got != 10 {
+		t.Errorf("budget grid renders %d observed values, want 10", got)
+	}
+	for _, want := range []string{"Enforced", "Monitored", "Aspirational", "Server-Timing"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("budget grid missing %q (ADR-000 classification / ADR-034 proof)", want)
+		}
+	}
 }
 
 // TestServer_CloseIsIdempotentAndKeepsServing pins the #117 lifecycle

--- a/internal/view/pages/home.templ
+++ b/internal/view/pages/home.templ
@@ -43,11 +43,16 @@ type ExplainerSource struct {
 	Snippet string
 }
 
-// BudgetStat is one ADR-000 budget, rendered from internal/performance.
+// BudgetStat is one ADR-000 budget, rendered from internal/performance,
+// next to what this process observed (ADR-034). Status is pass, fail or
+// unmeasured; Class is the ADR-000 §1 tier (Enforced/Monitored/Aspirational).
 type BudgetStat struct {
-	Label string
-	Value string
-	Note  string
+	Label    string
+	Budget   string
+	Observed string
+	Status   string
+	Class    string
+	Note     string
 }
 
 // surface is one entry in the home directory of demo surfaces.
@@ -189,27 +194,65 @@ templ explainer(nodes []ExplainerNode) {
 	</section>
 }
 
-// perfStats renders the ADR-000 budgets. The values arrive from the handler,
-// which reads internal/performance at request time — this component never
-// hardcodes a number, which is the point it demonstrates.
+// statusClasses maps a budget row's status to role-token styling (ADR-029).
+func statusClasses(status string) string {
+	switch status {
+	case "pass":
+		return "bg-success/10 text-success"
+	case "fail":
+		return "bg-danger/10 text-danger"
+	default:
+		return "bg-surface-hover text-muted-foreground"
+	}
+}
+
+func statusLabel(status string) string {
+	switch status {
+	case "pass":
+		return "within budget"
+	case "fail":
+		return "over budget"
+	default:
+		return "not measured"
+	}
+}
+
+// perfStats renders the ADR-000 budgets next to what this process observed
+// (ADR-034). Budgets arrive from the handler, which reads
+// internal/performance at request time; observations come from the process
+// observer — this component never hardcodes a number, which is the point.
 templ perfStats(stats []BudgetStat) {
 	<section id="budgets" data-testid="perf-stats" aria-labelledby="budgets-heading" class="max-w-3xl mx-auto pb-12 scroll-mt-20">
 		<header class="mb-6 text-center">
 			<p class="text-sm uppercase tracking-wide text-muted-foreground mb-2">Live performance budgets</p>
-			<h2 id="budgets-heading" class="text-2xl font-bold mb-3">What CI refuses to ship past</h2>
+			<h2 id="budgets-heading" class="text-2xl font-bold mb-3">Budget vs. observed, on this instance</h2>
 			<p class="text-muted-foreground max-w-xl mx-auto">
-				Rendered on this request from the constants in
+				Budgets are the constants in
 				<code class="text-xs px-1 rounded bg-primary/10 text-link">internal/performance/budgets.go</code>
-				— the same values <code class="text-xs px-1 rounded bg-primary/10 text-link">task ci</code> enforces. Change the constant, and this grid changes; no template edit involved.
+				— the same values <code class="text-xs px-1 rounded bg-primary/10 text-link">task ci</code> enforces.
+				Observed values are read from this process on every request: latency over the recent window, memory from the runtime, startup from main, assets and binary as shipped.
+			</p>
+			<p class="mt-3 text-xs text-muted-foreground max-w-xl mx-auto">
+				<span class="font-medium text-foreground">Enforced</span> fails the build ·
+				<span class="font-medium text-foreground">Monitored</span> is measured but does not gate ·
+				<span class="font-medium text-foreground">Aspirational</span> has no measurement yet (ADR-000 §1).
+				This response carries a <code class="text-xs px-1 rounded bg-primary/10 text-link">Server-Timing</code> header too — open your devtools' timing tab.
 			</p>
 		</header>
-		<dl class="grid gap-3 grid-cols-2 sm:grid-cols-3 lg:grid-cols-5">
+		<dl class="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
 			for _, s := range stats {
-				<div data-testid="perf-stat" class="bg-surface rounded-lg shadow-sm p-4 text-center">
-					<dt class="text-xs uppercase tracking-wide text-muted-foreground">{ s.Label }</dt>
-					<dd class="mt-1">
-						<span class="block text-xl font-semibold text-foreground">{ "< " + s.Value }</span>
-						<span class="block text-xs text-muted-foreground mt-1">{ s.Note }</span>
+				<div data-testid="perf-stat" class="bg-surface rounded-lg shadow-sm p-4">
+					<dt class="flex items-center justify-between gap-2">
+						<span class="text-xs uppercase tracking-wide text-muted-foreground">{ s.Label }</span>
+						<span class="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded border border-border text-muted-foreground">{ s.Class }</span>
+					</dt>
+					<dd class="mt-2">
+						<div class="flex items-baseline gap-3">
+							<span data-testid="perf-observed" class="text-xl font-semibold text-foreground tabular-nums">{ s.Observed }</span>
+							<span class="text-sm text-muted-foreground tabular-nums">{ "< " + s.Budget }</span>
+						</div>
+						<span class={ "inline-block mt-2 text-xs px-2 py-0.5 rounded-full " + statusClasses(s.Status) }>{ statusLabel(s.Status) }</span>
+						<span class="block text-xs text-muted-foreground mt-2">{ s.Note }</span>
 					</dd>
 				</div>
 			}

--- a/internal/view/pages/home_templ.go
+++ b/internal/view/pages/home_templ.go
@@ -51,11 +51,16 @@ type ExplainerSource struct {
 	Snippet string
 }
 
-// BudgetStat is one ADR-000 budget, rendered from internal/performance.
+// BudgetStat is one ADR-000 budget, rendered from internal/performance,
+// next to what this process observed (ADR-034). Status is pass, fail or
+// unmeasured; Class is the ADR-000 §1 tier (Enforced/Monitored/Aspirational).
 type BudgetStat struct {
-	Label string
-	Value string
-	Note  string
+	Label    string
+	Budget   string
+	Observed string
+	Status   string
+	Class    string
+	Note     string
 }
 
 // surface is one entry in the home directory of demo surfaces.
@@ -150,7 +155,7 @@ func HomePage(props HomePageProps) templ.Component {
 				var templ_7745c5c3_Var3 templ.SafeURL
 				templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(s.Href))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 114, Col: 33}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 119, Col: 33}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 				if templ_7745c5c3_Err != nil {
@@ -163,7 +168,7 @@ func HomePage(props HomePageProps) templ.Component {
 				var templ_7745c5c3_Var4 string
 				templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(s.Title)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 117, Col: 63}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 122, Col: 63}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 				if templ_7745c5c3_Err != nil {
@@ -176,7 +181,7 @@ func HomePage(props HomePageProps) templ.Component {
 				var templ_7745c5c3_Var5 string
 				templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(s.Description)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 118, Col: 61}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 123, Col: 61}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 				if templ_7745c5c3_Err != nil {
@@ -253,7 +258,7 @@ func explainer(nodes []ExplainerNode) templ.Component {
 			var templ_7745c5c3_Var7 templ.SafeURL
 			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL("#" + n.Anchor))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 149, Col: 45}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 154, Col: 45}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 			if templ_7745c5c3_Err != nil {
@@ -266,7 +271,7 @@ func explainer(nodes []ExplainerNode) templ.Component {
 			var templ_7745c5c3_Var8 string
 			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d · %s", n.Step, n.QuizTopic))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 150, Col: 53}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 155, Col: 53}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 			if templ_7745c5c3_Err != nil {
@@ -289,7 +294,7 @@ func explainer(nodes []ExplainerNode) templ.Component {
 			var templ_7745c5c3_Var9 string
 			templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.ResolveAttributeValue(n.Anchor)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 158, Col: 21}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 163, Col: 21}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var9)
 			if templ_7745c5c3_Err != nil {
@@ -302,7 +307,7 @@ func explainer(nodes []ExplainerNode) templ.Component {
 			var templ_7745c5c3_Var10 string
 			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", n.Step))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 160, Col: 167}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 165, Col: 167}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 			if templ_7745c5c3_Err != nil {
@@ -315,7 +320,7 @@ func explainer(nodes []ExplainerNode) templ.Component {
 			var templ_7745c5c3_Var11 string
 			templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("Step %d: ", n.Step))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 163, Col: 64}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 168, Col: 64}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 			if templ_7745c5c3_Err != nil {
@@ -328,7 +333,7 @@ func explainer(nodes []ExplainerNode) templ.Component {
 			var templ_7745c5c3_Var12 string
 			templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(n.Title)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 164, Col: 17}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 169, Col: 17}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 			if templ_7745c5c3_Err != nil {
@@ -341,7 +346,7 @@ func explainer(nodes []ExplainerNode) templ.Component {
 			var templ_7745c5c3_Var13 string
 			templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(n.Summary)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 166, Col: 64}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 171, Col: 64}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 			if templ_7745c5c3_Err != nil {
@@ -359,7 +364,7 @@ func explainer(nodes []ExplainerNode) templ.Component {
 				var templ_7745c5c3_Var14 string
 				templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(p)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 168, Col: 43}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 173, Col: 43}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 				if templ_7745c5c3_Err != nil {
@@ -377,7 +382,7 @@ func explainer(nodes []ExplainerNode) templ.Component {
 			var templ_7745c5c3_Var15 string
 			templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(n.Source.File)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 172, Col: 78}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 177, Col: 78}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
 			if templ_7745c5c3_Err != nil {
@@ -390,7 +395,7 @@ func explainer(nodes []ExplainerNode) templ.Component {
 			var templ_7745c5c3_Var16 string
 			templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(n.Source.Snippet)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 174, Col: 96}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 179, Col: 96}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
 			if templ_7745c5c3_Err != nil {
@@ -403,7 +408,7 @@ func explainer(nodes []ExplainerNode) templ.Component {
 			var templ_7745c5c3_Var17 templ.SafeURL
 			templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(n.ADR.Href))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 177, Col: 43}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 182, Col: 43}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 			if templ_7745c5c3_Err != nil {
@@ -416,7 +421,7 @@ func explainer(nodes []ExplainerNode) templ.Component {
 			var templ_7745c5c3_Var18 string
 			templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(n.ADR.Label)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 177, Col: 135}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 182, Col: 135}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
 			if templ_7745c5c3_Err != nil {
@@ -429,7 +434,7 @@ func explainer(nodes []ExplainerNode) templ.Component {
 			var templ_7745c5c3_Var19 templ.SafeURL
 			templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(quizTopicURL(n.QuizTopic)))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 178, Col: 58}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 183, Col: 58}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
 			if templ_7745c5c3_Err != nil {
@@ -442,7 +447,7 @@ func explainer(nodes []ExplainerNode) templ.Component {
 			var templ_7745c5c3_Var20 string
 			templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs("Quiz yourself on " + n.QuizTopic + " →")
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 178, Col: 139}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 183, Col: 139}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
 			if templ_7745c5c3_Err != nil {
@@ -461,9 +466,33 @@ func explainer(nodes []ExplainerNode) templ.Component {
 	})
 }
 
-// perfStats renders the ADR-000 budgets. The values arrive from the handler,
-// which reads internal/performance at request time — this component never
-// hardcodes a number, which is the point it demonstrates.
+// statusClasses maps a budget row's status to role-token styling (ADR-029).
+func statusClasses(status string) string {
+	switch status {
+	case "pass":
+		return "bg-success/10 text-success"
+	case "fail":
+		return "bg-danger/10 text-danger"
+	default:
+		return "bg-surface-hover text-muted-foreground"
+	}
+}
+
+func statusLabel(status string) string {
+	switch status {
+	case "pass":
+		return "within budget"
+	case "fail":
+		return "over budget"
+	default:
+		return "not measured"
+	}
+}
+
+// perfStats renders the ADR-000 budgets next to what this process observed
+// (ADR-034). Budgets arrive from the handler, which reads
+// internal/performance at request time; observations come from the process
+// observer — this component never hardcodes a number, which is the point.
 func perfStats(stats []BudgetStat) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
@@ -485,56 +514,117 @@ func perfStats(stats []BudgetStat) templ.Component {
 			templ_7745c5c3_Var21 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "<section id=\"budgets\" data-testid=\"perf-stats\" aria-labelledby=\"budgets-heading\" class=\"max-w-3xl mx-auto pb-12 scroll-mt-20\"><header class=\"mb-6 text-center\"><p class=\"text-sm uppercase tracking-wide text-muted-foreground mb-2\">Live performance budgets</p><h2 id=\"budgets-heading\" class=\"text-2xl font-bold mb-3\">What CI refuses to ship past</h2><p class=\"text-muted-foreground max-w-xl mx-auto\">Rendered on this request from the constants in <code class=\"text-xs px-1 rounded bg-primary/10 text-link\">internal/performance/budgets.go</code> — the same values <code class=\"text-xs px-1 rounded bg-primary/10 text-link\">task ci</code> enforces. Change the constant, and this grid changes; no template edit involved.</p></header><dl class=\"grid gap-3 grid-cols-2 sm:grid-cols-3 lg:grid-cols-5\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "<section id=\"budgets\" data-testid=\"perf-stats\" aria-labelledby=\"budgets-heading\" class=\"max-w-3xl mx-auto pb-12 scroll-mt-20\"><header class=\"mb-6 text-center\"><p class=\"text-sm uppercase tracking-wide text-muted-foreground mb-2\">Live performance budgets</p><h2 id=\"budgets-heading\" class=\"text-2xl font-bold mb-3\">Budget vs. observed, on this instance</h2><p class=\"text-muted-foreground max-w-xl mx-auto\">Budgets are the constants in <code class=\"text-xs px-1 rounded bg-primary/10 text-link\">internal/performance/budgets.go</code> — the same values <code class=\"text-xs px-1 rounded bg-primary/10 text-link\">task ci</code> enforces. Observed values are read from this process on every request: latency over the recent window, memory from the runtime, startup from main, assets and binary as shipped.</p><p class=\"mt-3 text-xs text-muted-foreground max-w-xl mx-auto\"><span class=\"font-medium text-foreground\">Enforced</span> fails the build · <span class=\"font-medium text-foreground\">Monitored</span> is measured but does not gate · <span class=\"font-medium text-foreground\">Aspirational</span> has no measurement yet (ADR-000 §1). This response carries a <code class=\"text-xs px-1 rounded bg-primary/10 text-link\">Server-Timing</code> header too — open your devtools' timing tab.</p></header><dl class=\"grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		for _, s := range stats {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "<div data-testid=\"perf-stat\" class=\"bg-surface rounded-lg shadow-sm p-4 text-center\"><dt class=\"text-xs uppercase tracking-wide text-muted-foreground\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "<div data-testid=\"perf-stat\" class=\"bg-surface rounded-lg shadow-sm p-4\"><dt class=\"flex items-center justify-between gap-2\"><span class=\"text-xs uppercase tracking-wide text-muted-foreground\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var22 string
 			templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs(s.Label)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 209, Col: 80}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 246, Col: 83}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "</dt><dd class=\"mt-1\"><span class=\"block text-xl font-semibold text-foreground\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "</span> <span class=\"text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded border border-border text-muted-foreground\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var23 string
-			templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs("< " + s.Value)
+			templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(s.Class)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 211, Col: 80}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 247, Col: 130}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "</span> <span class=\"block text-xs text-muted-foreground mt-1\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "</span></dt><dd class=\"mt-2\"><div class=\"flex items-baseline gap-3\"><span data-testid=\"perf-observed\" class=\"text-xl font-semibold text-foreground tabular-nums\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var24 string
-			templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(s.Note)
+			templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(s.Observed)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 212, Col: 69}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 251, Col: 112}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "</span></dd></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "</span> <span class=\"text-sm text-muted-foreground tabular-nums\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var25 string
+			templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs("< " + s.Budget)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 252, Col: 81}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "</span></div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var26 = []any{"inline-block mt-2 text-xs px-2 py-0.5 rounded-full " + statusClasses(s.Status)}
+			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var26...)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "<span class=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var27 string
+			templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var26).String())
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 1, Col: 0}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var27)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var28 string
+			templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs(statusLabel(s.Status))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 254, Col: 125}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "</span> <span class=\"block text-xs text-muted-foreground mt-2\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var29 string
+			templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.JoinStringErrs(s.Note)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/view/pages/home.templ`, Line: 255, Col: 69}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var29))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "</span></dd></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "</dl></section>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "</dl></section>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/scripts/check-asset-budgets/main.go
+++ b/scripts/check-asset-budgets/main.go
@@ -1,7 +1,8 @@
 // Command check-asset-budgets enforces the ADR-000 frontend budgets against
 // the assets the base layout actually ships (internal/view/layouts/base.templ).
-// Sizes are measured gzipped — what crosses the wire — so the budgets in
-// internal/performance are the single source of truth. Run from the repo root.
+// Sizes are measured gzipped — what crosses the wire — so the budgets AND the
+// file lists in internal/performance are the single source of truth (the
+// runtime observer measures the same files, ADR-034). Run from the repo root.
 package main
 
 import (
@@ -19,16 +20,12 @@ var checks = []struct {
 	{
 		name:   "JavaScript Bundle",
 		budget: performance.MaxJavaScriptSize,
-		files: []string{
-			"web/static/js/htmx.min.js",
-			"web/static/js/alpine.min.js",
-			"web/static/js/app.js",
-		},
+		files:  performance.ShippedAssetPaths("web/static", performance.ShippedJS),
 	},
 	{
 		name:   "CSS Bundle",
 		budget: performance.MaxCSSSize,
-		files:  []string{"web/static/css/app.css"},
+		files:  performance.ShippedAssetPaths("web/static", performance.ShippedCSS),
 	},
 }
 


### PR DESCRIPTION
## Summary

Track 2 of the demo enhancements, stacked on #128. The landing page's budgets grid stops showing ceilings alone and puts what *this process* observed next to each one.

- **Observer** (`internal/performance/observed.go`): 4096-sample latency ring (nearest-rank p50/p95/p99), runtime memory + since-boot peak, startup recorded once by `main` after the listener binds (process start → listening socket, ADR-000's definition), executable size, and gzipped shipped assets — measured from the same `ShippedJS`/`ShippedCSS` lists `scripts/check-asset-budgets` now imports (one source of truth).
- **Grid**: budget · observed · pass/fail · ADR-000 class (Enforced/Monitored/Aspirational) per row, with a legend. Unmeasured renders as "not measured", never a passing zero. Total page stays visibly Aspirational.
- **`Server-Timing: app;dur=<ms>`** on every response from the metrics middleware (handler time to first byte).
- **ADR-034** documents the decision and specifies the RLS isolation check and rate-limit demo that the next two stacked PRs deliver.

Local reading on a dev build, for flavour: p95 3.5 ms, memory 18 MB, startup 3.5 ms, binary 13.9 MB, JS 32.0 KB, CSS 7.6 KB, all within budget; Total page "not measured".

## Tests (ADR-023, written first)

- `internal/performance`: percentile ring (empty, single, ramp, wrap, unsorted), snapshot with temp static dir, shared asset paths.
- `internal/middleware`: Server-Timing on explicit and implicit header commits; observer sample recorded per request.
- `internal/handler`: observed grid statuses/classes/formatting for empty, healthy and breached snapshots; duration formatter.
- `internal/server`: home page renders 10 observed values and the classification legend.

## Verification

- `task ci` green locally.
- Ran the app credential-free and confirmed the grid and the header on the wire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)