### PR TITLE
fix(deploy): stamp the continuous-deploy image with the git describe version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,6 +49,8 @@ jobs:
       DATABASE_URL: ${{ secrets.SUPABASE_DATABASE_URL }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0 # full history + tags so git describe can name the build
 
       - name: Set up flyctl
         uses: superfly/flyctl-actions/setup-flyctl@dfdfedc86b296f5e5384f755a18bf400409a15d0 # v1.4
@@ -67,4 +69,9 @@ jobs:
       # and build config come from fly.toml, so nothing here is
       # deployment-specific.
       - name: Deploy
-        run: flyctl deploy --remote-only
+        # Stamp the image with the version the release path uses (Dockerfile
+        # ARG VERSION -> -X main.version). Without it every continuous deploy
+        # reports "dev" in /health and re-stamps asset URLs from process start,
+        # and the deploy that follows a tagged release silently replaces the
+        # tagged image with a "dev" one.
+        run: flyctl deploy --remote-only --build-arg "VERSION=$(git describe --tags --always)"


### PR DESCRIPTION
## Summary

Found while verifying the v0.9.0 release: minutes after `release.yml` deployed the tagged image, the `deploy.yml` run triggered by the release's own `versions.json` stamp commit rebuilt the image without the `VERSION` build arg and replaced it. `/health` on the demo reports `"version":"dev"` and asset URLs are stamped from process start instead of the release.

- `flyctl deploy --remote-only --build-arg "VERSION=$(git describe --tags --always)"` — the same arg `release.yml` passes.
- `fetch-depth: 0` on the checkout so `git describe` can see the tags.

After this lands, the next master deploy will report `v0.9.0-N-g<sha>` and a tagged deploy followed by a stamp commit will report `v0.9.0-1-g<sha>` rather than `dev`.

## Verification

- `task ci` green locally; the workflow YAML parses. The behaviour itself shows up on the first deploy after merge (`/health` version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)