### PR TITLE
fix(health): report the stamped build version on deployed instances

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/joho/godotenv"
 
 	"github.com/clownware/go-performance-starter/internal/config"
+	"github.com/clownware/go-performance-starter/internal/handler"
 	"github.com/clownware/go-performance-starter/internal/jobs"
 	"github.com/clownware/go-performance-starter/internal/middleware"
 	"github.com/clownware/go-performance-starter/internal/performance"
@@ -56,6 +57,8 @@ func main() {
 	// Stamp static asset URLs with the build version so each release busts
 	// the 1-year asset cache (ADR-016); dev builds keep a process-start stamp.
 	view.SetAssetVersion(version)
+	// /health names the build by the same stamp (Docker builds carry no VCS info).
+	handler.SetBuildVersion(version)
 
 	// Create context that listens for termination signals
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/handler/health_handler.go
+++ b/internal/handler/health_handler.go
@@ -22,7 +22,37 @@ var (
 	startOnce  sync.Once
 	healthDB   Pinger
 	healthDBMu sync.RWMutex
+
+	// buildVersion is the -X main.version stamp main hands over at boot;
+	// "dev" until then, matching main's default.
+	buildVersion   = "dev"
+	buildVersionMu sync.RWMutex
 )
+
+// SetBuildVersion records the build's version string (main's ldflags stamp)
+// so /health can name the build even where no VCS info is compiled in —
+// Docker builds copy the tree without .git, so the revision alone reported
+// "dev" on every deployed instance.
+func SetBuildVersion(v string) {
+	buildVersionMu.Lock()
+	buildVersion = v
+	buildVersionMu.Unlock()
+}
+
+// resolveVersion picks the most specific name for the running build: the
+// stamped version when a release or deploy set one, else the short VCS
+// revision of an unstamped local build, else "dev".
+func resolveVersion(settings []debug.BuildSetting, build string) string {
+	if build != "" && build != "dev" {
+		return build
+	}
+	for _, s := range settings {
+		if s.Key == "vcs.revision" && len(s.Value) >= 7 {
+			return s.Value[:7]
+		}
+	}
+	return "dev"
+}
 
 // InitHealth records the server start time and stores the dependency the
 // detail probe pings. Pass nil when no database is configured — callers
@@ -65,15 +95,14 @@ func HealthDetailHandler(w http.ResponseWriter, r *http.Request) {
 		dbStatus = "not configured"
 	}
 
-	version := "dev"
+	var settings []debug.BuildSetting
 	if info, ok := debug.ReadBuildInfo(); ok {
-		for _, s := range info.Settings {
-			if s.Key == "vcs.revision" && len(s.Value) >= 7 {
-				version = s.Value[:7]
-				break
-			}
-		}
+		settings = info.Settings
 	}
+	buildVersionMu.RLock()
+	build := buildVersion
+	buildVersionMu.RUnlock()
+	version := resolveVersion(settings, build)
 
 	httpStatus := http.StatusOK
 	if status != "ok" {

--- a/internal/handler/health_handler_test.go
+++ b/internal/handler/health_handler_test.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"runtime/debug"
+	"strings"
 	"testing"
 )
 
@@ -133,5 +135,50 @@ func TestHealthDetailHandler_PingTimeout(t *testing.T) {
 
 	if !sawDeadline {
 		t.Error("ping context carried no deadline — a slow dependency could hang the probe")
+	}
+}
+
+// TestResolveVersion pins how /health names the build: the ldflags version
+// wins when a release or deploy stamped one (Docker builds carry no VCS
+// info, so the revision alone reported "dev" on every deployed instance —
+// found verifying v0.9.0); a local build without a stamp falls back to the
+// short VCS revision; nothing known stays "dev".
+func TestResolveVersion(t *testing.T) {
+	vcs := []debug.BuildSetting{{Key: "vcs.revision", Value: "abcdef1234567890"}}
+	tests := []struct {
+		name     string
+		settings []debug.BuildSetting
+		build    string
+		want     string
+	}{
+		{name: "stamped build version wins over the revision", settings: vcs, build: "v0.9.0-3-gbda0524", want: "v0.9.0-3-gbda0524"},
+		{name: "unstamped local build uses the short revision", settings: vcs, build: "dev", want: "abcdef1"},
+		{name: "empty build version behaves like dev", settings: vcs, build: "", want: "abcdef1"},
+		{name: "no stamp and no revision is dev", settings: nil, build: "dev", want: "dev"},
+		{name: "revision too short to shorten is ignored", settings: []debug.BuildSetting{{Key: "vcs.revision", Value: "abc"}}, build: "", want: "dev"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveVersion(tt.settings, tt.build); got != tt.want {
+				t.Errorf("resolveVersion() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestHealthDetailHandler_ReportsBuildVersion proves the wiring: the version
+// main stamps at boot is what the probe reports.
+func TestHealthDetailHandler_ReportsBuildVersion(t *testing.T) {
+	SetBuildVersion("v9.9.9-test")
+	t.Cleanup(func() { SetBuildVersion("dev") })
+	InitHealth(nil)
+
+	rec := httptest.NewRecorder()
+	HealthDetailHandler(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), `"version":"v9.9.9-test"`) {
+		t.Errorf("body = %s, want the stamped build version", rec.Body.String())
 	}
 }


### PR DESCRIPTION
## Summary

Follow-through on #140. That fix stamped the image (asset URLs now carry `v0.9.0-3-gbda0524`), but `/health` still said `"version":"dev"` on the demo: it named the build from `vcs.revision` in the Go build info, which Docker builds never have.

- `handler.SetBuildVersion(version)` is called by `main` next to the asset stamp.
- `resolveVersion`: stamped version wins; an unstamped local build keeps the short VCS revision; only a build with neither stays `dev`.

## Tests (ADR-023, written first)

- `TestResolveVersion` table: stamped wins, local falls back to the revision, empty behaves like dev, no info is dev, short revision ignored.
- `TestHealthDetailHandler_ReportsBuildVersion` proves the wiring end to end.

## Verification

- `task ci` green locally. After merge, `/health` on the demo should report `v0.9.0-N-g<sha>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)